### PR TITLE
Allow ControlPanels to be spawned via ControlPanel:AddControl

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/controlpanel.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/controlpanel.lua
@@ -140,6 +140,18 @@ function PANEL:LoadControlsFromTextFile( strName )
 end
 
 --[[---------------------------------------------------------
+   Name: ControlValues
+-----------------------------------------------------------]]
+function PANEL:ControlValues( data )
+	if ( data.label) then
+		self:SetLabel( data.label );
+	end
+	if ( data.closed ) then
+		self:SetExpanded( false );
+	end
+end
+
+--[[---------------------------------------------------------
    Name: AddControl
 -----------------------------------------------------------]]
 function PANEL:AddControl( control, data )


### PR DESCRIPTION
It's pretty useful for sectioning bits of an unweildy tool, since ControlPanel is a souped up DForm which is in turn a souped up DCategoryCollapse.
