### PR TITLE
Fix propspec from spawning players in noclip

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -310,17 +310,6 @@ function FixSpectators()
    end
 end
 
--- Calls PROPSPEC.End on all players who currently have a propspec
--- Normally this is handled by the gamemode because the entity is no longer valid
--- But in our case the props were not removed
-local function FixPropSpectators()
-   for _, ply in pairs(player.GetAll()) do
-      if ply.propspec then
-         PROPSPEC.End(ply)
-      end
-   end
-end
-
 -- Used to be in think, now a timer
 local function WinChecker()
    if GetRoundState() == ROUND_ACTIVE then
@@ -655,9 +644,6 @@ function BeginRound()
    AnnounceVersion()
 
    InitRoundEndTime()
-
-   -- Unspectate players who were spectating during prep
-   FixPropSpectators()
 
    if CheckForAbort() then return end
 


### PR DESCRIPTION
Every three or so rounds this causes players to spawn invisible and in noclip (as if a
spectator). This probably wasn't the best name for the commit now that I read it, but hey, what can you do?

Reverts commits e2ada66a093a808e29b320be006f4e44bfe50b57 and 6aaed736f3279ddfe50e41e0e1750792bc5c4230

Even after the commit to stop breaking spectators, it still causes issues with players. I have been testing this change on my server for 3 hours now, and it seems to fix the problem.
