### PR TITLE
Remove game.CleanUpMap() from persistence

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/persistence.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/persistence.lua
@@ -1,5 +1,4 @@
 
-
 if ( SERVER ) then 
 
 local PersistPage = GetConVarString( "sbox_persist" )
@@ -40,8 +39,6 @@ hook.Add( "PersistenceLoad", "PersistenceLoad", function( name )
 	if ( !tab ) then return end
 	if ( !tab.Entities ) then return end
 	if ( !tab.Constraints ) then return end
-
-	game.CleanUpMap()
 
 	local Ents, Constraints = duplicator.Paste( nil, tab.Entities, tab.Constraints )
 


### PR DESCRIPTION
This is making too much confusion with the InitPostEntity hook where it will not sometimes work for creating entities because game.CleanUpMap() is ran in that hook.

And why do we even need that if we load persistence file only once, when the game starts?
