### PR TITLE
Improved MatSelect for context menu

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/emitter.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/emitter.lua
@@ -207,6 +207,8 @@ function TOOL.BuildCPanel( CPanel )
 		matselect:SetItemWidth( 64 )
 		matselect:SetItemHeight( 64 )
 		matselect:SetAutoHeight( true )
+		
+		Derma_Hook( matselect.List, "Paint", "Paint", "Panel" )
 	
 		local list = list.Get( "EffectType" )		
 		for k, v in pairs( list ) do

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/faceposer.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/faceposer.lua
@@ -196,6 +196,9 @@ if ( CLIENT ) then
 				QuickFace:SetNumRows( 3 )
 				QuickFace:SetItemWidth( 64 )
 				QuickFace:SetItemHeight( 32 )
+
+				QuickFace.List:SetSpacing( 0 )
+				QuickFace.List:SetPadding( 0 )
 				
 				-- Todo: These really need to be the name of the flex.
 				

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/controlpanel.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/controlpanel.lua
@@ -54,7 +54,8 @@ end
 function PANEL:MatSelect( strConVar, tblOptions, bAutoStretch, iWidth, iHeight )
 
 	local MatSelect = vgui.Create( "MatSelect", self )
-	
+		Derma_Hook( MatSelect.List, "Paint", "Paint", "Panel" )
+
 		MatSelect:SetConVar( strConVar )
 		
 		if ( bAutoStretch != nil ) then MatSelect:SetAutoHeight( bAutoStretch ) end
@@ -212,6 +213,9 @@ function PANEL:AddControl( control, data )
 		local ctrl = vgui.Create( "MatSelect", self )
 		ctrl:ControlValues( data ) -- Yack.
 		self:AddPanel( ctrl )
+		
+		Derma_Hook( ctrl.List, "Paint", "Paint", "Panel" )
+		
 		return ctrl
 		
 	end
@@ -379,6 +383,8 @@ function PANEL:AddControl( control, data )
 		ctrl:SetItemHeight( data.height or 32 )
 		ctrl:SetNumRows( data.rows or 4 )
 		ctrl:SetConVar( data.convar or nil )
+		
+		Derma_Hook( ctrl.List, "Paint", "Paint", "Panel" )
 		
 		for name, tab in pairs( data.options ) do
 		

--- a/garrysmod/lua/vgui/dform.lua
+++ b/garrysmod/lua/vgui/dform.lua
@@ -190,7 +190,6 @@ function PANEL:CheckBox( strLabel, strConVar )
 	left:SetText( strLabel )
 	left:SetDark( true )
 	left:SetConVar( strConVar )
-	left:SetIndent( 5 )
 
 	self:AddItem( left, nil )
 	

--- a/garrysmod/lua/vgui/matselect.lua
+++ b/garrysmod/lua/vgui/matselect.lua
@@ -30,8 +30,8 @@ function PANEL:Init()
 	self.List = vgui.Create( "DPanelList", self )
 		self.List:EnableHorizontal( true )
 		self.List:EnableVerticalScrollbar()
-		self.List:SetSpacing( 0 )
-		self.List:SetPadding( 5 )
+		self.List:SetSpacing( 1 )
+		self.List:SetPadding( 3 )
 	
 	self.Controls 	= {}
 	self.Height		= 2


### PR DESCRIPTION
Added a background just like on model selection which is extremely
useful for material tool.
Added spacing and padding to match model selection, and it looks better.
Also removed indent for checkboxes in context menu, so all elements look
kinda lined up.
