### PR TITLE
TTT: Removed role reset from ttt_spectate

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/traitor_state.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/traitor_state.lua
@@ -155,7 +155,6 @@ local function force_spectate(ply, cmd, arg)
 
          GAMEMODE:PlayerSpawnAsSpectator(ply)
          ply:SetTeam(TEAM_SPEC)
-         ply:SetRole(ROLE_INNOCENT)
          ply:SetForceSpec(true)
          ply:Spawn()
 


### PR DESCRIPTION
Resetting the role in ttt_spectate only caused troubles. This would throw damage logs off if the player, for example, threw an incendiary grenade or planted a C4 before entering spectator mode. Servers with a defibrillator would cause the player to respawn as an innocent serverside, but still a traitor clientside.
