### PR TITLE
Added magic hold type to base weapon

### DIFF
--- a/garrysmod/gamemodes/base/entities/weapons/weapon_base/sh_anim.lua
+++ b/garrysmod/gamemodes/base/entities/weapons/weapon_base/sh_anim.lua
@@ -16,6 +16,7 @@ local ActIndex = {
 	[ "knife" ]			= ACT_HL2MP_IDLE_KNIFE,
 	[ "duel" ]			= ACT_HL2MP_IDLE_DUEL,
 	[ "camera" ]		= ACT_HL2MP_IDLE_CAMERA,
+	[ "magic" ]			= ACT_HL2MP_IDLE_MAGIC,
 	[ "revolver" ]		= ACT_HL2MP_IDLE_REVOLVER	
 }
 	


### PR DESCRIPTION
The animations used for entity driving also work as a weapon hold type other then the fact that there are no attack animations, which isn't a big deal.
Now magic weapons can have nice third person animations.
