### PR TITLE
Fallback to gm_flatgrass if the last played map is not found

### DIFF
--- a/garrysmod/lua/menu/getmaps.lua
+++ b/garrysmod/lua/menu/getmaps.lua
@@ -204,7 +204,7 @@ local IgnoreMaps = { "background", "^test_", "^styleguide", "^devtest", "sdk_sha
 
 local function RefreshMaps()
 
-	UpdateMapPatterns();
+	UpdateMapPatterns()
 
 	g_MapList = {}
 	g_MapListCategorised = {}
@@ -301,11 +301,17 @@ end
 function LoadLastMap()
 
 	local t = string.Explode( ";", cookie.GetString( "lastmap", "" ) )
+
 	local map = t[ 1 ] or ""
 	local cat = t[ 2 ] or ""
 
+	local mapinfo = g_MapList[ map .. ".bsp" ]
+
+	if ( !mapinfo ) then map = "gm_flatgrass" end
+	if ( !g_MapListCategorised[ cat ] ) then cat = mapinfo and mapinfo.Category or "Sandbox" end
+
 	cat = string.gsub( cat, "'", "\\'" )
 
-	pnlMainMenu:Call( "SetLastMap('" .. map .. "','" .. cat .. "')" );
+	pnlMainMenu:Call( "SetLastMap('" .. map .. "','" .. cat .. "')" )
 
 end


### PR DESCRIPTION
If the last played map is not found then the map choice screen appears blank. This commit fixes this issue by falling back to gm_flatgrass in these cases.

The last played map may not be found if:
- the player has yet to load a map through the map choice screen after the update which started saving last maps (this includes newcomers)
- the map has been deleted since
- the cookies get cleared or corrupted in some way
