### PR TITLE
Fixed sql.SQLStr.

### DIFF
--- a/garrysmod/lua/includes/util/sql.lua
+++ b/garrysmod/lua/includes/util/sql.lua
@@ -7,17 +7,21 @@ if ( !sql ) then return end
     Attempts to make a string safe to put into the database
 ------------------------------------------------------------]]
 function sql.SQLStr( str_in, bNoQuotes )
- 
-    local str = tostring( str_in )
- 
-    str = str:gsub( [["]], [[""]] )
- 
-    if ( bNoQuotes ) then
-        return str
-    end
- 
-    return [["]] .. str .. [["]];
- 
+	
+	local str = tostring( str_in )
+	
+	str = str:gsub( "'", "''" )
+	
+	local null_chr = string.find( str, "\0" )
+	if null_chr then
+		str = string.sub( str, 1, null_chr - 1 )
+	end
+	
+	if ( bNoQuotes ) then
+		return str
+	end
+	
+	return "'" .. str .. "'"
 end
 
 SQLStr = sql.SQLStr


### PR DESCRIPTION
### The current sql.SQLStr does not follow the SQL(ite) standard.
### Please see:

https://sqlite.org/lang_keywords.html
(or shorter:) https://www.sqlite.org/faq.html#q14
### Proof of concept:

http://codepad.org/SGui7tE6
### \0

I added a '\0' fix as well, as this is somewhat related.
If you don't want to include it, it's fine, tell me or remove lines 15-18 yourself.
### Information:

On our servers, we have been using this fix for all of our queries since December 2012,
and there have been no problems whatsoever.
