### PR TITLE
Adjusted net.Read/WriteEntity bits.

### DIFF
--- a/garrysmod/lua/includes/modules/net.lua
+++ b/garrysmod/lua/includes/modules/net.lua
@@ -54,29 +54,6 @@ function net.ReadEntity()
 end
 
 --
--- Read/Write a player to the stream
---
-function net.WritePlayer( ent )
-
-	if ( !IsValid( ent ) ) then 
-		net.WriteUInt( 0, 8 )
-	else
-		net.WriteUInt( ent:EntIndex(), 8 )
-	end
-
-end
-
-function net.ReadPlayer()
-
-	local i = net.ReadUInt( 8 )
-	if ( !i ) then return  end
-	
-	return Entity( i )
-	
-end
-
-
---
 -- Write a whole table to the stream
 -- This is less optimal than writing each
 -- item indivdually and in a specific order


### PR DESCRIPTION
Considering the max entity count is only ~8096, sending 32 bits for it seems a little excessive. So let's use 16 bits instead, that way we get between 0-65534, align to nearest byte for simplicity.
Players are indexed from 0, MaxPlayers so it can't exceed 128, align to the nearest byte gives us 8 bits.
Just a little optimization.
