### PR TITLE
Fixed misc menu issues

### DIFF
--- a/garrysmod/html/css/menu/Servers.css
+++ b/garrysmod/html/css/menu/Servers.css
@@ -401,10 +401,17 @@ SPAN.installgamemode:hover
 
 .server_gamemodes
 {
-	margin-right: 300px; 
-	margin-left: 300px; 
 	top: 64px; 
 	border: 5px solid white;
+}
+
+@media screen and (min-width: 1280px)
+{
+	.server_gamemodes {
+		margin: 0 auto;
+		width: 80%;
+		max-width: 1000px;
+	}
 }
 
 .noplayers


### PR DESCRIPTION
Fixed gamemode names spanning across multiple lines. Left is before, right is after; pay close attention to the Space Build gamemode name.
![gamemode names](http://i.imm.io/12Pem.png)

Fixed gamemodes list not being visible on small resolutions. The style changes using css media queries. Check the css for additional details.
![small resolutions](http://i.imm.io/12Pkp.png)
Issue was originally posted here: http://facepunch.com/showthread.php?t=1259253
