### PR TITLE
Fix table.Copy erroring on tables with __metatable

### DIFF
--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -25,7 +25,7 @@ function table.Copy(t, lookup_table)
 	if (t == nil) then return nil end
 	
 	local copy = {}
-	setmetatable(copy, getmetatable(t))
+	setmetatable(copy, debug.getmetatable(t))
 	for i,v in pairs(t) do
 		if ( !istable(v) ) then
 			copy[i] = v


### PR DESCRIPTION
table.Copy errors on tables with the __metatable metamethod set to a non-table, because it would call setmetatable with the value of __metatable instead of the actual metatable.
