### PR TITLE
Variadic Hook Returns - Revised for Performance

### DIFF
--- a/garrysmod/lua/includes/modules/hook.lua
+++ b/garrysmod/lua/includes/modules/hook.lua
@@ -51,13 +51,10 @@ function Run( name, ... )
 	return Call( name, nil, ... )
 end
 
-
-
 --
--- Called by the engine
--- Call( name, gamemode, ... )
+-- function Call( name, gm, ... )
 --
-Call = (function()
+do
 	local ret
 	local function setRet(first, ...)
 		if(first == nil)then
@@ -65,7 +62,10 @@ Call = (function()
 		end
 		ret = { first, ... }
 	end
-	return function( name, gm, ... )
+	--
+	-- Called by the engine
+	--
+	function Call( name, gm, ... )
 		--
 		-- Run hooks
 		--
@@ -129,4 +129,4 @@ Call = (function()
 		return GamemodeFunction( gm, ... )	
 		
 	end
-end)()
+end


### PR DESCRIPTION
I have created one last attempt at variadic hook returns, revising them for performance at the cost of readability. I am not entirely sure that this method is faster (The cost of varargs should be significantly less than the creation of a table since the removal of the "arg" table brought in by LuaJit), but it does attempt to keep varargs on the stack rather than in a table on hooks which don't return anything, preventing creation of a table on such hooks.

P.S. Sorry for the multitude of pull requests on this subject, this last version is my final attempt at implementing this feature
