### PR TITLE
Fix for disabling DComboBoxes

### DIFF
--- a/garrysmod/lua/skins/default.lua
+++ b/garrysmod/lua/skins/default.lua
@@ -739,7 +739,7 @@ end
 function SKIN:PaintComboDownArrow( panel, w, h )
 
 	if ( panel.ComboBox:GetDisabled() ) then
-		return self.Input.ComboBox.Button.Disabled( 0, 0, w, h );	
+		return self.tex.Input.ComboBox.Button.Disabled( 0, 0, w, h );	
 	end	
 	
 	if ( panel.ComboBox.Depressed || panel.ComboBox:IsMenuOpen() ) then
@@ -760,7 +760,7 @@ end
 function SKIN:PaintComboBox( panel, w, h )
 	
 	if ( panel:GetDisabled() ) then
-		return self.Input.ComboBox.Disabled( 0, 0, w, h );	
+		return self.tex.Input.ComboBox.Disabled( 0, 0, w, h );	
 	end	
 	
 	if ( panel.Depressed || panel:IsMenuOpen() ) then


### PR DESCRIPTION
Changed 2 lines in the default derma skin that were incorrect. They were causing error spam whenever you called PANEL:SetDisabled(true) for a DComboBox that is currently rendering. These were the errors:

[ERROR] lua/skins/default.lua:763: attempt to index field 'Input' (a nil value)
1. unknown - lua/skins/default.lua:763

[ERROR] lua/skins/default.lua:742: attempt to index field 'Input' (a nil value)
1. SkinHook - lua/skins/default.lua:742
   1. unknown - lua/vgui/dcombobox.lua:24
