### PR TITLE
Fixed GetLastValue & GetLastKey

### DIFF
--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -640,14 +640,14 @@ end
 
 function table.GetLastKey( t )
 
-	local k, v = next( t, table.Count(t) )
+	local k, v = next( t, table.Count(t) - 1 )
 	return k
 	
 end
 
 function table.GetLastValue( t )
 
-	local k, v = next( t, table.Count(t) )
+	local k, v = next( t, table.Count(t) - 1 )
 	return v
 	
 end


### PR DESCRIPTION
As stated in in issue 353 they don't work correctly because they trying to find the next index of the last value/key which doesn't exist.
