### PR TITLE
Fix GM:GetVehicles()

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/base/gamemode/cl_init.lua
@@ -1,4 +1,3 @@
-
 include( 'shared.lua' )
 include( 'cl_scoreboard.lua' )
 include( 'cl_targetid.lua' )
@@ -262,7 +261,7 @@ end
 -----------------------------------------------------------]]
 function GM:GetVehicles()
 
-	return vehicles.GetTable()
+	return list.Get( "Vehicles" )
 	
 end
 


### PR DESCRIPTION
vehicles library is gone, so we gotta use new method. But why do we even need this function and why it's clientside only?
