### PR TITLE
Update notification.lua to allow for external poking around 

### DIFF
--- a/garrysmod/lua/includes/modules/notification.lua
+++ b/garrysmod/lua/includes/modules/notification.lua
@@ -13,7 +13,7 @@ NOTIFY_CLEANUP			= 4
 
 module( "notification", package.seeall )
 
-local NoticeMaterial = {}
+NoticeMaterial = {}
 
 NoticeMaterial[ NOTIFY_GENERIC ] 	= Material( "vgui/notices/generic" )
 NoticeMaterial[ NOTIFY_ERROR ] 		= Material( "vgui/notices/error" )
@@ -21,7 +21,7 @@ NoticeMaterial[ NOTIFY_UNDO ] 		= Material( "vgui/notices/undo" )
 NoticeMaterial[ NOTIFY_HINT ] 		= Material( "vgui/notices/hint" )
 NoticeMaterial[ NOTIFY_CLEANUP ] 	= Material( "vgui/notices/cleanup" )
 
-local Notices = {}
+Notices = {}
 
 function AddProgress( uid, text )
 


### PR DESCRIPTION
This allows for the editing of the notification icons and notice list from external scripts, without making a custom copy of the module. Fixed from the previous pull request's flaws.
