### PR TITLE
TTT: Fixed autorefresh of scoring.lua cause errors when decoding round events later on

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/scoring.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/scoring.lua
@@ -5,9 +5,8 @@ local string = string
 local table = table
 local pairs = pairs
 
-SCORE = {}
-SCORE.Events = {}
---SCORE.Scores = {}
+SCORE = SCORE or {}
+SCORE.Events = SCORE.Events or {}
 
 -- One might wonder why all the key names in the event tables are so annoyingly
 -- short. Well, the serialisation module in gmod (glon) does not do any


### PR DESCRIPTION
SCORE.Events was getting reset to an empty table every time scoring.lua was autorefreshed.
