### PR TITLE
Fixes issue with spectating players during prep

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -310,6 +310,17 @@ function FixSpectators()
    end
 end
 
+-- Calls PROPSPEC.End on all players who currently have a propspec
+-- Normally this is handled by the gamemode because the entity is no longer valid
+-- But in our case the props were not removed
+function FixPropSpectators()
+   for _, ply in pairs(player.GetAll()) do
+      if ply.propspec then
+         PROPSPEC.End(ply)
+      end
+   end
+end
+
 -- Used to be in think, now a timer
 local function WinChecker()
    if GetRoundState() == ROUND_ACTIVE then
@@ -656,6 +667,9 @@ function BeginRound()
    WEPS.ForcePrecache()
 
    if CheckForAbort() then return end
+   
+   -- Unspectate players who were spectating during prep
+   FixPropSpectators()
 
    -- Select traitors & co. This is where things really start so we can't abort
    -- anymore.


### PR DESCRIPTION
If a player spectates during prep they will be spectating that prop if they die before the round restarts. This calls PROPSEC.End on players who currently have a propspec table during the start of a round, it must also be called after aborting is not possible because we don't want to boot people out of spectator when the round isn't going to start anyway.
