### PR TITLE
Noclip Gesture Animation Fix

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/animations.lua
+++ b/garrysmod/gamemodes/base/gamemode/animations.lua
@@ -65,9 +65,7 @@ end
 
 function GM:HandlePlayerNoClipping( ply, velocity )
 
-	if ( ply:InVehicle() ) then return end
-
-	if ( ply:GetMoveType() != MOVETYPE_NOCLIP ) then 
+	if ( ply:GetMoveType() != MOVETYPE_NOCLIP || ply:InVehicle() ) then 
 
 		if ( ply.m_bWasNoclipping ) then
 
@@ -304,7 +302,7 @@ function GM:CalcMainActivity( ply, velocity )
 	end
 
 	ply.m_bWasOnGround = ply:IsOnGround()
-	ply.m_bWasNoclipping = (ply:GetMoveType() == MOVETYPE_NOCLIP)
+	ply.m_bWasNoclipping = ( ply:GetMoveType() == MOVETYPE_NOCLIP && !ply:InVehicle() )
 
 	return ply.CalcIdeal, ply.CalcSeqOverride
 


### PR DESCRIPTION
The changes made cause the noclip gesture reset code to be called when a player enters a vehicle from noclip mode. More details can be found in the [facepunch thread](http://www.facepunch.com/showthread.php?t=1243830&p=39421983).
