### PR TITLE
Added search results -> spawnlist button to spawnmenu.

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contentsearch.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contentsearch.lua
@@ -26,6 +26,20 @@ function PANEL:Init()
 	btn:DockMargin( 4, 2, 4, 2 )
 	btn:SetSize( 16, 16 )
 
+	self.Search.SpawnlistBtn = self.Search:Add( "DImageButton" )
+	self.Search.SpawnlistBtn:SetImage( "icon16/page_add.png" )
+	self.Search.SpawnlistBtn:SetText( "" )
+	self.Search.SpawnlistBtn:Dock( RIGHT )
+	self.Search.SpawnlistBtn:DockMargin( 4, 2, 4, 2 )
+	self.Search.SpawnlistBtn:SetSize( 16, 16 )
+	self.Search.SpawnlistBtn:SetTooltip( "Create spawnlist from results" )
+	self.Search.SpawnlistBtn.DoClick = function()
+
+		self:CreateSpawnlistFromResults( self.Search:GetText() )
+
+	end
+	self.Search.SpawnlistBtn:SetVisible( false )
+
 	self.Search.OnKeyCode = function( p, code )
 
 		if ( code == KEY_F1 ) then hook.Run( "OnSpawnMenuClose" ) end
@@ -68,7 +82,8 @@ end
 
 function PANEL:RefreshResults() 
 
-	if ( self.Search:GetText() == "" ) then return end
+	if ( self.Search:GetText() == "" ) then self.Search.SpawnlistBtn:SetVisible( false ) return end
+	self.Search.SpawnlistBtn:SetVisible( true )
 
 	self.PropPanel:Clear()
 
@@ -96,6 +111,73 @@ function PANEL:AddSearchResult( text, func, icon )
 
 end
 
+function PANEL:CreateSpawnlistFromResults( name )
+
+	local node = CustomizableSpawnlistNode:AddNode( name, "icon16/page.png" )
+
+	--
+	-- Search results don't just include models, they pick up vehicles, NPCs, weapons, etc too
+	-- Spawnlists are intended for models only (as far as I can see), so filter then out
+	--
+	local results = self.PropPanel:ContentsToTable()
+	local mdlresults = {}
+	for k, v in pairs( results ) do
+
+		if v.type == "model" then
+
+			table.insert( mdlresults, v )
+
+		end
+
+	end
+
+	node.OnModified = function()
+		hook.Run( "SpawnlistContentChanged" )
+	end
+		
+	node.DoRightClick = function( self )
+	
+		local menu = DermaMenu()
+		menu:AddOption( "Edit", function() self:InternalDoClick(); hook.Run( "OpenToolbox" )  end )
+		menu:AddOption( "New Category", function() AddCustomizableNode( ContentPanel, "New Category", "", self ); self:SetExpanded( true ); hook.Run( "SpawnlistContentChanged" ) end )
+		menu:AddOption( "Delete", function() node:Remove(); hook.Run( "SpawnlistContentChanged" ) end )
+		
+		
+		menu:Open()
+	
+	end
+	
+	node.DoPopulate = function( self )
+	
+		if self.PropPanel then return end
+
+		self.PropPanel = vgui.Create( "ContentContainer", ContentPanel )
+		self.PropPanel:SetVisible( false )
+		
+		for i, object in SortedPairs( mdlresults ) do
+
+			local cp = spawnmenu.GetContentType( object.type )
+			if ( cp ) then cp( self.PropPanel, object ) end
+
+		end 
+
+		self.PropPanel:SetTriggerSpawnlistChange( true )
+
+	end
+	
+	node.DoClick = function( self )
+	
+		self:DoPopulate()		
+		ContentPanel:SwitchPanel( self.PropPanel );
+	
+	end
+
+	--
+	-- Save the new spawnlist
+	--
+	hook.Run( "SpawnlistContentChanged" )
+
+end
 
 hook.Add( "PopulateContent", "AddSearchContent", function( pnlContent, tree, node )
 

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/custom.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/custom.lua
@@ -1,5 +1,4 @@
 
-local AddCustomizableNode = nil
 
 local function SetupCustomNode( node, pnlContent, needsapp )
 


### PR DESCRIPTION
This adds a small button to the search box, next to the current search
button, clicking it will create a custom spawnlist with the props from
the search results.

(I'm not sure why the changes show up as deleting the whole file then adding it again, when I committed it locally GitHub displayed just the changes I made fine..)
