### PR TITLE
Update tooltips.lua

### DIFF
--- a/garrysmod/lua/includes/util/tooltips.lua
+++ b/garrysmod/lua/includes/util/tooltips.lua
@@ -13,7 +13,7 @@ local TooltippedPanel = nil
 	Name: ChangeTooltip
 		Called from engine on hovering over a panel
 -----------------------------------------------------------]] 
-local function RemoveTooltip( PositionPanel )
+function RemoveTooltip( PositionPanel )
 
 	if ( !IsValid( Tooltip ) ) then return true end
 		


### PR DESCRIPTION
Let the function be global so we can just remove an active tooltip without needing to find it.
