### PR TITLE
Fixed matproxy error spam when NPC holds physgun

### DIFF
--- a/garrysmod/lua/matproxy/player_weapon_color.lua
+++ b/garrysmod/lua/matproxy/player_weapon_color.lua
@@ -1,7 +1,7 @@
 
-matproxy.Add( 
+matproxy.Add(
 {
-	name	=	"PlayerWeaponColor", 
+	name	=	"PlayerWeaponColor",
 
 	init	=	function( self, mat, values )
 
@@ -14,7 +14,7 @@ matproxy.Add(
 		if ( !IsValid( ent ) ) then return end
 
 		local owner = ent:GetOwner();
-		if ( !IsValid( owner ) ) then return end
+		if ( !IsValid( owner ) or !owner:IsPlayer() ) then return end
 
 		local col = owner:GetWeaponColor();
 		if ( !isvector( col ) ) then return end
@@ -23,5 +23,5 @@ matproxy.Add(
 
 		mat:SetVector( self.ResultTo, col + col * mul );
 
-	end 
+	end
 })


### PR DESCRIPTION
Reproducing issue: gmod_spawnnpc npc_citizen weapon_physgun.
Sublime automatically removed trailing spaces, so those are removed in that file now too.
