### PR TITLE
Fixes vehicle noclip bug

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/player.lua
+++ b/garrysmod/gamemodes/base/gamemode/player.lua
@@ -560,11 +560,9 @@ end
 -----------------------------------------------------------]]
 function GM:CanExitVehicle( vehicle, ply )
 	
-	if ( ply:GetMoveType() == MOVETYPE_NOCLIP ) then 
-		ply:SetMoveType( MOVETYPE_WALK )
-	end 
-
+	ply:SetMoveType( MOVETYPE_WALK )
 	return true
+	
 end
 
 --[[---------------------------------------------------------


### PR DESCRIPTION
Removes bug when you leave a vehicle and remove it at the same time which gives the player noclip.
Fixes the spelling error. :P

Removed my if statement, I deem it is as not needed.

For some fun reason when a player exits a vehicle it quickly sets the player to noclipped then to walking for some reason internally. But setting the movetype without the statement would also work pretty nice too and save a few lines.
