### PR TITLE
Fixed cleanup accumulating invalid entities.

### DIFF
--- a/garrysmod/lua/includes/modules/cleanup.lua
+++ b/garrysmod/lua/includes/modules/cleanup.lua
@@ -166,7 +166,7 @@ if ( SERVER ) then
 			end
 			
 			game.CleanUpMap()
-						
+			
 			-- Send tooltip command to client
 			pl:SendLua( "GAMEMODE:OnCleanup( 'all' )" )
 			


### PR DESCRIPTION
The cleanup library would continue to track entities it had already
removed. It now empties an entity list after using it for cleanup.
