### PR TITLE
TTT: Fixes issue with spectating players during prep

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player_ext.lua
@@ -1,3 +1,4 @@
+
 -- serverside extensions to player table
 
 local plymeta = FindMetaTable( "Player" )


### PR DESCRIPTION
If a player spectates during prep they will be spectating that prop if they die before the round restarts. This calls PROPSEC.End on players who currently have a propspec table during the start of a round, it must also be called after aborting is not possible because we don't want to boot people out of spectator when the round isn't going to start anyway.
