### PR TITLE
TTT: Added Scoreboard hooks

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_main.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_main.lua
@@ -24,10 +24,6 @@ surface.CreateFont("treb_small", {font = "Trebuchet18",
 
 local logo = surface.GetTextureID("VGUI/ttt/score_logo")
 
-TTT_COLUMN_HEADING = 0
-TTT_COLUMN_ROW = 1
-TTT_COLUMN_BACKGROUND = 2
-
 local PANEL = {}
 
 local max = math.max
@@ -107,19 +103,23 @@ function PANEL:Init()
    local t = vgui.Create("TTTScoreGroup", self.ply_frame:GetCanvas())
    t:SetGroupInfo(GetTranslation("terrorists"), Color(0,200,0,100), GROUP_TERROR)
    self.ply_groups[GROUP_TERROR] = t
+   t.TTTPlayerFrame = self
 
    t = vgui.Create("TTTScoreGroup", self.ply_frame:GetCanvas())
    t:SetGroupInfo(GetTranslation("spectators"), Color(200, 200, 0, 100), GROUP_SPEC)
    self.ply_groups[GROUP_SPEC] = t
+   t.TTTPlayerFrame = self
 
    if DetectiveMode() then
       t = vgui.Create("TTTScoreGroup", self.ply_frame:GetCanvas())
       t:SetGroupInfo(GetTranslation("sb_mia"), Color(130, 190, 130, 100), GROUP_NOTFOUND)
       self.ply_groups[GROUP_NOTFOUND] = t
+      t.TTTPlayerFrame = self
 
       t = vgui.Create("TTTScoreGroup", self.ply_frame:GetCanvas())
       t:SetGroupInfo(GetTranslation("sb_confirmed"), Color(130, 170, 10, 100), GROUP_FOUND)
       self.ply_groups[GROUP_FOUND] = t
+      t.TTTPlayerFrame = self
    end
 
    -- the various score column headers
@@ -132,7 +132,7 @@ function PANEL:Init()
       self:AddColumn( GetTranslation("sb_karma") )
    end
    
-   hook.Call( "TTTScoreboardColumns", nil, self, TTT_COLUMN_HEADING ) --We'll grab custom headers here, same hook as the rows for ease of use
+   hook.Call( "TTTScoreboardColumns", nil, self ) --We'll grab custom headers here, same hook as the rows for ease of use
 
    self:UpdateScoreboard()
    self:StartUpdateTimer()
@@ -141,6 +141,7 @@ end
 function PANEL:AddColumn( label, func )
    local lbl = vgui.Create( "DLabel", self )
    lbl:SetText( label )
+   lbl.IsHeading = true
    
    table.insert( self.cols, lbl )
    return lbl

--- a/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -27,7 +27,7 @@ function PANEL:Init()
       self:AddColumn( GetTranslation("sb_karma"), function(ply) return math.Round(ply:GetBaseKarma()) end )
    end
    
-   hook.Call( "TTTScoreboardColumns", nil, self, TTT_COLUMN_ROW ) --Let coders add their own columns, first arg panel
+   hook.Call( "TTTScoreboardColumns", nil, self ) --Let coders add their own columns, first arg panel
 
    for _, c in ipairs(self.cols) do
       c:SetMouseInputEnabled(false)
@@ -58,6 +58,7 @@ function PANEL:AddColumn( label, func )
    local lbl = vgui.Create( "DLabel", self )
    lbl:SetText( label )
    lbl.func = func
+   lbl.IsHeading = false
    
    table.insert( self.cols, lbl )
    return lbl

--- a/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_team.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_team.lua
@@ -31,14 +31,6 @@ function PANEL:Init()
    self.rows_sorted = {}
    
    self.group = "spec"
-   
-   self.cols = {true,true,true, KARMA.IsEnabled() and true or nil} --We want to see the columns, so the darkening effect can match. 3 static columns, karma optional fourth
-   
-   hook.Call( "TTTScoreboardColumns", nil, self, TTT_COLUMN_BACKGROUND ) --Grab custom columns
-end
-
-function PANEL:AddColumn()
-   table.insert( self.cols, true ) --We don't keed to know anything about the column, only that it exists
 end
 
 function PANEL:SetGroupInfo(name, color, group)
@@ -83,8 +75,13 @@ function PANEL:Paint()
    -- Column darkening
    local scr = sboard_panel.ply_frame.scroll.Enabled and 16 or 0
    surface.SetDrawColor(0,0,0, 80)
-   for i=1,#self.cols,2 do --Odd numbers
-      surface.DrawRect(self:GetWide() - (50*i) - 25 - scr, 0, 50, self:GetTall())
+   if self.TTTPlayerFrame.cols then
+     for i=1,#self.TTTPlayerFrame.cols,2 do --Odd numbers
+        surface.DrawRect(self:GetWide() - (50*i) - 25 - scr, 0, 50, self:GetTall())
+     end
+   else --This shouldn't paint before the columns are set up, but you never know...
+      surface.DrawRect(self:GetWide() - 175 - 25 - scr, 0, 50, self:GetTall())
+      surface.DrawRect(self:GetWide() - 75 - 25 - scr, 0, 50, self:GetTall())
    end
 end
 


### PR DESCRIPTION
This creates hooks for developers wanting to edit the scoreboard. Allows adding additional columns, and adding options a right-click menu. This means people will no longer need to overwrite the default files to add these, meaning a lot better compatibility between addons.

New hooks:
"TTTScoreboardColumns"  -- One argument, TTTScoreGroup/TTTPlayerFrame Panel (the panel to add the column to).
"TTTScoreboardMenu"  -- One argument, Menu Panel. Return true to hide the menu.

New functions:
PANEL:AddPanel( label, func ) -- Label is the column heading. Function has arguments Player, Panel, and returns a string for the value to be displayed. AddPanel returns a dlabel panel

Usage example:
http://pastebin.com/8hCzWL9g 
![2014-02-28_00003](https://f.cloud.github.com/assets/2471776/2299620/64e83d74-a0d0-11e3-984e-221302b35de8.jpg)
