### PR TITLE
Fixed CS:GO spawnlists appearing if CS:GO is not mounted

### DIFF
--- a/garrysmod/settings/spawnlist/default/030-cs_ global offensive.txt
+++ b/garrysmod/settings/spawnlist/default/030-cs_ global offensive.txt
@@ -3,6 +3,7 @@
 	"parentid"		"0"
 	"icon"		"icon16/folder.png"
 	"id"		"30"
+	"needsapp"	"csgo"
 	"name"		"CS: Global Offensive"
 	"version"		"3"
 }


### PR DESCRIPTION
A fix for https://github.com/Facepunch/garrysmod-issues/issues/95
