### PR TITLE
Fixed hands not rendering when spectating other players

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/player_class/player_default.lua
+++ b/garrysmod/gamemodes/base/gamemode/player_class/player_default.lua
@@ -122,9 +122,11 @@ end
 --
 function PLAYER:PostDrawViewModel( vm, weapon )
 
-	if ( weapon.UseHands || !weapon:IsScripted() ) then
+	local owner = weapon:GetOwner()
 
-		local hands = self.Player:GetHands()
+	if ( weapon.UseHands || !weapon:IsScripted() ) and IsValid( owner ) then
+
+		local hands = owner:GetHands()
 		if ( IsValid( hands ) ) then
 			hands:DrawModel()
 		end


### PR DESCRIPTION
I noticed that when you spectate other players the hands are not rendering. I found that the PostDrawViewModel was always passing the localplayer for the player argument so I did this fix on my servers.. Dunno if that's a separate bug or not.
