### PR TITLE
Add DefaultUnderline font to ChatScheme.res to allow third party program...

### DIFF
--- a/garrysmod/resource/ChatScheme.res
+++ b/garrysmod/resource/ChatScheme.res
@@ -351,6 +351,54 @@ Scheme
 			}
 		}
 
+		"DefaultUnderline"
+		{
+			"1"
+			{
+				"name"		"Verdana"
+				"tall"		"12"
+				"weight"	"700"
+				"yres"		"480 599"
+				"dropshadow"	"1"
+				"underline"	"1"
+			}
+			"2"
+			{
+				"name"		"Verdana"
+				"tall"		"14"
+				"weight"	"700"
+				"yres"		"600 767"
+				"dropshadow"	"1"
+				"underline"	"1"
+			}
+			"3"
+			{
+				"name"		"Verdana"
+				"tall"		"15"
+				"weight"	"700"
+				"yres"		"768 1023"
+				"dropshadow"	"1"
+				"underline"	"1"
+			}
+			"4"
+			{
+				"name"		"Verdana"
+				"tall"		"17"
+				"weight"	"700"
+				"yres"		"1024 1199"
+				"dropshadow"	"1"
+				"underline"	"1"
+			}
+			"5"
+			{
+				"name"		"Verdana"
+				"tall"		"22"
+				"weight"	"700"
+				"yres"		"1200 10000"
+				"dropshadow"	"1"
+				"underline"	"1"
+			}
+		}
 
 	}
 


### PR DESCRIPTION
...mers to add clickable links to chat

This is what my code looks like with the vanilla ChatScheme.res:

![gay](http://peniscorp.com/stuff/Garry's_Mod_2013-08-23_23-26-28.png)

This is what it looks like with that ChatScheme.res:

![lessgay](http://peniscorp.com/stuff/Garry's_Mod_2013-08-24_00-16-38.png)
