### PR TITLE
Fixed string escaping in when calling `DownloadFile` and `SetStatusChanged`

### DIFF
--- a/garrysmod/lua/menu/loading.lua
+++ b/garrysmod/lua/menu/loading.lua
@@ -130,12 +130,12 @@ function PANEL:StatusChanged( strStatus )
 	if ( string.find( strStatus, "Downloading " ) ) then
 	
 		local Filename = string.gsub( strStatus, "Downloading ", "" )
-		Filename = string.gsub( Filename, "'", "\'" )
+		Filename = string.gsub( Filename, "'", "\\'" )
 		self:RunJavascript( "if ( window.DownloadingFile ) DownloadingFile( '" .. Filename .. "' )" );
 	
 	return end
 	
-	strStatus = string.gsub( strStatus, "'", "\'" )
+	strStatus = string.gsub( strStatus, "'", "\\'" )
 	self:RunJavascript( "if ( window.SetStatusChanged ) SetStatusChanged( '" .. strStatus .. "' )" );
 	
 end


### PR DESCRIPTION
When calling `DownloadFile` and `SetStatusChanged`, the string was not correctly escaped (replacing a `'` with `'` instead of `\'`).
