### PR TITLE
Make Context Menu text fields resizeable

### DIFF
--- a/garrysmod/lua/vgui/dform.lua
+++ b/garrysmod/lua/vgui/dform.lua
@@ -107,7 +107,7 @@ function PANEL:TextEntry( strLabel, strConVar )
 	
 	local right = vgui.Create( "DTextEntry", self )
 	right:SetConVar( strConVar )
-	right:Dock( FILL )
+	right:Dock( TOP )
 	
 	self:AddItem( left, right )
 	


### PR DESCRIPTION
This also make them a bit higher by default so they look nice and text can actually fix inside.
