### PR TITLE
TTT: Moved syncing of detective and traitor lists from PlayerInitialSpawn to the client's InitPostEntity

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
@@ -71,6 +71,7 @@ function GM:InitPostEntity()
 
    timer.Create("cache_ents", 1, 0, GAMEMODE.DoCacheEnts)
 
+   RunConsoleCommand("_ttt_request_rolelist")
    RunConsoleCommand("_ttt_request_serverlang")
 end
 
@@ -192,7 +193,7 @@ local function ReceiveRoleList()
             ply.traitor_gvoice = false -- assume traitorchat by default
          end
 
-         --print(ply, "is", RoleToString(ply))
+         --print(ply, "is", ply:GetRoleString())
       end
    end
 end
@@ -307,7 +308,7 @@ function GM:CalcView( ply, origin, angles, fov )
    local wep = ply:GetActiveWeapon()
    if IsValid(wep) then
 
-	-- viewmodel repositioning is now done in GM:CalcViewModelView
+   -- viewmodel repositioning is now done in GM:CalcViewModelView
 --[[
       local func = wep.GetViewModelPosition
       if func then

--- a/garrysmod/gamemodes/terrortown/gamemode/player.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player.lua
@@ -32,8 +32,6 @@ function GM:PlayerInitialSpawn( ply )
    -- Game has started, tell this guy where the round is at
    if rstate != ROUND_WAIT then
       SendRoundState(rstate, ply)
-      SendConfirmedTraitors(ply)
-      SendDetectiveList(ply)
    end
 
    -- Handle spec bots

--- a/garrysmod/gamemodes/terrortown/gamemode/traitor_state.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/traitor_state.lua
@@ -109,6 +109,24 @@ end
 
 ---- Console commands
 
+local function request_rolelist(ply)
+   -- The player has just joined and their client state has intialised
+   -- If they joined in the middle of the round, they do not know who's detective or confirmed traitor.
+   -- If they joined at the last second before the round started, it is possible, if they are traitor, that they do not know who their fellow traitors are.
+   -- This concommand is called in the InitPostEntity hook clientside.
+   -- If called before (eg. PlayerInitialSpawn serverside), player.GetByID(idx) will always return NULL.
+
+   if (GetRoundState() or ROUND_WAIT) != ROUND_WAIT then
+      SendDetectiveList(ply)
+      if ply:IsTraitor() then
+         SendTraitorList(ply)
+      else
+         SendConfirmedTraitors(ply)
+      end
+   end
+end
+concommand.Add("_ttt_request_rolelist", request_rolelist)
+
 local function force_terror(ply)
    if cvars.Bool("sv_cheats", 0) then
       ply:SetRole(ROLE_INNOCENT)


### PR DESCRIPTION
When a player joins mid-round, they will not know who are detectives and who are confirmed traitors. This was sent in PlayerInitialSpawn but did not work as since entities had not yet initialised clientside, player.GetByID(idx) always returned NULL.

The fix for this was to make the client request for this role list once they've hit InitPostEntity.

This also covers a similar situation where player's who joined just before the round started will potentially also not know the detectives or, if they are traitor, their fellow traitor buddies.
