### PR TITLE
Add joinable boolean check to team.BestAutoJoinTeam

### DIFF
--- a/garrysmod/lua/includes/modules/team.lua
+++ b/garrysmod/lua/includes/modules/team.lua
@@ -166,7 +166,7 @@ function BestAutoJoinTeam()
 	
 	for id, tm in pairs( team.GetAllTeams() ) do
 	
-		if ( id != TEAM_SPECTATOR && id != TEAM_UNASSIGNED && id != TEAM_CONNECTING ) then
+		if ( id != TEAM_SPECTATOR && id != TEAM_UNASSIGNED && id != TEAM_CONNECTING && tm.Joinable ) then
 			
 			local PlayerCount = team.NumPlayers( id )
 			if ( PlayerCount < SmallestPlayers || (PlayerCount == SmallestPlayers && id < SmallestTeam ) ) then


### PR DESCRIPTION
Added check to see if the team is joinable when using team.BestAutoJoinTeam(). team.SetUp includes the boolean isJoinable as the 4th argument, defaults to true. Useful to have a check for if it is false
