### PR TITLE
Update gmod_hoverball.lua

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/entities/gmod_hoverball.lua
+++ b/garrysmod/gamemodes/sandbox/entities/entities/gmod_hoverball.lua
@@ -186,7 +186,7 @@ function ENT:SetZVelocity( z )
 		local phys = self:GetPhysicsObject()
 		if ( phys:IsValid() ) then
 			phys:Wake()
-		edn
+		end
 	end
 
 	self.ZVelocity = z * FrameTime() * 5000


### PR DESCRIPTION
Fixes an error if the hoverballs PhysObj is not valid
