### PR TITLE
Changed ttt_playercolor_mode convar to 0 by default

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/shared.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/shared.lua
@@ -145,7 +145,7 @@ local ttt_playercolors = {
    }
 };
 
-CreateConVar("ttt_playercolor_mode", "1")
+CreateConVar("ttt_playercolor_mode", "0")
 function GM:TTTPlayerColor(model)
    if hook.Call("TTTShouldColorModel", GAMEMODE, model) then
       local mode = GetConVarNumber("ttt_playercolor_mode") or 0


### PR DESCRIPTION
There's really no reason this should be 1 by default. Only causes coloring issues.
