### PR TITLE
Updated mp_falldamage 1 with actual Source values.

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/player.lua
+++ b/garrysmod/gamemodes/base/gamemode/player.lua
@@ -1,4 +1,3 @@
-
 --[[---------------------------------------------------------
    Name: gamemode:OnPhysgunFreeze( weapon, phys, ent, player )
    Desc: The physgun wants to freeze a prop
@@ -677,7 +676,7 @@ end
 function GM:GetFallDamage( ply, flFallSpeed )
 
 	if( GetConVarNumber( "mp_falldamage" ) > 0 ) then -- realistic fall damage is on
-		return ( flFallSpeed - 580 ) * 0.227; -- near the Source SDK value
+		return ( flFallSpeed - 526.5 ) * (100 / 396); -- the Source SDK value
 	end
 	
 	return 10


### PR DESCRIPTION
https://github.com/ValveSoftware/source-sdk-2013/blob/master/mp/src/game/shared/shareddefs.h#L368

// NOTE: The discrete ticks can have quantization error, so these numbers are biased a little to
// make the heights more exact
# define PLAYER_FATAL_FALL_SPEED 922.5f
# define PLAYER_MAX_SAFE_FALL_SPEED 526.5f
# define DAMAGE_FOR_FALL_SPEED 100.0f / ( PLAYER_FATAL_FALL_SPEED - PLAYER_MAX_SAFE_FALL_SPEED )
