### PR TITLE
Reversed SENT Output Firing Order

### DIFF
--- a/garrysmod/gamemodes/base/entities/entities/base_entity/outputs.lua
+++ b/garrysmod/gamemodes/base/entities/entities/base_entity/outputs.lua
@@ -66,10 +66,12 @@ function ENT:TriggerOutput(name, activator)
 	if (!self.Outputs) then return end
 	if (!self.Outputs[name]) then return end
 	
-	for idx,op in pairs(self.Outputs[name]) do
-		
-		if ( !FireSingleOutput(op, self.Entity, activator) ) then
-			
+	local OutputList = self.Outputs[name]
+
+	for idx = #OutputList, 1, -1 do
+
+		if ( !FireSingleOutput( OutputList[idx], self.Entity, activator ) ) then
+
 			self.Outputs[name][idx] = nil
 
 		end


### PR DESCRIPTION
The Source Engine uses a linked list for storing entity output order. New events replace the head pointer. This can be seen for `CBaseEntityOutput::AddEventAction` in `game\server\cbase.cpp`.

In the Garry's Mod SENT implementation, `ENT.StoreOutput` appends events to a table, and fires them in the same order. This leads to a reversed firing order which can break complicated entity I/O.

The fix I've implemented triggers the output in reverse. More information can be found in this thread: http://www.facepunch.com/showthread.php?t=1238499
