### PR TITLE
Made scripted_ents.GetList respect Aliases

### DIFF
--- a/garrysmod/lua/includes/modules/scripted_ents.lua
+++ b/garrysmod/lua/includes/modules/scripted_ents.lua
@@ -210,6 +210,9 @@ function GetList()
 	for k,v in pairs(SEntList) do
 		result[ k ] = v
 	end
+	for k,v in pairs(Aliases) do
+		result[ k ] = SEntList[ v ]
+	end
 	
 	return result
 end


### PR DESCRIPTION
Currently, scripted_ents.Get(name) checks if the name is registered as an Alias of another class, but scripted_ents.GetList does not show these aliased classes as valid.
