### PR TITLE
Fixed server list map name casing issue

### DIFF
--- a/garrysmod/html/js/menu/control.Menu.js
+++ b/garrysmod/html/js/menu/control.Menu.js
@@ -277,7 +277,7 @@ function UpdateMaps( inmaps )
 		for ( v in inmaps[k] )
 		{
 			maps.push( inmaps[k][v] );
-			MapIndex[v.toLowerCase()] = inmaps[k][v];
+			MapIndex[v.toLowerCase()] = true;
 		}
 
 		mapList.push( 
@@ -294,8 +294,7 @@ function UpdateMaps( inmaps )
 
 function DoWeHaveMap( map )
 {
-	if ( MapIndex[map.toLowerCase()] ) return true;
-	return false;
+	return MapIndex[map.toLowerCase()] || false;
 }
 
 function UpdateLanguages( lang )


### PR DESCRIPTION
Determining whether or not a user has a map downloaded depended on the casing of the map name. This is an issue when the casing for a map name is different even though they may have it downloaded.

Here's an image of the issue fixed
![fixed](http://samuelmaddock.com/up/2013-06-29_17-10-00.png)

Since `MapIndex` is only used for checking if the user has a map, the change doesn't affect any other features. I also changed it to simply use a boolean since it would likely be wasting memory otherwise.
