### PR TITLE
TTT: Fixed eye angles being odd when switching players with LMB after exiting propspec

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/player.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player.lua
@@ -317,6 +317,7 @@ function GM:KeyPress(ply, key)
       if key == IN_ATTACK then
          -- snap to random guy
          ply:Spectate(OBS_MODE_ROAMING)
+         ply:SetEyeAngles(angle_zero) -- After exiting propspec, this could be set to awkward values
          ply:SpectateEntity(nil)
 
          local alive = util.GetAlivePlayers()
@@ -326,6 +327,7 @@ function GM:KeyPress(ply, key)
          local target = table.Random(alive)
          if IsValid(target) then
             ply:SetPos(target:EyePos())
+            ply:SetEyeAngles(target:EyeAngles())
          end
       elseif key == IN_ATTACK2 then
          -- spectate either the next guy or a random guy in chase


### PR DESCRIPTION
After exiting propspec, it is likely that your eye angles will be at odd angles. When pressing the LMB to switch to a random player, these eye angles were still set so you will likely be spectating with an awkward roll.

This fix resets the eye angles whenever you press the LMB while spectating.
