### PR TITLE
Persistence Mode sandbox cvar type changed

### DIFF
--- a/garrysmod/gamemodes/sandbox/sandbox.txt
+++ b/garrysmod/gamemodes/sandbox/sandbox.txt
@@ -236,9 +236,9 @@
 		{
 			"name"		"sbox_persist"
 			"text"		"persistent_mode"
-			"help"		"Set to anything but 0 to enable persistence mode"
-			"type"		"Text"
-			"default"	""
+			"help"		"If checked then persistence mode is enabled"
+			"type"		"CheckBox"
+			"default"	"0"
 		}
 	}
 }


### PR DESCRIPTION
Why was this even text cvar while it acted just like the other toggleable cvars?

That's fixed anyway.
