### PR TITLE
Sprint button now restricts camera roll when zooming

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_camera.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_camera.lua
@@ -241,7 +241,7 @@ end
 --
 function SWEP:DoRotateThink( cmd, fDelta )
 
-	if ( cmd:KeyDown( IN_ATTACK2 ) ) then
+	if ( cmd:KeyDown( IN_ATTACK2 ) && !cmd:KeyDown( IN_SPEED ) ) then
 
 		self:SetRoll( self:GetRoll() + cmd:GetMouseX() * 0.5 * fDelta )
 		


### PR DESCRIPTION
I have came across situations where I would want to take a completely straight zoomed-in screenshot with the gmod camera, yet zooming also affected the roll. This adjustment will allow users to hold the sprint button to prevent the camera from changing the roll angle.

I thought this way would keep the familiarity of the controls everyone already knows, but I also believe it might be better to make it only roll when holding the sprint button.
