### PR TITLE
Removed GM:ScalePlayerDamage from sandbox

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/player.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/player.lua
@@ -188,33 +188,6 @@ function GM:PlayerSpawnedSWEP( ply, ent )
 end
 
 --[[---------------------------------------------------------
-   Name: gamemode:ScalePlayerDamage( ply, hitgroup, dmginfo )
-   Desc: Scale the damage based on being shot in a hitbox
------------------------------------------------------------]]
-function GM:ScalePlayerDamage( ply, hitgroup, dmginfo )
-
-	-- More damage if we're shot in the head
-	 if ( hitgroup == HITGROUP_HEAD ) then
-	 
-		dmginfo:ScaleDamage( 3 )
-	 
-	 end
-	 
-	-- Less damage if we're shot in the arms or legs
-	if ( hitgroup == HITGROUP_LEFTARM ||
-		 hitgroup == HITGROUP_RIGHTARM || 
-		 hitgroup == HITGROUP_LEFTLEG ||
-		 hitgroup == HITGROUP_RIGHTLEG ||
-		 hitgroup == HITGROUP_GEAR ) then
-	 
-		dmginfo:ScaleDamage( 0.5 )
-	 
-	 end
-
-end
-
-
---[[---------------------------------------------------------
    Name: gamemode:PlayerEnteredVehicle( player, vehicle, role )
    Desc: Player entered the vehicle fine
 -----------------------------------------------------------]]


### PR DESCRIPTION
This function is defined in base gamemode and has proper scale values.
