### PR TITLE
Fix Spawnmenu Save button not showing

### DIFF
--- a/garrysmod/lua/vgui/ddragbase.lua
+++ b/garrysmod/lua/vgui/ddragbase.lua
@@ -74,6 +74,8 @@ function PANEL:DropAction_Simple( Drops, bDoDrop, Command, x, y )
 			
 		end
 		
+		self:OnModified()
+		
 	end
 
 end


### PR DESCRIPTION
This fixes a bug in the spawnmenu, to recreate:
- Create two spawnlists, into one of them move any spawn icon
- Click on the save button
- Move the item between the two spawnlists

The save button doesn't appear now, but it should as the lists changed. 

This happens because the check in DropAction_Normal in line 88 passes, which calls DropAction_Simple. In DropAction_Simple the OnModify call isn't present, while in DropAction_Normal it is (l. 142)
