### PR TITLE
Fix numeric checking on DTextEntry and children.

### DIFF
--- a/garrysmod/lua/vgui/dtextentry.lua
+++ b/garrysmod/lua/vgui/dtextentry.lua
@@ -323,7 +323,7 @@ function PANEL:CheckNumeric( strValue )
 	if ( !self:GetNumeric() ) then return false end
 	
 	-- God I hope numbers look the same in every language
-	if ( !string.find ( strAllowedNumericCharacters, strValue ) ) then
+	if ( !string.find ( strAllowedNumericCharacters, strValue, 1, true ) ) then
 	
 		-- Noisy Error?
 		return true


### PR DESCRIPTION
Inserting a special character like "%" will be parsed as a pattern and error. So we tell string.find not to use pattern checking.

Fixes: https://github.com/Facepunch/garrysmod-issues/issues/773
