### PR TITLE
Added hook.Call("PlayerSpawnedButton", nil, pl, button)

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/button.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/button.lua
@@ -1,4 +1,3 @@
-
 TOOL.Category		= "Construction"
 TOOL.Name			= "#tool.button.name"
 TOOL.Command		= nil
@@ -117,7 +116,9 @@ if (SERVER) then
 		end
 		
 		DoPropSpawnedEffect( button )
-
+		
+		hook.Call("PlayerSpawnedButton", nil, pl, button)
+		
 		return button
 		
 	end


### PR DESCRIPTION
I need a hook to be called when someone spawns a button with the tool. Maybe it should be used with PlayerSpawnedSENT?
