### PR TITLE
TTT: Moved ttt_spectate call from InitPostEntity to Initialize

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
@@ -52,12 +52,12 @@ function GM:Initialize()
    LANG.Init()
 
    self.BaseClass:Initialize()
+
+   RunConsoleCommand("ttt_spectate", GetConVar("ttt_spectator_mode"):GetInt())
 end
 
 function GM:InitPostEntity()
    MsgN("TTT Client post-init...")
-
-   RunConsoleCommand("ttt_spectate", GetConVar("ttt_spectator_mode"):GetInt())
 
    if not game.SinglePlayer() then
       timer.Create("idlecheck", 5, 0, CheckIdle)


### PR DESCRIPTION
A disheartening moment for some players is when they've joined just before their traitor round and they are in spectator mode from last time they were on. ttt_spectate is only set in InitPostEntity and this potentially could be after the round has started and the traitors have been picked. An annoyance for both the player and their traitor buddies.

Moving the ttt_spectate call from InitPostEntity to Initialize prevents this.
