### PR TITLE
Changed Flechette Gun to be spawnable again

### DIFF
--- a/garrysmod/lua/weapons/flechette_gun.lua
+++ b/garrysmod/lua/weapons/flechette_gun.lua
@@ -8,7 +8,7 @@ AddCSLuaFile()
 SWEP.Author			= ""
 SWEP.Instructions	= "Shoots flechettes"
 
-SWEP.Spawnable			= false
+SWEP.Spawnable			= true
 SWEP.AdminOnly			= true
 
 SWEP.ViewModel			= "models/weapons/v_pistol.mdl"


### PR DESCRIPTION
Why was it disabled in the first place?
