### PR TITLE
Added hook for camera screenshots

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_camera.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_camera.lua
@@ -145,8 +145,10 @@ function SWEP:PrimaryAttack()
 	-- If we're multiplayer this can be done totally clientside
 	if ( !game.SinglePlayer() && SERVER ) then return end
 	if ( CLIENT && !IsFirstTimePredicted() ) then return end
-	
-	self.Owner:ConCommand( "jpeg" )
+	local arg = hook.Run("CameraTakePicture", self.Owner)
+	if arg != false then
+		self.Owner:ConCommand( "jpeg" )
+	end
 	
 end
 


### PR DESCRIPTION
Useful for hiding models before screenshot is taken, return false to disable screenshots entirely. Name could be better.
