### PR TITLE
Add new hook GM:OnMapCleanUp

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/init.lua
+++ b/garrysmod/gamemodes/base/gamemode/init.lua
@@ -132,3 +132,8 @@ function GM:CheckPassword( steamid, networkid, server_password, password, name )
 end
 
 
+--
+-- Called after game.CleanUpMap() is run
+--
+function GM:OnCleanUpMap( )
+end

--- a/garrysmod/lua/includes/gmsave.lua
+++ b/garrysmod/lua/includes/gmsave.lua
@@ -37,6 +37,7 @@ if ( SERVER ) then
 		end
 		
 		game.CleanUpMap()
+		gamemode.Call( "OnCleanUpMap" )
 		
 		if ( IsValid( ply ) ) then
 

--- a/garrysmod/lua/includes/modules/cleanup.lua
+++ b/garrysmod/lua/includes/modules/cleanup.lua
@@ -166,6 +166,7 @@ if ( SERVER ) then
 			end
 			
 			game.CleanUpMap()
+			gamemode.Call( "OnCleanUpMap" )
 			
 			-- Send tooltip command to client
 			pl:SendLua( "GAMEMODE:OnCleanup( 'all' )" )


### PR DESCRIPTION
It is called after game.CleanUpMap() is run.

This is useful so Prop Protections can reset what they think of as World owned entities, among other uses.

This addresses Facepunch/garrysmod-requests#1
It would probably be more appropriate to do in C, inside game.CleanUpMap() if possible, but this is an lua solution.
