### PR TITLE
Modified server info to use docking functionality

### DIFF
--- a/garrysmod/html/css/menu/Servers.css
+++ b/garrysmod/html/css/menu/Servers.css
@@ -299,10 +299,7 @@ A.bglink
 
 .serverinfo button
 {
-	position: absolute;
-	bottom: 8px;
-	right: 16px;
-	left: 16px;
+	width: 100%;
 	font-size: 30px;
 }
 
@@ -315,40 +312,49 @@ A.bglink
 .serverinfo subinfo
 {
 	display: block;
-	color: 
-	#444;
+	color: #444;
 }
 
-.serverinfo password
+.serverinfo > div
 {
-	position: absolute;
-	bottom: 60px;
-	left: 32px;
-	right: 32px;
+	display: table;
+	width: 100%;
+	height: 100%;
+	table-layout: fixed;
 }
 
-.serverinfo password SPAN
+.serverinfo div.cell
 {
-	line-height: 25px;
-	color: #666;
+	display: table-cell;
 }
 
-.serverinfo password INPUT
+.serverinfo header
 {
-	width: 200px;
-	float: right;
+	display: table-row;
+	height: 0;
 }
 
 .serverinfo players
 {
+	display: block;
+	height: 100%;
 	background-color: #EEE;
-	position: absolute;
-	left: 20px;
-	right: 20px;
-	top: 55px;
-	bottom: 85px;
 	border-radius: 4px;
 	overflow: auto;
+}
+
+.serverinfo footer
+{
+	display: table-row;
+	height: 0;
+	margin-top: 5px;
+}
+
+.serverinfo footer input[type=password]
+{
+	width: 100%;
+	padding: 4px;
+	margin-bottom: 5px;
 }
 
 .activeserver

--- a/garrysmod/html/template/servers.html
+++ b/garrysmod/html/template/servers.html
@@ -104,10 +104,14 @@
 			<div class='serverinfo'>
 				<div ng-show="CurrentGamemode.Selected">
 
-					<name>{{CurrentGamemode.Selected.name}}</name>
-					<address>{{CurrentGamemode.Selected.address}}</address>
-					<players>
+					<header>
+						<div class="cell" style="padding-bottom: 5px;">
+							<name>{{CurrentGamemode.Selected.name}}</name>
+							<address>{{CurrentGamemode.Selected.address}}</address>
+						</div>
+					</header>
 
+					<players>
 						<table style="font-size: 12px; padding: 8px; width: 100%;">
 
 							<tr style="color: #999; font-weight: bold;">
@@ -122,15 +126,15 @@
 								<td style="text-align: right;" ng-Seconds="player.time"></td>
 							</tr>
 						</table>
-
 					</players>
 
-					<password ng-show="CurrentGamemode.Selected.pass">
-						<input type='password' ng-model="CurrentGamemode.Selected.password" ui-keypress="{'enter':'JoinServer( CurrentGamemode.Selected )'}" />
-						<span>Password:</span>
-					</password>
+					<footer>
+						<div class="cell" style="padding-top: 5px;">
+							<input type='password' ng-model="CurrentGamemode.Selected.password" ng-show="CurrentGamemode.Selected.pass" ui-keypress="{'enter':'JoinServer( CurrentGamemode.Selected )'}" placeholder="Password" />
 
-					<button class="btn-primary" ng-click="JoinServer( CurrentGamemode.Selected )">Join Server</button>
+							<button class="btn-primary" ng-click="JoinServer( CurrentGamemode.Selected )">Join Server</button>
+						</div>
+					</footer>
 
 				</div>
 			</div>


### PR DESCRIPTION
The server info now functions in a way similar to docking elements. Elements can be stacked to either above or below the player list without leaving unnecessary white-space.

The password input was also revised. Additional padding was added and the label was replaced in favor of placeholder text (and more input width).

Server with large amount of players
![info](http://samuelmaddock.com/up/2013-05-02_19-16-58.png)

Server with password
![password](http://samuelmaddock.com/up/2013-05-02_18-57-18.png)

Docking example; this should be handy in the future if a 'Favorite' button is added
![docking](http://samuelmaddock.com/up/2013-05-02_19-14-41.png)
