### PR TITLE
Fix vehicle third person affecting cameras

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/base/gamemode/cl_init.lua
@@ -297,7 +297,7 @@ end
 -----------------------------------------------------------]]
 function GM:CalcVehicleView( Vehicle, ply, view )
 
-	if ( Vehicle.GetThirdPersonMode == nil ) then
+	if ( Vehicle.GetThirdPersonMode == nil || ply:GetViewEntity() != ply ) then
 		-- This hsouldn't ever happen.
 		return
 	end


### PR DESCRIPTION
When looking through camera, the vehicle third person affects view position. It shouldn't.
