### PR TITLE
Fix Reload

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_rifle/shared.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_rifle/shared.lua
@@ -1,4 +1,3 @@
-
 if SERVER then
    AddCSLuaFile( "shared.lua" )
 end
@@ -85,6 +84,7 @@ function SWEP:PreDrop()
 end
 
 function SWEP:Reload()
+    if self.Weapon:Clip1() == self.Primary.ClipSize or self.Owner:GetAmmoCount(self.Primary.Ammo) <= 0 then return end
     self.Weapon:DefaultReload( ACT_VM_RELOAD );
     self:SetIronsights( false )
     self:SetZoom(false)


### PR DESCRIPTION
While scoped and holding reload the rifle it will go all spastic with the zoom.

Checks if the clip is full or check if they have any more ammo to reload.
