### PR TITLE
Clean up constraint tools

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/axis.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/axis.lua
@@ -1,6 +1,6 @@
 
-TOOL.Category		= "Constraints"
-TOOL.Name			= "#tool.axis.name"
+TOOL.Category	= "Constraints"
+TOOL.Name		= "#tool.axis.name"
 
 TOOL.ClientConVar[ "forcelimit" ] = 0
 TOOL.ClientConVar[ "torquelimit" ] = 0
@@ -9,23 +9,26 @@ TOOL.ClientConVar[ "nocollide" ] = 0
 
 function TOOL:LeftClick( trace )
 
-	if ( trace.Entity:IsValid() && trace.Entity:IsPlayer() ) then return end
-	
+	if ( self:GetOperation() == 2 ) then return false end
+
+	if ( IsValid( trace.Entity ) && trace.Entity:IsPlayer() ) then return end
+
 	-- todo: Don't attempt to constrain the first object if it's already constrained to a static object
 	
 	local iNum = self:NumObjects()
 	
 	-- Don't allow us to choose the world as the first object
-	if (iNum == 0 && !trace.Entity:IsValid()) then return false end
+	if ( iNum == 0 && !IsValid( trace.Entity ) ) then return false end
 	
 	-- Don't do jeeps (crash protection until we get it fixed)
-	if (iNum == 0 && trace.Entity:GetClass() == "prop_vehicle_jeep") then return false end
+	if ( iNum == 0 && trace.Entity:GetClass() == "prop_vehicle_jeep" ) then return false end
 	
 	-- If there's no physics object then we can't constraint it!
 	if ( SERVER && !util.IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) ) then return false end
 	
 	local Phys = trace.Entity:GetPhysicsObjectNum( trace.PhysicsBone )
 	self:SetObject( iNum + 1, trace.Entity, trace.HitPos, Phys, trace.PhysicsBone, trace.HitNormal )
+	self:SetOperation( 1 )
 	
 	if ( iNum > 0 ) then
 	
@@ -40,20 +43,20 @@ function TOOL:LeftClick( trace )
 		end
 	
 		-- Get client's CVars
-		local forcelimit	= self:GetClientNumber( "forcelimit", 0 )
-		local torquelimit 	= self:GetClientNumber( "torquelimit", 0 )
-		local friction		= self:GetClientNumber( "hingefriction", 0 )
 		local nocollide		= self:GetClientNumber( "nocollide", 0 )
+		local forcelimit	= self:GetClientNumber( "forcelimit", 0 )
+		local torquelimit	= self:GetClientNumber( "torquelimit", 0 )
+		local friction		= self:GetClientNumber( "hingefriction", 0 )
 		
-		local Ent1,  Ent2  = self:GetEnt(1),	 self:GetEnt(2)
-		local Bone1, Bone2 = self:GetBone(1),	 self:GetBone(2)
-		local WPos1, WPos2 = self:GetPos(1),	 self:GetPos(2)
-		local LPos1, LPos2 = self:GetLocalPos(1),self:GetLocalPos(2)
-		local Norm1, Norm2 = self:GetNormal(1),	 self:GetNormal(2)
-		local Phys1, Phys2 = self:GetPhys(1), self:GetPhys(2)
+		local Ent1, Ent2 = self:GetEnt( 1 ),	 	self:GetEnt( 2 )
+		local Bone1, Bone2 = self:GetBone( 1 ),	 	self:GetBone( 2 )
+		local Norm1, Norm2 = self:GetNormal( 1 ),	self:GetNormal( 2 )
+		local LPos1, LPos2 = self:GetLocalPos( 1 ),	self:GetLocalPos( 2 )
+		local Phys1 = self:GetPhys( 1 )
+		local WPos2 = self:GetPos( 2 )
 		
 		-- Note: To keep stuff ragdoll friendly try to treat things as physics objects rather than entities
-		local Ang1, Ang2 = Norm1:Angle(), (Norm2 * -1):Angle()
+		local Ang1, Ang2 = Norm1:Angle(), ( -Norm2 ):Angle()
 		local TargetAngle = Phys1:AlignAngles( Ang1, Ang2 )
 		
 		Phys1:SetAngles( TargetAngle )
@@ -66,14 +69,14 @@ function TOOL:LeftClick( trace )
 		
 		-- Wake up the physics object so that the entity updates
 		Phys1:Wake()
-				
+		
 		-- Set the hinge Axis perpendicular to the trace hit surface
 		LPos1 = Phys1:WorldToLocal( WPos2 + Norm2 )
 
 		-- Create a constraint axis
 		local constraint = constraint.Axis( Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, forcelimit, torquelimit, friction, nocollide )
-
-		undo.Create("Axis")
+		
+		undo.Create( "Axis" )
 		undo.AddEntity( constraint )
 		undo.SetPlayer( self:GetOwner() )
 		undo.Finish()
@@ -87,7 +90,7 @@ function TOOL:LeftClick( trace )
 	else
 	
 		self:StartGhostEntity( trace.Entity )
-		self:SetStage( iNum+1 )
+		self:SetStage( iNum + 1 )
 	
 	end
 	
@@ -97,15 +100,18 @@ end
 
 function TOOL:RightClick( trace )
 
-	if ( trace.Entity:IsValid() && trace.Entity:IsPlayer() ) then return false end
-	
+	if ( self:GetOperation() == 1 ) then return false end
+
+	if ( IsValid( trace.Entity ) && trace.Entity:IsPlayer() ) then return false end
+
 	local iNum = self:NumObjects()
 	
 	-- Don't allow us to choose the world as the first object
-	if (iNum == 0 && !trace.Entity:IsValid()) then return false end
+	if ( iNum == 0 && !IsValid( trace.Entity ) ) then return false end
 	
 	local Phys = trace.Entity:GetPhysicsObjectNum( trace.PhysicsBone )
 	self:SetObject( iNum + 1, trace.Entity, trace.HitPos, Phys, trace.PhysicsBone, trace.HitNormal )
+	self:SetOperation( 2 )
 	
 	if ( iNum > 0 ) then
 	
@@ -113,27 +119,26 @@ function TOOL:RightClick( trace )
 		if ( CLIENT ) then
 		
 			self:ClearObjects()
-			self:ReleaseGhostEntity()
 			
 			return true
 		
 		end
 		
 		-- Get client's CVars
-		local forcelimit	= self:GetClientNumber( "forcelimit", 0 ) 
-		local torquelimit 	= self:GetClientNumber( "torquelimit", 0 ) 
-		local friction		= self:GetClientNumber( "hingefriction", 0 ) 
-		local nocollide		= self:GetClientNumber( "nocollide", 0 ) 
+		local nocollide		= self:GetClientNumber( "nocollide", 0 )
+		local forcelimit	= self:GetClientNumber( "forcelimit", 0 )
+		local torquelimit	= self:GetClientNumber( "torquelimit", 0 )
+		local friction		= self:GetClientNumber( "hingefriction", 0 )
 		
-		local Ent1,  Ent2  = self:GetEnt(1),	 self:GetEnt(2)
-		local Bone1, Bone2 = self:GetBone(1),	 self:GetBone(2)
-		local WPos1, WPos2 = self:GetPos(1),	 self:GetPos(2)
-		local LPos1, LPos2 = self:GetLocalPos(1),self:GetLocalPos(2)
-		local Norm1, Norm2 = self:GetNormal(1),	 self:GetNormal(2)
-		local Phys1, Phys2 = self:GetPhys(1), self:GetPhys(2)
+		local Ent1, Ent2 = self:GetEnt( 1 ), 		self:GetEnt( 2 )
+		local Bone1, Bone2 = self:GetBone( 1 ), 	self:GetBone( 2 )
+		local Norm1, Norm2 = self:GetNormal( 1 ),	self:GetNormal( 2 )
+		local LPos1, LPos2 = self:GetLocalPos( 1 ),	self:GetLocalPos( 2 )
+		local Phys1 = self:GetPhys( 1 )
+		local WPos2 = self:GetPos( 2 )
 		
 		-- Note: To keep stuff ragdoll friendly try to treat things as physics objects rather than entities
-		local Ang1, Ang2 = Norm1:Angle(), (Norm2 * -1):Angle()
+		local Ang1, Ang2 = Norm1:Angle(), ( -Norm2 ):Angle()
 		local TargetAngle = Phys1:AlignAngles( Ang1, Ang2 )
 		
 		--Phys1:SetAngles( TargetAngle )
@@ -147,7 +152,7 @@ function TOOL:RightClick( trace )
 
 		local constraint = constraint.Axis( Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, forcelimit, torquelimit, friction, nocollide )
 
-		undo.Create("Axis")
+		undo.Create( "Axis" )
 		undo.AddEntity( constraint )
 		undo.SetPlayer( self:GetOwner() )
 		undo.Finish()
@@ -158,12 +163,10 @@ function TOOL:RightClick( trace )
 		self:ClearObjects()
 		self:ReleaseGhostEntity()
 
-
 	else
-	
-		self:StartGhostEntity( trace.Entity )
-		self:SetStage( iNum+1 )
-	
+
+		self:SetStage( iNum + 1 )
+
 	end
 
 	return true
@@ -172,35 +175,38 @@ end
 
 function TOOL:Reload( trace )
 
-	if (!trace.Entity:IsValid() || trace.Entity:IsPlayer() ) then return false end
+	if ( !IsValid( trace.Entity ) || trace.Entity:IsPlayer() ) then return false end
 	if ( CLIENT ) then return true end
-	
-	local  bool = constraint.RemoveConstraints( trace.Entity, "Axis" )
-	return bool
-	
+
+	return constraint.RemoveConstraints( trace.Entity, "Axis" )
+
 end
 
 function TOOL:Think()
 
-	if (self:NumObjects() != 1) then return end
+	if ( self:NumObjects() != 1 ) then return end
 	
 	self:UpdateGhostEntity()
 
 end
 
+function TOOL:Holster()
+
+	self:ClearObjects()
+
+end
+
+local ConVarsDefault = TOOL:BuildConVarList()
+
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description	= "#tool.axis.help" }  )
+	CPanel:AddControl( "Header", { Description = "#tool.axis.help" } )
 	
-	CPanel:AddControl( "ComboBox", { Label = "#tool.presets",
-									 MenuButton = 1,
-									 Folder = "axis",
-									 Options = { Default = { axis_forcelimit = '0', axis_torquelimit='0', axis_hingefriction='0', axis_nocollide='0' } },
-									 CVars = { "axis_forcelimit", "axis_torquelimit", "axis_hingefriction", "axis_nocollide" } } )
+	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "axis", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
 
-	CPanel:AddControl( "Slider", 	{ Label = "#tool.forcelimit", Type = "Float", 	Command = "axis_forcelimit", 	Min = "0", 	Max = "50000", Help = true }  )
-	CPanel:AddControl( "Slider", 	{ Label = "#tool.torquelimit", Type = "Float", 	Command = "axis_torquelimit", 	Min = "0", 	Max = "50000", Help = true }  )
-	CPanel:AddControl( "Slider", 	{ Label = "#tool.hingefriction", Type = "Float", 	Command = "axis_hingefriction", 	Min = "0", 	Max = "200", Help = true }  )
-	CPanel:AddControl( "CheckBox",	{ Label = "#tool.nocollide", Command = "axis_nocollide" }  )
-									
+	CPanel:AddControl( "Slider", { Label = "#tool.forcelimit", Command = "axis_forcelimit", Type = "Float", Min = "0", Max = "50000", Help = true } )
+	CPanel:AddControl( "Slider", { Label = "#tool.torquelimit", Command = "axis_torquelimit", Type = "Float", Min = "0", Max = "50000", Help = true } )
+	CPanel:AddControl( "Slider", { Label = "#tool.hingefriction", Command = "axis_hingefriction", Type = "Float", Min = "0", Max = "200", Help = true } )
+	CPanel:AddControl( "CheckBox", { Label = "#tool.nocollide", Command = "axis_nocollide" } )
+
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/ballsocket.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/ballsocket.lua
@@ -1,6 +1,6 @@
 
-TOOL.Category		= "Constraints"
-TOOL.Name			= "#tool.ballsocket.name"
+TOOL.Category	= "Constraints"
+TOOL.Name		= "#tool.ballsocket.name"
 
 TOOL.ClientConVar[ "forcelimit" ] = "0"
 TOOL.ClientConVar[ "torquelimit" ] = "0"
@@ -8,7 +8,7 @@ TOOL.ClientConVar[ "nocollide" ] = "0"
 
 function TOOL:LeftClick( trace )
 
-	if ( trace.Entity:IsValid() && trace.Entity:IsPlayer() ) then return end
+	if ( IsValid( trace.Entity ) && trace.Entity:IsPlayer() ) then return end
 	
 	-- If there's no physics object then we can't constraint it!
 	if ( SERVER && !util.IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) ) then return false end
@@ -27,18 +27,18 @@ function TOOL:LeftClick( trace )
 		end
 		
 		-- Get client's CVars
-		local forcelimit 	= self:GetClientNumber( "forcelimit", 0 )
-		local torquelimit 	= self:GetClientNumber( "torquelimit", 0 )
 		local nocollide 	= self:GetClientNumber( "nocollide", 0 )
+		local forcelimit 	= self:GetClientNumber( "forcelimit", 0 )
+		local torquelimit	= self:GetClientNumber( "torquelimit", 0 )
 
 		-- Get information we're about to use
-		local Ent1,  Ent2  = self:GetEnt(1),  self:GetEnt(2)
-		local Bone1, Bone2 = self:GetBone(1), self:GetBone(2)
-		local LPos	   = self:GetLocalPos(2)
+		local Ent1, Ent2 = self:GetEnt( 1 ), self:GetEnt( 2 )
+		local Bone1, Bone2 = self:GetBone( 1 ), self:GetBone( 2 )
+		local LPos = self:GetLocalPos( 2 )
 
 		local constraint = constraint.Ballsocket( Ent1, Ent2, Bone1, Bone2, LPos, forcelimit, torquelimit, nocollide )
 
-		undo.Create("BallSocket")
+		undo.Create( "BallSocket" )
 		undo.AddEntity( constraint )
 		undo.SetPlayer( self:GetOwner() )
 		undo.Finish()
@@ -50,7 +50,7 @@ function TOOL:LeftClick( trace )
 
 	else
 	
-		self:SetStage( iNum+1 )
+		self:SetStage( iNum + 1 )
 		
 	end
 
@@ -60,26 +60,29 @@ end
 
 function TOOL:Reload( trace )
 
-	if (!trace.Entity:IsValid() || trace.Entity:IsPlayer() ) then return false end
+	if ( !IsValid( trace.Entity ) || trace.Entity:IsPlayer() ) then return false end
 	if ( CLIENT ) then return true end
-	
-	local  bool = constraint.RemoveConstraints( trace.Entity, "Ballsocket" )
-	return bool
+
+	return constraint.RemoveConstraints( trace.Entity, "Ballsocket" )
 	
 end
 
+function TOOL:Holster()
+
+	self:ClearObjects()
+
+end
+
+local ConVarsDefault = TOOL:BuildConVarList()
+
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description	= "#tool.ballsocket.help" }  )
+	CPanel:AddControl( "Header", { Description = "#tool.ballsocket.help" } )
 	
-	CPanel:AddControl( "ComboBox", { Label = "#tool.presets",
-									 MenuButton = 1,
-									 Folder = "ballsocket",
-									 Options = { Default = { ballsocket_forcelimit = '0', ballsocket_torquelimit='0', ballsocket_nocollide='0' } },
-									 CVars = { "ballsocket_forcelimit", "ballsocket_torquelimit", "ballsocket_nocollide" } } )
+	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "ballsocket", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
 
-	CPanel:AddControl( "Slider", 	{ Label = "#tool.forcelimit", Type = "Float", 	Command = "ballsocket_forcelimit", 	Min = "0", 	Max = "50000", Help=true }  )
-	CPanel:AddControl( "Slider", 	{ Label = "#tool.torquelimit", Type = "Float", 	Command = "ballsocket_torquelimit", 	Min = "0", 	Max = "50000", Help=true }  )
-	CPanel:AddControl( "CheckBox",	{ Label = "#tool.nocollide", Command = "ballsocket_nocollide", Help=true }  )
-									
+	CPanel:AddControl( "Slider", { Label = "#tool.forcelimit", Command = "ballsocket_forcelimit", Type = "Float", Min = "0", Max = "50000", Help = true } )
+	CPanel:AddControl( "Slider", { Label = "#tool.torquelimit", Command = "ballsocket_torquelimit", Type = "Float", Min = "0", Max = "50000", Help = true } )
+	CPanel:AddControl( "CheckBox", { Label = "#tool.nocollide", Command = "ballsocket_nocollide", Help = true } )
+
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/editentity.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/editentity.lua
@@ -4,17 +4,17 @@
 -- better instead to use the right click properties?
 --
 
-TOOL.AddToMenu		= false
+TOOL.AddToMenu	= false
 
-TOOL.Category		= "Construction"
-TOOL.Name			= "#tool.editentity.name"
+TOOL.Category	= "Construction"
+TOOL.Name		= "#tool.editentity.name"
 
 function TOOL:LeftClick( trace )
 
 	if ( !trace.Hit ) then return false end
 	
 	self.Weapon:SetTargetEntity1( trace.Entity )
-		
+	
 	return true
 	
 end
@@ -46,10 +46,9 @@ end
 function TOOL.BuildCPanel( CPanel, Entity )
 
 	local control = vgui.Create( "DEntityProperties" )
-		control:SetEntity( Entity )
-		control:SetSize( 10, 500 )
+	control:SetEntity( Entity )
+	control:SetSize( 10, 500 )
 
 	CPanel:AddPanel( control )
 
 end
-

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/elastic.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/elastic.lua
@@ -1,6 +1,6 @@
 
-TOOL.Category		= "Constraints"
-TOOL.Name			= "#tool.elastic.name"
+TOOL.Category	= "Constraints"
+TOOL.Name		= "#tool.elastic.name"
 
 TOOL.ClientConVar[ "constant" ] = "500"
 TOOL.ClientConVar[ "damping" ] = "3"
@@ -11,7 +11,7 @@ TOOL.ClientConVar[ "stretch_only" ] = "1"
 
 function TOOL:LeftClick( trace )
 
-	if ( trace.Entity:IsValid() && trace.Entity:IsPlayer() ) then return end
+	if ( IsValid( trace.Entity ) && trace.Entity:IsPlayer() ) then return end
 	
 	-- If there's no physics object then we can't constraint it!
 	if ( SERVER && !util.IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) ) then return false end
@@ -34,33 +34,33 @@ function TOOL:LeftClick( trace )
 		local constant		= self:GetClientNumber( "constant" )
 		local damping		= self:GetClientNumber( "damping" )
 		local rdamping		= self:GetClientNumber( "rdamping" )
-		local material 		= self:GetClientInfo( "material" )
 		local width 		= self:GetClientNumber( "width" )
 		local stretchonly	= self:GetClientNumber( "stretch_only" )
+		local material 		= self:GetClientInfo( "material" )
 		
 		-- Get information we're about to use
-		local Ent1,  Ent2  = self:GetEnt(1),	 	self:GetEnt(2)
-		local Bone1, Bone2 = self:GetBone(1),	 	self:GetBone(2)
-		local LPos1, LPos2 = self:GetLocalPos(1),	self:GetLocalPos(2)
+		local Ent1, Ent2 = self:GetEnt( 1 ),	 	self:GetEnt( 2 )
+		local Bone1, Bone2 = self:GetBone( 1 ),	 	self:GetBone( 2 )
+		local LPos1, LPos2 = self:GetLocalPos( 1 ),	self:GetLocalPos( 2 )
 		local constraint, rope = constraint.Elastic( Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, constant, damping, rdamping, material, width, stretchonly )
 
 		-- Add The constraint to the players undo table
 
-		undo.Create("Elastic")
+		undo.Create( "Elastic" )
 		undo.AddEntity( constraint )
-		if rope then undo.AddEntity( rope ) end
+		if ( IsValid( rope ) ) then undo.AddEntity( rope ) end
 		undo.SetPlayer( self:GetOwner() )
 		undo.Finish()
 		
 		self:GetOwner():AddCleanup( "ropeconstraints", constraint )
-		if rope then self:GetOwner():AddCleanup( "ropeconstraints", rope ) end
+		if ( IsValid( rope ) ) then self:GetOwner():AddCleanup( "ropeconstraints", rope ) end
 
 		-- Clear the objects so we're ready to go again
 		self:ClearObjects()
 	
 	else
 	
-		self:SetStage( iNum+1 )
+		self:SetStage( iNum + 1 )
 	
 	end
 	
@@ -70,31 +70,33 @@ end
 
 function TOOL:Reload( trace )
 
-	if (!trace.Entity:IsValid() || trace.Entity:IsPlayer() ) then return false end
+	if ( !IsValid( trace.Entity ) || trace.Entity:IsPlayer() ) then return false end
 	if ( CLIENT ) then return true end
-	
-	local  bool = constraint.RemoveConstraints( trace.Entity, "Elastic" )
-	return bool
+
+	return constraint.RemoveConstraints( trace.Entity, "Elastic" )
 	
 end
 
+function TOOL:Holster()
+
+	self:ClearObjects()
+
+end
+
+local ConVarsDefault = TOOL:BuildConVarList()
+
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description	= "#tool.elastic.help" }  )
+	CPanel:AddControl( "Header", { Description = "#tool.elastic.help" } )
 	
-	CPanel:AddControl( "ComboBox", { Label = "#tool.presets",
-									 MenuButton = 1,
-									 Folder = "elastic",
-									 Options = { Default = { elastic_constant = '500',	elastic_damping='3',	elastic_rdamping='0.01',		elastic_material='cable/cable',		elastic_width='2',		elastic_stretch_only="1" } },
-									 CVars =				{ "elastic_constant",		"elastic_damping",		"elastic_rdamping",			"elastic_material",					"elastic_width",		"elastic_stretch_only" } } )
+	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "elastic", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
 
-	CPanel:AddControl( "Slider", 		{ Label = "#tool.elastic.constant",		Type = "Float", 	Command = "elastic_constant", 	Min = "0", 	Max = "4000", Help=true }  )
-	CPanel:AddControl( "Slider", 		{ Label = "#tool.elastic.damping",		Type = "Float", 	Command = "elastic_damping", 	Min = "0", 	Max = "50", Help=true }  )
-	CPanel:AddControl( "Slider", 		{ Label = "#tool.elastic.rdamping",		Type = "Float", 	Command = "elastic_rdamping", 	Min = "0", 	Max = "1", Help=true }  )
-	CPanel:AddControl( "CheckBox",		{ Label = "#tool.elastic.stretchonly",	Command = "elastic_stretch_only", Help=true }  )
+	CPanel:AddControl( "Slider", { Label = "#tool.elastic.constant", Command = "elastic_constant", Type = "Float", Min = "0", Max = "4000", Help = true } )
+	CPanel:AddControl( "Slider", { Label = "#tool.elastic.damping", Command = "elastic_damping", Type = "Float", Min = "0", Max = "50", Help = true } )
+	CPanel:AddControl( "Slider", { Label = "#tool.elastic.rdamping", Command = "elastic_rdamping", Type = "Float", Min = "0", Max = "1", Help = true } )
+	CPanel:AddControl( "CheckBox", { Label = "#tool.elastic.stretchonly", Command = "elastic_stretch_only", Help = true } )
 
-	CPanel:AddControl( "Slider", 		{ Label = "#tool.elastic.width",		Type = "Float", 	Command = "elastic_width", 		Min = "0", 	Max = "20" }  )
-	CPanel:AddControl( "RopeMaterial", 	{ Label = "#tool.elastic.material",		convar	= "elastic_material" }  )
-	
-									
+	CPanel:AddControl( "Slider", { Label = "#tool.elastic.width", Command = "elastic_width", Type = "Float", Min = "0", Max = "20" } )
+	CPanel:AddControl( "RopeMaterial", { Label = "#tool.elastic.material", ConVar = "elastic_material" } )
+
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/example.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/example.lua
@@ -1,12 +1,12 @@
 
 -- Remove this to add it to the menu
-TOOL.AddToMenu		= false
+TOOL.AddToMenu	= false
 
 -- Define these!
-TOOL.Category		= "My Category"		-- Name of the category
-TOOL.Name			= "#Example"		-- Name to display
-TOOL.Command		= nil				-- Command on click (nil for default), can be removed
-TOOL.ConfigName		= nil				-- Config file name (nil for default), can be removed
+TOOL.Category	= "My Category"	-- Name of the category
+TOOL.Name		= "#Example"	-- Name to display
+TOOL.Command	= nil			-- Command on click (nil for default), can be removed
+TOOL.ConfigName	= nil			-- Config file name (nil for default), can be removed
 
 if ( true ) then return end
 

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/hydraulic.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/hydraulic.lua
@@ -1,6 +1,6 @@
 
-TOOL.Category		= "Constraints"
-TOOL.Name			= "#tool.hydraulic.name"
+TOOL.Category	= "Constraints"
+TOOL.Name		= "#tool.hydraulic.name"
 
 TOOL.ClientConVar[ "group" ] = "37"
 TOOL.ClientConVar[ "width" ] = "3"
@@ -11,7 +11,7 @@ TOOL.ClientConVar[ "material" ] = "cable/rope"
 
 function TOOL:LeftClick( trace )
 
-	if ( trace.Entity:IsValid() && trace.Entity:IsPlayer() ) then return false end
+	if ( IsValid( trace.Entity ) && trace.Entity:IsPlayer() ) then return false end
 	
 	-- If there's no physics object then we can't constraint it!
 	if ( SERVER && !util.IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) ) then return false end
@@ -20,6 +20,7 @@ function TOOL:LeftClick( trace )
 	
 	local Phys = trace.Entity:GetPhysicsObjectNum( trace.PhysicsBone )
 	self:SetObject( iNum + 1, trace.Entity, trace.HitPos, Phys, trace.PhysicsBone, trace.HitNormal )
+	self:SetOperation( 1 )
 	
 	if ( iNum > 0 ) then
 		
@@ -28,7 +29,7 @@ function TOOL:LeftClick( trace )
 			return true
 		end
 		
-		if ( ( !self:GetEnt(1):IsValid() && !self:GetEnt(2):IsValid() ) || iNum > 1 ) then 
+		if ( ( !IsValid( self:GetEnt( 1 ) ) && !IsValid( self:GetEnt( 2 ) ) ) || iNum > 1 ) then
 
 			self:ClearObjects()
 			return true
@@ -36,43 +37,43 @@ function TOOL:LeftClick( trace )
 		end
 		
 		-- Get client's CVars
-		local width			= self:GetClientNumber( "width", 3 )
-		local bind			= self:GetClientNumber( "group", 1 )
-		local AddLength		= self:GetClientNumber( "addlength", 0 )
-		local fixed			= self:GetClientNumber( "fixed", 1 )
-		local speed			= self:GetClientNumber( "speed", 64 )
-		local material		= self:GetClientInfo( "material" )
+		local width		= self:GetClientNumber( "width", 3 )
+		local bind		= self:GetClientNumber( "group", 1 )
+		local AddLength	= self:GetClientNumber( "addlength", 0 )
+		local fixed		= self:GetClientNumber( "fixed", 1 )
+		local speed		= self:GetClientNumber( "speed", 64 )
+		local material	= self:GetClientInfo( "material" )
 		
 		-- Get information we're about to use
-		local Ent1,  Ent2  = self:GetEnt(1),	 self:GetEnt(2)
-		local Bone1, Bone2 = self:GetBone(1),	 self:GetBone(2)
-		local LPos1, LPos2 = self:GetLocalPos(1),self:GetLocalPos(2)
-		local WPos1, WPos2 = self:GetPos(1),     self:GetPos(2)
+		local Ent1, Ent2 = self:GetEnt( 1 ),		self:GetEnt( 2 )
+		local Bone1, Bone2 = self:GetBone( 1 ),	 	self:GetBone( 2 )
+		local LPos1, LPos2 = self:GetLocalPos( 1 ),	self:GetLocalPos( 2 )
+		local WPos1, WPos2 = self:GetPos( 1 ),		self:GetPos( 2 )
 
-		local Length1 = (WPos1 - WPos2):Length()
-		local Length2 = Length1 + AddLength	
+		local Length1 = ( WPos1 - WPos2 ):Length()
+		local Length2 = Length1 + AddLength
 	
-		local constraint,rope,controller,slider = constraint.Hydraulic( self:GetOwner(), Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, Length1, Length2, width, bind, fixed, speed, material )
+		local constraint, rope, controller, slider = constraint.Hydraulic( self:GetOwner(), Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, Length1, Length2, width, bind, fixed, speed, material )
 
-		undo.Create("Hydraulic")
-		if constraint then undo.AddEntity( constraint ) end
-		if rope   then undo.AddEntity( rope ) end
-		if slider then undo.AddEntity( slider ) end
-		if controller then undo.AddEntity( controller ) end
+		undo.Create( "Hydraulic" )
+		if ( IsValid( constraint ) ) then undo.AddEntity( constraint ) end
+		if ( IsValid( rope ) ) then undo.AddEntity( rope ) end
+		if ( IsValid( slider ) ) then undo.AddEntity( slider ) end
+		if ( IsValid( controller ) ) then undo.AddEntity( controller ) end
 		undo.SetPlayer( self:GetOwner() )
 		undo.Finish()
 		
-		if constraint then	self:GetOwner():AddCleanup( "ropeconstraints", constraint ) end
-		if rope   then		self:GetOwner():AddCleanup( "ropeconstraints", rope ) end
-		if slider then		self:GetOwner():AddCleanup( "ropeconstraints", slider ) end
-		if controller then	self:GetOwner():AddCleanup( "ropeconstraints", controller ) end
+		if ( IsValid( constraint ) ) then self:GetOwner():AddCleanup( "ropeconstraints", constraint ) end
+		if ( IsValid( rope ) ) then self:GetOwner():AddCleanup( "ropeconstraints", rope ) end
+		if ( IsValid( slider ) ) then self:GetOwner():AddCleanup( "ropeconstraints", slider ) end
+		if ( IsValid( controller ) ) then self:GetOwner():AddCleanup( "ropeconstraints", controller ) end
 		
 		-- Clear the objects so we're ready to go again
 		self:ClearObjects()
 		
 	else
 	
-		self:SetStage( iNum+1 )
+		self:SetStage( iNum + 1 )
 		
 	end
 	
@@ -81,6 +82,8 @@ function TOOL:LeftClick( trace )
 end
 
 function TOOL:RightClick( trace )
+
+	if ( self:GetOperation() == 1 ) then return false end
 
 	-- If there's no physics object then we can't constraint it!
 	if ( SERVER && !util.IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) ) then return false end
@@ -92,31 +95,30 @@ function TOOL:RightClick( trace )
 
 	local tr = {}
 	tr.start = trace.HitPos
-	tr.endpos = tr.start + (trace.HitNormal * 16384)
-	tr.filter = {} 
+	tr.endpos = tr.start + ( trace.HitNormal * 16384 )
+	tr.filter = {}
 	tr.filter[1] = self:GetOwner()
-	if (trace.Entity:IsValid()) then
+	if ( IsValid( trace.Entity ) ) then
 		tr.filter[2] = trace.Entity
 	end
 	
 	local tr = util.TraceLine( tr )
-		
 	if ( !tr.Hit ) then
 		self:ClearObjects()
 		return
 	end
-		
+	
 	-- Don't try to constrain world to world
 	if ( trace.HitWorld && tr.HitWorld ) then
 		self:ClearObjects()
-		return 
+		return
 	end
 	
-	if ( trace.Entity:IsValid() && trace.Entity:IsPlayer() ) then
+	if ( IsValid( trace.Entity ) && trace.Entity:IsPlayer() ) then
 		self:ClearObjects()
 		return
 	end
-	if ( tr.Entity:IsValid() && tr.Entity:IsPlayer() ) then
+	if ( IsValid( tr.Entity ) && tr.Entity:IsPlayer() ) then
 		self:ClearObjects()
 		return
 	end
@@ -132,34 +134,34 @@ function TOOL:RightClick( trace )
 	-- Get client's CVars
 	local width		= self:GetClientNumber( "width", 3 )
 	local bind		= self:GetClientNumber( "group", 1 )
-	local AddLength		= self:GetClientNumber( "addlength", 0 )
+	local AddLength	= self:GetClientNumber( "addlength", 0 )
 	local fixed		= self:GetClientNumber( "fixed", 1 )
 	local speed		= self:GetClientNumber( "speed", 64 )
-	local material		= self:GetClientInfo( "material" )
+	local material	= self:GetClientInfo( "material" )
 	
 	-- Get information we're about to use
-	local Ent1,  Ent2  = self:GetEnt(1),	 self:GetEnt(2)
-	local Bone1, Bone2 = self:GetBone(1),	 self:GetBone(2)
-	local LPos1, LPos2 = self:GetLocalPos(1),self:GetLocalPos(2)
-	local WPos1, WPos2 = self:GetPos(1),     self:GetPos(2)
+	local Ent1, Ent2 = self:GetEnt( 1 ),		self:GetEnt( 2 )
+	local Bone1, Bone2 = self:GetBone( 1 ),		self:GetBone( 2 )
+	local LPos1, LPos2 = self:GetLocalPos( 1 ),	self:GetLocalPos( 2 )
+	local WPos1, WPos2 = self:GetPos( 1 ),		self:GetPos( 2 )
 
-	local Length1 = (WPos1 - WPos2):Length()
-	local Length2 = Length1 + AddLength	
+	local Length1 = ( WPos1 - WPos2 ):Length()
+	local Length2 = Length1 + AddLength
 
-	local constraint,rope,controller,slider = constraint.Hydraulic( self:GetOwner(), Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, Length1, Length2, width, bind, fixed, speed, material )
+	local constraint, rope, controller, slider = constraint.Hydraulic( self:GetOwner(), Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, Length1, Length2, width, bind, fixed, speed, material )
 
 	undo.Create("Hydraulic")
-	if constraint then undo.AddEntity( constraint ) end
-	if rope   then undo.AddEntity( rope ) end
-	if slider then undo.AddEntity( slider ) end
-	if controller then undo.AddEntity( controller ) end
+	if ( IsValid( constraint ) ) then undo.AddEntity( constraint ) end
+	if ( IsValid( rope ) ) then undo.AddEntity( rope ) end
+	if ( IsValid( slider ) ) then undo.AddEntity( slider ) end
+	if ( IsValid( controller ) ) then undo.AddEntity( controller ) end
 	undo.SetPlayer( self:GetOwner() )
 	undo.Finish()
 	
-	if constraint then	self:GetOwner():AddCleanup( "ropeconstraints", constraint ) end
-	if rope   then		self:GetOwner():AddCleanup( "ropeconstraints", rope ) end
-	if slider then		self:GetOwner():AddCleanup( "ropeconstraints", slider ) end
-	if controller then	self:GetOwner():AddCleanup( "ropeconstraints", controller ) end
+	if ( IsValid( constraint ) ) then self:GetOwner():AddCleanup( "ropeconstraints", constraint ) end
+	if ( IsValid( rope ) ) then self:GetOwner():AddCleanup( "ropeconstraints", rope ) end
+	if ( IsValid( slider ) ) then self:GetOwner():AddCleanup( "ropeconstraints", slider ) end
+	if ( IsValid( controller ) ) then self:GetOwner():AddCleanup( "ropeconstraints", controller ) end
 
 	-- Clear the objects so we're ready to go again
 	self:ClearObjects()
@@ -170,32 +172,33 @@ end
 
 function TOOL:Reload( trace )
 
-	if (!trace.Entity:IsValid() || trace.Entity:IsPlayer() ) then return false end
+	if ( !IsValid( trace.Entity ) || trace.Entity:IsPlayer() ) then return false end
 	if ( CLIENT ) then return true end
-	
-	local  bool = constraint.RemoveConstraints( trace.Entity, "Hydraulic" )
-	return bool
-	
+
+	return constraint.RemoveConstraints( trace.Entity, "Hydraulic" )
+
 end
+
+function TOOL:Holster()
+
+	self:ClearObjects()
+
+end
+
+local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description	= "#tool.hydraulic.help" }  )
+	CPanel:AddControl( "Header", { Description = "#tool.hydraulic.help" } )
 	
-	CPanel:AddControl( "ComboBox", { Label = "#tool.presets",
-									 MenuButton = 1,
-									 Folder = "hydraulic",
-									 Options = { Default = { hydraulic_width = '3',		hydraulic_group='1',	hydraulic_addlength='100',		hydraulic_fixed='1' } },
-									 CVars =				{ "hydraulic_width",		"hydraulic_group",		"hydraulic_addlength",			"hydraulic_fixed" } } )
+	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "hydraulic", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
 
-	CPanel:AddControl( "Numpad",		{ Label = "#tool.hydraulic.controls",	Command = "hydraulic_group" } )
-	CPanel:AddControl( "Slider", 		{ Label = "#tool.hydraulic.addlength",	Type = "Float", 	Command = "hydraulic_addlength", 	Min = "-1000", 	Max = "1000", Help=true }  )
-	CPanel:AddControl( "Slider", 		{ Label = "#tool.hydraulic.speed",		Type = "Float", 	Command = "hydraulic_speed", 	Min = "0", 	Max = "50", Help=true }  )
-	CPanel:AddControl( "CheckBox",		{ Label = "#tool.hydraulic.fixed",		Command = "hydraulic_fixed", Help=true }  )
+	CPanel:AddControl( "Numpad", { Label = "#tool.hydraulic.controls", Command = "hydraulic_group" } )
+	CPanel:AddControl( "Slider", { Label = "#tool.hydraulic.addlength", Command = "hydraulic_addlength", Type = "Float", Min = "-1000", Max = "1000", Help = true } )
+	CPanel:AddControl( "Slider", { Label = "#tool.hydraulic.speed", Command = "hydraulic_speed", Type = "Float", Min = "0", Max = "50", Help = true } )
+	CPanel:AddControl( "CheckBox", { Label = "#tool.hydraulic.fixed", Command = "hydraulic_fixed", Help = true } )
 
-	CPanel:AddControl( "Slider", 		{ Label = "#tool.hydraulic.width",		Type = "Float", 	Command = "hydraulic_width", 	Min = "0", 	Max = "5" }  )
-	CPanel:AddControl( "RopeMaterial", 	{ Label = "#tool.hydraulic.material",		convar	= "hydraulic_material" }  )
-	
-	
-									
+	CPanel:AddControl( "Slider", { Label = "#tool.hydraulic.width", Command = "hydraulic_width", Type = "Float", Min = "0", Max = "5" } )
+	CPanel:AddControl( "RopeMaterial", { Label = "#tool.hydraulic.material", ConVar = "hydraulic_material" } )
+
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/leafblower.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/leafblower.lua
@@ -1,5 +1,4 @@
 
-
 TOOL.AddToMenu		= false
 
 --
@@ -15,28 +14,28 @@ function TOOL:LeftClick( trace )
 	util.PrecacheSound( "ambient/wind/wind_hit2.wav" )
 	self:GetOwner():EmitSound( "ambient/wind/wind_hit2.wav" )
 
-	if ( trace.Entity:IsValid() ) then
+	if ( IsValid( trace.Entity ) ) then
 	
 		if ( trace.Entity:GetPhysicsObject():IsValid() ) then
 		
-			local phys = trace.Entity:GetPhysicsObject()		-- The physics object
-			local direction = trace.StartPos - trace.HitPos		-- The direction of the force
-			local force = 32					-- The ideal amount of force
-			local distance = direction:Length()			-- The distance the phys object is from the gun
-			local maxdistance = 512					-- The max distance the gun should reach
+			local phys = trace.Entity:GetPhysicsObject()	-- The physics object
+			local direction = trace.StartPos - trace.HitPos	-- The direction of the force
+			local force = 32								-- The ideal amount of force
+			local distance = direction:Length()				-- The distance the phys object is from the gun
+			local maxdistance = 512							-- The max distance the gun should reach
 			
 			-- Lessen the force from a distance
-			local ratio = math.Clamp( (1 - (distance/maxdistance)), 0, 1 )
+			local ratio = math.Clamp( ( 1 - ( distance / maxdistance ) ), 0, 1 )
 			
 			-- Set up the 'real' force and the offset of the force
-			local vForce = -1*direction * (force * ratio)
+			local vForce = -direction * ( force * ratio )
 			local vOffset = trace.HitPos
 			
 			-- Apply it!
 			phys:ApplyForceOffset( vForce, vOffset )
-						
-		end
 		
+		end
+	
 	end
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/motor.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/motor.lua
@@ -1,6 +1,6 @@
 
-TOOL.Category		= "Constraints"
-TOOL.Name			= "#tool.motor.name"
+TOOL.Category	= "Constraints"
+TOOL.Name		= "#tool.motor.name"
 
 TOOL.ClientConVar[ "torque" ] = "500"
 TOOL.ClientConVar[ "friction" ] = "1"
@@ -13,7 +13,7 @@ TOOL.ClientConVar[ "forcelimit" ] = "0"
 
 function TOOL:LeftClick( trace )
 
-	if ( trace.Entity:IsValid() && trace.Entity:IsPlayer() ) then return end
+	if ( IsValid( trace.Entity ) && trace.Entity:IsPlayer() ) then return end
 
 	-- If there's no physics object then we can't constraint it!
 	if ( SERVER && !util.IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) ) then return false end
@@ -23,10 +23,10 @@ function TOOL:LeftClick( trace )
 	local Phys = trace.Entity:GetPhysicsObjectNum( trace.PhysicsBone )
 	
 	-- Don't allow us to choose the world as the first object
-	if (iNum == 0 && !trace.Entity:IsValid()) then return end
+	if ( iNum == 0 && !IsValid( trace.Entity ) ) then return end
 	
 	-- Don't allow us to choose the same object
-	if (iNum == 1 && trace.Entity == self:GetEnt(1) ) then return end
+	if ( iNum == 1 && trace.Entity == self:GetEnt( 1 ) ) then return end
 	
 	self:SetObject( iNum + 1, trace.Entity, trace.HitPos, Phys, trace.PhysicsBone, trace.HitNormal )
 	
@@ -42,24 +42,24 @@ function TOOL:LeftClick( trace )
 		end
 		
 		-- Get client's CVars
-		local torque		= self:GetClientNumber( "torque" )
-		local friction 		= self:GetClientNumber( "friction" )
-		local nocollide		= self:GetClientNumber( "nocollide" )
-		local time			= self:GetClientNumber( "forcetime" )
-		local forekey		= self:GetClientNumber( "fwd" )
-		local backkey		= self:GetClientNumber( "bwd" )
-		local toggle		= self:GetClientNumber( "toggle" )
-		local limit			= self:GetClientNumber( "forcelimit" )
+		local torque	= self:GetClientNumber( "torque" )
+		local friction 	= self:GetClientNumber( "friction" )
+		local nocollide	= self:GetClientNumber( "nocollide" )
+		local time		= self:GetClientNumber( "forcetime" )
+		local forekey	= self:GetClientNumber( "fwd" )
+		local backkey	= self:GetClientNumber( "bwd" )
+		local toggle	= self:GetClientNumber( "toggle" )
+		local limit		= self:GetClientNumber( "forcelimit" )
 		
-		local Ent1,  Ent2  = self:GetEnt(1),	 self:GetEnt(2)
-		local Bone1, Bone2 = self:GetBone(1),	 self:GetBone(2)
-		local WPos1, WPos2 = self:GetPos(1),	 self:GetPos(2)
-		local LPos1, LPos2 = self:GetLocalPos(1),self:GetLocalPos(2)
-		local Norm1, Norm2 = self:GetNormal(1),	 self:GetNormal(2)
-		local Phys1, Phys2 = self:GetPhys(1), self:GetPhys(2)
+		local Ent1, Ent2 = self:GetEnt( 1 ),		self:GetEnt( 2 )
+		local Bone1, Bone2 = self:GetBone( 1 ),		self:GetBone( 2 )
+		local LPos1, LPos2 = self:GetLocalPos( 1 ),	self:GetLocalPos( 2 )
+		local Norm1, Norm2 = self:GetNormal( 1 ),	self:GetNormal( 2 )
+		local Phys1 = self:GetPhys( 1 )
+		local WPos2 = self:GetPos( 2 )
 		
 		-- Note: To keep stuff ragdoll friendly try to treat things as physics objects rather than entities
-		local Ang1, Ang2 = Norm1:Angle(), (Norm2 * -1):Angle()
+		local Ang1, Ang2 = Norm1:Angle(), ( -Norm2 ):Angle()
 		local TargetAngle = Phys1:AlignAngles( Ang1, Ang2 )
 		
 		Phys1:SetAngles( TargetAngle )
@@ -78,7 +78,7 @@ function TOOL:LeftClick( trace )
 
 		local constraint, axis = constraint.Motor( Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, friction, torque, time, nocollide, toggle, self:GetOwner(), limit, forekey, backkey, 1 )
 
-		undo.Create("Motor")
+		undo.Create( "Motor" )
 		undo.AddEntity( axis )
 		undo.AddEntity( constraint )
 		undo.SetPlayer( self:GetOwner() )
@@ -94,7 +94,7 @@ function TOOL:LeftClick( trace )
 	else
 	
 		self:StartGhostEntity( trace.Entity )
-		self:SetStage( iNum+1 )
+		self:SetStage( iNum + 1 )
 		
 	end
 	
@@ -102,46 +102,43 @@ function TOOL:LeftClick( trace )
 	
 end
 
-function TOOL:RightClick( trace )
-	
-	return false
-	
-end
-
 function TOOL:Reload( trace )
 
-	if (!trace.Entity:IsValid() || trace.Entity:IsPlayer() ) then return false end
+	if ( !IsValid( trace.Entity ) || trace.Entity:IsPlayer() ) then return false end
 	if ( CLIENT ) then return true end
-	
-	local  bool = constraint.RemoveConstraints( trace.Entity, "Motor" )
-	return bool
-	
+
+	return constraint.RemoveConstraints( trace.Entity, "Motor" )
+
 end
 
 function TOOL:Think()
 
-	if (self:NumObjects() != 1) then return end
+	if ( self:NumObjects() != 1 ) then return end
 	
 	self:UpdateGhostEntity()
 
 end
 
+function TOOL:Holster()
+
+	self:ClearObjects()
+
+end
+
+local ConVarsDefault = TOOL:BuildConVarList()
+
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description	= "#tool.motor.help" }  )
+	CPanel:AddControl( "Header", { Description = "#tool.motor.help" } )
 	
-	CPanel:AddControl( "ComboBox", { Label = "#tool.presets",
-									 MenuButton = 1,
-									 Folder = "motor",
-									 Options = { Default = { motor_torque = '1000',	motor_friction='0',		motor_nocollide='0',		motor_forcetime='0' } },
-									 CVars =				{ "motor_torque",		"motor_friction",		"motor_nocollide",			"motor_forcetime" } } )
+	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "motor", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
 
-	CPanel:AddControl( "Numpad",		{ Label = "#tool.motor.numpad1",	Command = "motor_fwd", Label2 = "#tool.motor.numpad2",	Command2 = "motor_bwd" } )
-	CPanel:AddControl( "Slider", 		{ Label = "#tool.motor.torque",		Type = "Float", 	Command = "motor_torque",		Min = "0", 	Max = "10000" } )
-	CPanel:AddControl( "Slider", 		{ Label = "#tool.forcelimit",		Type = "Float", 	Command = "motor_forcelimit", 	Min = "0", 	Max = "50000", Help=true }  )
-	CPanel:AddControl( "Slider", 		{ Label = "#tool.hingefriction",	Type = "Float", 	Command = "motor_friction", 	Min = "0", 	Max = "100", Help=true }  )
-	CPanel:AddControl( "Slider", 		{ Label = "#tool.motor.forcetime",	Type = "Float", 	Command = "motor_forcetime", 	Min = "0", 	Max = "120", Help=true }  )
-	CPanel:AddControl( "CheckBox",		{ Label = "#tool.nocollide",		Command = "motor_nocollide", Help=true }  )
-	CPanel:AddControl( "CheckBox",		{ Label = "#tool.toggle",			Command = "motor_toggle", Help=true }  )	
-									
+	CPanel:AddControl( "Numpad", { Label = "#tool.motor.numpad1", Command = "motor_fwd", Label2 = "#tool.motor.numpad2", Command2 = "motor_bwd" } )
+	CPanel:AddControl( "Slider", { Label = "#tool.motor.torque", Command = "motor_torque", Type = "Float", Min = "0", Max = "10000" } )
+	CPanel:AddControl( "Slider", { Label = "#tool.forcelimit", Command = "motor_forcelimit", Type = "Float", Min = "0", Max = "50000", Help = true } )
+	CPanel:AddControl( "Slider", { Label = "#tool.hingefriction", Command = "motor_friction", Type = "Float", Min = "0", Max = "100", Help = true } )
+	CPanel:AddControl( "Slider", { Label = "#tool.motor.forcetime", Command = "motor_forcetime", Type = "Float", Min = "0", Max = "120", Help = true } )
+	CPanel:AddControl( "CheckBox", { Label = "#tool.nocollide", Command = "motor_nocollide", Help = true } )
+	CPanel:AddControl( "CheckBox", { Label = "#tool.toggle", Command = "motor_toggle", Help = true } )
+
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/muscle.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/muscle.lua
@@ -1,6 +1,6 @@
 
-TOOL.Category		= "Constraints"
-TOOL.Name			= "#tool.muscle.name"
+TOOL.Category	= "Constraints"
+TOOL.Name		= "#tool.muscle.name"
 
 TOOL.ClientConVar[ "group" ] = "37"
 TOOL.ClientConVar[ "width" ] = "2"
@@ -12,7 +12,7 @@ TOOL.ClientConVar[ "starton" ] = "0"
 
 function TOOL:LeftClick( trace )
 
-	if ( trace.Entity:IsValid() && trace.Entity:IsPlayer() ) then return end
+	if ( IsValid( trace.Entity ) && trace.Entity:IsPlayer() ) then return end
 	
 	-- If there's no physics object then we can't constraint it!
 	if ( SERVER && !util.IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) ) then return false end
@@ -21,6 +21,7 @@ function TOOL:LeftClick( trace )
 	
 	local Phys = trace.Entity:GetPhysicsObjectNum( trace.PhysicsBone )
 	self:SetObject( iNum + 1, trace.Entity, trace.HitPos, Phys, trace.PhysicsBone, trace.HitNormal )
+	self:SetOperation( 1 )
 	
 	if ( iNum > 0 ) then
 	
@@ -29,7 +30,7 @@ function TOOL:LeftClick( trace )
 			return true
 		end
 		
-		if ( ( !self:GetEnt(1):IsValid() && !self:GetEnt(2):IsValid() ) || iNum > 1 ) then 
+		if ( ( !IsValid( self:GetEnt( 1 ) ) && !IsValid( self:GetEnt( 2 ) ) ) || iNum > 1 ) then
 
 			self:ClearObjects()
 			return true
@@ -37,18 +38,18 @@ function TOOL:LeftClick( trace )
 		end
 		
 		-- Get client's CVars
-		local width			= self:GetClientNumber( "width", 3 )
-		local bind			= self:GetClientNumber( "group", 1 )
-		local AddLength		= self:GetClientNumber( "addlength", 0 )
-		local fixed			= self:GetClientNumber( "fixed", 1 )
-		local period		= self:GetClientNumber( "period", 1 )
-		local material		= self:GetClientInfo( "material" )
-		local starton		= self:GetClientNumber( "starton" )
+		local width		= self:GetClientNumber( "width", 3 )
+		local bind		= self:GetClientNumber( "group", 1 )
+		local AddLength	= self:GetClientNumber( "addlength", 0 )
+		local fixed		= self:GetClientNumber( "fixed", 1 )
+		local period	= self:GetClientNumber( "period", 1 )
+		local starton	= self:GetClientNumber( "starton" )
+		local material	= self:GetClientInfo( "material" )
 		
 		-- If AddLength is 0 then what's the point.
 		if ( AddLength == 0 ) then
 			self:ClearObjects()
-			return true 
+			return true
 		end
 		
 		if ( period <= 0 ) then period = 0.1 end
@@ -56,37 +57,37 @@ function TOOL:LeftClick( trace )
 		AddLength = math.Clamp( AddLength, -1000, 1000 )
 		
 		-- Get information we're about to use
-		local Ent1,  Ent2  = self:GetEnt(1),	 self:GetEnt(2)
-		local Bone1, Bone2 = self:GetBone(1),	 self:GetBone(2)
-		local LPos1, LPos2 = self:GetLocalPos(1),self:GetLocalPos(2)
-		local WPos1, WPos2 = self:GetPos(1),     self:GetPos(2)
+		local Ent1, Ent2 = self:GetEnt( 1 ),		self:GetEnt( 2 )
+		local Bone1, Bone2 = self:GetBone( 1 ),		self:GetBone( 2 )
+		local LPos1, LPos2 = self:GetLocalPos( 1 ),	self:GetLocalPos( 2 )
+		local WPos1, WPos2 = self:GetPos( 1 ),		self:GetPos( 2 )
 
-		local Length1 = (WPos1 - WPos2):Length()
-		local Length2 = Length1 + AddLength	
+		local Length1 = ( WPos1 - WPos2 ):Length()
+		local Length2 = Length1 + AddLength
 		
 		local amp = Length2 - Length1
 	
-		local constraint,rope,controller,slider = constraint.Muscle( self:GetOwner(), Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, Length1, Length2, width, bind, fixed, period, amp, starton, material )
+		local constraint, rope, controller, slider = constraint.Muscle( self:GetOwner(), Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, Length1, Length2, width, bind, fixed, period, amp, starton, material )
 
-		undo.Create("Muscle")
-		if constraint then undo.AddEntity( constraint ) end
-		if rope   then undo.AddEntity( rope ) end
-		if slider then undo.AddEntity( slider ) end
-		if controller then undo.AddEntity( controller ) end
+		undo.Create( "Muscle" )
+		if ( IsValid( constraint ) ) then undo.AddEntity( constraint ) end
+		if ( IsValid( rope ) ) then undo.AddEntity( rope ) end
+		if ( IsValid( slider ) ) then undo.AddEntity( slider ) end
+		if ( IsValid( controller ) ) then undo.AddEntity( controller ) end
 		undo.SetPlayer( self:GetOwner() )
 		undo.Finish()
 		
-		if constraint then	self:GetOwner():AddCleanup( "ropeconstraints", constraint ) end
-		if rope   then		self:GetOwner():AddCleanup( "ropeconstraints", rope ) end
-		if slider then		self:GetOwner():AddCleanup( "ropeconstraints", slider ) end
-		if controller then	self:GetOwner():AddCleanup( "ropeconstraints", controller ) end
+		if ( IsValid( constraint ) ) then self:GetOwner():AddCleanup( "ropeconstraints", constraint ) end
+		if ( IsValid( rope ) ) then self:GetOwner():AddCleanup( "ropeconstraints", rope ) end
+		if ( IsValid( slider ) ) then self:GetOwner():AddCleanup( "ropeconstraints", slider ) end
+		if ( IsValid( controller ) ) then self:GetOwner():AddCleanup( "ropeconstraints", controller ) end
 		
 		-- Clear the objects so we're ready to go again
 		self:ClearObjects()
 		
 	else
 	
-		self:SetStage( iNum+1 )
+		self:SetStage( iNum + 1 )
 		
 	end
 	
@@ -96,6 +97,8 @@ end
 
 function TOOL:RightClick( trace )
 
+	if ( self:GetOperation() == 1 ) then return false end
+
 	local iNum = self:NumObjects()
 
 	local Phys = trace.Entity:GetPhysicsObjectNum( trace.PhysicsBone )
@@ -103,31 +106,30 @@ function TOOL:RightClick( trace )
 
 	local tr = {}
 	tr.start = trace.HitPos
-	tr.endpos = tr.start + (trace.HitNormal * 16384)
-	tr.filter = {} 
+	tr.endpos = tr.start + ( trace.HitNormal * 16384 )
+	tr.filter = {}
 	tr.filter[1] = self:GetOwner()
-	if (trace.Entity:IsValid()) then
+	if ( IsValid( trace.Entity ) ) then
 		tr.filter[2] = trace.Entity
 	end
 	
 	local tr = util.TraceLine( tr )
-		
 	if ( !tr.Hit ) then
 		self:ClearObjects()
 		return
 	end
-		
+	
 	-- Don't try to constrain world to world
 	if ( trace.HitWorld && tr.HitWorld ) then
 		self:ClearObjects()
-		return 
+		return
 	end
 	
-	if ( trace.Entity:IsValid() && trace.Entity:IsPlayer() ) then
+	if ( IsValid(trace.Entity ) && trace.Entity:IsPlayer() ) then
 		self:ClearObjects()
 		return
 	end
-	if ( tr.Entity:IsValid() && tr.Entity:IsPlayer() ) then
+	if ( IsValid( tr.Entity ) && tr.Entity:IsPlayer() ) then
 		self:ClearObjects()
 		return
 	end
@@ -141,39 +143,39 @@ function TOOL:RightClick( trace )
 	end
 	
 	-- Get client's CVars
-	local width			= self:GetClientNumber( "width", 3 )
-	local bind			= self:GetClientNumber( "group", 1 )
-	local AddLength		= self:GetClientNumber( "addlength", 0 )
-	local fixed			= self:GetClientNumber( "fixed", 1 )
-	local period		= self:GetClientNumber( "period", 64 )
-	local material		= self:GetClientInfo( "material" )
-	local starton		= self:GetClientNumber( "starton" )
+	local width		= self:GetClientNumber( "width", 3 )
+	local bind		= self:GetClientNumber( "group", 1 )
+	local AddLength	= self:GetClientNumber( "addlength", 0 )
+	local fixed		= self:GetClientNumber( "fixed", 1 )
+	local period	= self:GetClientNumber( "period", 64 )
+	local starton	= self:GetClientNumber( "starton" )
+	local material	= self:GetClientInfo( "material" )
 	
 	-- Get information we're about to use
-	local Ent1,  Ent2  = self:GetEnt(1),	 self:GetEnt(2)
-	local Bone1, Bone2 = self:GetBone(1),	 self:GetBone(2)
-	local LPos1, LPos2 = self:GetLocalPos(1),self:GetLocalPos(2)
-	local WPos1, WPos2 = self:GetPos(1),     self:GetPos(2)
+	local Ent1, Ent2 = self:GetEnt( 1 ),		self:GetEnt( 2 )
+	local Bone1, Bone2 = self:GetBone( 1 ),		self:GetBone( 2 )
+	local LPos1, LPos2 = self:GetLocalPos( 1 ),	self:GetLocalPos( 2 )
+	local WPos1, WPos2 = self:GetPos( 1 ),		self:GetPos( 2 )
 
-	local Length1 = (WPos1 - WPos2):Length()
-	local Length2 = Length1 + AddLength	
+	local Length1 = ( WPos1 - WPos2 ):Length()
+	local Length2 = Length1 + AddLength
 
 	local amp = Length2 - Length1
 
-	local constraint,rope,controller,slider = constraint.Muscle( self:GetOwner(), Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, Length1, Length2, width, bind, fixed, period, amp, starton, material )
+	local constraint, rope, controller, slider = constraint.Muscle( self:GetOwner(), Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, Length1, Length2, width, bind, fixed, period, amp, starton, material )
 
-	undo.Create("Muscle")
-	if constraint then undo.AddEntity( constraint ) end
-	if rope   then undo.AddEntity( rope ) end
-	if slider then undo.AddEntity( slider ) end
-	if controller then undo.AddEntity( controller ) end
+	undo.Create( "Muscle" )
+	if ( IsValid( constraint ) ) then undo.AddEntity( constraint ) end
+	if ( IsValid( rope ) ) then undo.AddEntity( rope ) end
+	if ( IsValid( slider ) ) then undo.AddEntity( slider ) end
+	if ( IsValid( controller ) ) then undo.AddEntity( controller ) end
 	undo.SetPlayer( self:GetOwner() )
 	undo.Finish()
 
-	if constraint then	self:GetOwner():AddCleanup( "ropeconstraints", constraint ) end
-	if rope   then		self:GetOwner():AddCleanup( "ropeconstraints", rope ) end
-	if slider then		self:GetOwner():AddCleanup( "ropeconstraints", slider ) end
-	if controller then	self:GetOwner():AddCleanup( "ropeconstraints", controller ) end
+	if ( IsValid( constraint ) ) then self:GetOwner():AddCleanup( "ropeconstraints", constraint ) end
+	if ( IsValid( rope ) ) then self:GetOwner():AddCleanup( "ropeconstraints", rope ) end
+	if ( IsValid( slider ) ) then self:GetOwner():AddCleanup( "ropeconstraints", slider ) end
+	if ( IsValid( controller ) ) then self:GetOwner():AddCleanup( "ropeconstraints", controller ) end
 
 	-- Clear the objects so we're ready to go again
 	self:ClearObjects()
@@ -184,31 +186,34 @@ end
 
 function TOOL:Reload( trace )
 
-	if (!trace.Entity:IsValid() || trace.Entity:IsPlayer() ) then return false end
+	if ( !IsValid( trace.Entity ) || trace.Entity:IsPlayer() ) then return false end
 	if ( CLIENT ) then return true end
-	
-	local  bool = constraint.RemoveConstraints( trace.Entity, "Muscle" )
-	return bool
+
+	return constraint.RemoveConstraints( trace.Entity, "Muscle" )
 	
 end
 
+function TOOL:Holster()
+
+	self:ClearObjects()
+
+end
+
+local ConVarsDefault = TOOL:BuildConVarList()
+
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description	= "#tool.muscle.help" } )
+	CPanel:AddControl( "Header", { Description = "#tool.muscle.help" } )
 	
-	CPanel:AddControl( "ComboBox", { Label = "#tool.presets",
-									 MenuButton = 1,
-									 Folder = "muscle",
-									 Options = { Default = { muscle_width = '2',	muscle_group='1',	muscle_addlength='100',		muscle_fixed='1',		muscle_period="1" } },
-									 CVars =				{ "muscle_width",		"muscle_group",		"muscle_addlength",			"muscle_fixed",			"muscle_period", "muscle_material" } } )
+	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "muscle", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
 
-	CPanel:AddControl( "Numpad",		{ Label = "#tool.muscle.numpad",	Command = "muscle_group" } )
-	CPanel:AddControl( "Slider", 		{ Label = "#tool.muscle.length",	Type = "Float", 	Command = "muscle_addlength", 	Min = "-1000", 	Max = "1000", Help=true }  )
-	CPanel:AddControl( "Slider", 		{ Label = "#tool.muscle.period",	Type = "Float", 	Command = "muscle_period", 	Min = "0", 	Max = "10", Help=true }  )
-	CPanel:AddControl( "CheckBox",		{ Label = "#tool.muscle.fixed",		Command = "muscle_fixed", Help=true }  )
-	CPanel:AddControl( "CheckBox",		{ Label = "#tool.muscle.starton",	Command = "muscle_starton", Help=true }  )
+	CPanel:AddControl( "Numpad", { Label = "#tool.muscle.numpad", Command = "muscle_group" } )
+	CPanel:AddControl( "Slider", { Label = "#tool.muscle.length", Command = "muscle_addlength", Type = "Float", Min = "-1000", Max = "1000", Help = true } )
+	CPanel:AddControl( "Slider", { Label = "#tool.muscle.period", Command = "muscle_period", Type = "Float", Min = "0", Max = "10", Help = true } )
+	CPanel:AddControl( "CheckBox", { Label = "#tool.muscle.fixed", Command = "muscle_fixed", Help = true } )
+	CPanel:AddControl( "CheckBox", { Label = "#tool.muscle.starton", Command = "muscle_starton", Help = true } )
 
-	CPanel:AddControl( "Slider", 		{ Label = "#tool.muscle.width",			Type = "Float", 	Command = "muscle_width", 	Min = "0", 	Max = "5" }  )
-	CPanel:AddControl( "RopeMaterial", 	{ Label = "#tool.muscle.material",		convar	= "muscle_material" }  )
+	CPanel:AddControl( "Slider", { Label = "#tool.muscle.width", Command = "muscle_width", Type = "Float", Min = "0", Max = "5" } )
+	CPanel:AddControl( "RopeMaterial", { Label = "#tool.muscle.material", ConVar = "muscle_material" } )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/pulley.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/pulley.lua
@@ -1,6 +1,6 @@
 
-TOOL.Category		= "Constraints"
-TOOL.Name			= "#tool.pulley.name"
+TOOL.Category	= "Constraints"
+TOOL.Name		= "#tool.pulley.name"
 
 TOOL.ClientConVar[ "width" ] = "3"
 TOOL.ClientConVar[ "forcelimit" ] = "0"
@@ -14,8 +14,8 @@ function TOOL:LeftClick( trace )
 
 	local iNum = self:NumObjects()
 
-	if ( trace.Entity:IsValid() && trace.Entity:IsPlayer() ) then return end
-	if ( !trace.Entity:IsValid() && ( iNum == nil || iNum == 0 || iNum > 2 ) ) then return end
+	if ( IsValid( trace.Entity ) && trace.Entity:IsPlayer() ) then return end
+	if ( !IsValid( trace.Entity ) && ( iNum == nil || iNum == 0 || iNum > 2 ) ) then return end
 
 	local Phys = trace.Entity:GetPhysicsObjectNum( trace.PhysicsBone )
 	self:SetObject( iNum + 1, trace.Entity, trace.HitPos, Phys, trace.PhysicsBone, trace.HitNormal )
@@ -26,22 +26,22 @@ function TOOL:LeftClick( trace )
 		
 		local width			= self:GetClientNumber( "width" )
 		local forcelimit	= self:GetClientNumber( "forcelimit" )
-		local rigid			= util.tobool( self:GetClientNumber( "rigid" ) )
+		local rigid			= self:GetClientNumber( "rigid" ) == 1
 		local material		= self:GetClientInfo( "material" )
 		
 		-- Get information we're about to use
-		local Ent1 = self:GetEnt(1)
-		local Ent4 = self:GetEnt(4)
-		local Bone1 = self:GetBone(1)
-		local Bone4 = self:GetBone(4)
-		local LPos1 = self:GetLocalPos(1)
-		local LPos4 = self:GetLocalPos(4)
-		local WPos2 = self:GetPos(2)
-		local WPos3 = self:GetPos(3)
+		local Ent1 = self:GetEnt( 1 )
+		local Ent4 = self:GetEnt( 4 )
+		local Bone1 = self:GetBone( 1 )
+		local Bone4 = self:GetBone( 4 )
+		local LPos1 = self:GetLocalPos( 1 )
+		local LPos4 = self:GetLocalPos( 4 )
+		local WPos2 = self:GetPos( 2 )
+		local WPos3 = self:GetPos( 3 )
 
 		local constraint = constraint.Pulley( Ent1, Ent4, Bone1, Bone4, LPos1, LPos4, WPos2, WPos3, forcelimit, rigid, width, material )
 
-		undo.Create("Pulley")
+		undo.Create( "Pulley" )
 		undo.AddEntity( constraint )
 		undo.SetPlayer( self:GetOwner() )
 		undo.Finish()
@@ -50,17 +50,9 @@ function TOOL:LeftClick( trace )
 
 		self:ClearObjects()
 
-	elseif ( iNum == 2 ) then
-
-		self:SetStage( iNum+1 )
-		
-	elseif ( iNum == 1 ) then
-
-		self:SetStage( iNum+1 )
-		
 	else
 
-		self:SetStage( iNum+1 )
+		self:SetStage( iNum + 1 )
 		
 	end
 	
@@ -70,31 +62,31 @@ end
 
 function TOOL:Reload( trace )
 
-	if (!trace.Entity:IsValid() || trace.Entity:IsPlayer() ) then return false end
+	if ( !IsValid( trace.Entity ) || trace.Entity:IsPlayer() ) then return false end
 	if ( CLIENT ) then return true end
-	
-	local  bool = constraint.RemoveConstraints( trace.Entity, "Pulley" )
-	return bool
+
+	return constraint.RemoveConstraints( trace.Entity, "Pulley" )
 	
 end
 
+function TOOL:Holster()
+
+	self:ClearObjects()
+
+end
+
+local ConVarsDefault = TOOL:BuildConVarList()
+
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description	= "#tool.pulley.help" }  )
-	
-	CPanel:AddControl( "ComboBox", { 
+	CPanel:AddControl( "Header", { Description = "#tool.pulley.help" } )
 
-			Label = "#tool.presets",
-			MenuButton = 1,
-			Folder = "pulley",
-			Options =	{ Default = {	pulley_forcelimit = '0',		pulley_width='2',		pulley_rigid='0',		pulley_material='cable/cable' } },
-			CVars =		{				"pulley_forcelimit",			"pulley_width",			"pulley_rigid",			"pulley_material" } 
-									})
+	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "pulley", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
 
-	CPanel:AddControl( "Slider", 		{ Label = "#tool.forcelimit",		Type = "Float", 	Command = "pulley_forcelimit", 	Min = "0", 	Max = "1000", Help=true }  )
-	CPanel:AddControl( "CheckBox",		{ Label = "#tool.pulley.rigid",		Command = "pulley_rigid", Help=true }  )
+	CPanel:AddControl( "Slider", { Label = "#tool.forcelimit", Command = "pulley_forcelimit", Type = "Float", Min = "0", Max = "1000", Help = true } )
+	CPanel:AddControl( "CheckBox", { Label = "#tool.pulley.rigid", Command = "pulley_rigid", Help = true } )
 
-	CPanel:AddControl( "Slider", 		{ Label = "#tool.pulley.width",		Type = "Float", 	Command = "pulley_width", 		Min = "0", 	Max = "10" }  )
-	CPanel:AddControl( "RopeMaterial", 	{ Label = "#tool.pulley.material",		convar	= "pulley_material" }  )
-									
+	CPanel:AddControl( "Slider", { Label = "#tool.pulley.width", Command = "pulley_width", Type = "Float", Min = "0", Max = "10" } )
+	CPanel:AddControl( "RopeMaterial", { Label = "#tool.pulley.material", ConVar = "pulley_material" } )
+
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/rope.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/rope.lua
@@ -1,6 +1,6 @@
 
-TOOL.Category		= "Constraints"
-TOOL.Name			= "#tool.rope.name"
+TOOL.Category	= "Constraints"
+TOOL.Name		= "#tool.rope.name"
 
 TOOL.ClientConVar[ "forcelimit" ] = "0"
 TOOL.ClientConVar[ "addlength" ] = "0"
@@ -10,7 +10,7 @@ TOOL.ClientConVar[ "rigid" ] = "0"
 
 function TOOL:LeftClick( trace )
 
-	if ( trace.Entity:IsValid() && trace.Entity:IsPlayer() ) then return end
+	if ( IsValid( trace.Entity ) && trace.Entity:IsPlayer() ) then return end
 	
 	-- If there's no physics object then we can't constraint it!
 	if ( SERVER && !util.IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) ) then return false end
@@ -31,17 +31,17 @@ function TOOL:LeftClick( trace )
 		
 		-- Get client's CVars
 		local forcelimit = self:GetClientNumber( "forcelimit" )
-		local addlength	 = self:GetClientNumber( "addlength" )
-		local material 	 = self:GetClientInfo( "material" )
-		local width 	 = self:GetClientNumber( "width" ) 
-		local rigid	 	= self:GetClientNumber( "rigid" ) == 1
+		local addlength	= self:GetClientNumber( "addlength" )
+		local material	= self:GetClientInfo( "material" )
+		local width		= self:GetClientNumber( "width" )
+		local rigid		= self:GetClientNumber( "rigid" ) == 1
 		
 		-- Get information we're about to use
-		local Ent1,  Ent2  = self:GetEnt(1),	 self:GetEnt(2)
-		local Bone1, Bone2 = self:GetBone(1),	 self:GetBone(2)
-		local WPos1, WPos2 = self:GetPos(1),	 self:GetPos(2)
-		local LPos1, LPos2 = self:GetLocalPos(1),self:GetLocalPos(2)
-		local length = ( WPos1 - WPos2):Length()
+		local Ent1, Ent2 = self:GetEnt( 1 ),		self:GetEnt( 2 )
+		local Bone1, Bone2 = self:GetBone( 1 ),		self:GetBone( 2 )
+		local WPos1, WPos2 = self:GetPos( 1 ),		self:GetPos( 2 )
+		local LPos1, LPos2 = self:GetLocalPos( 1 ),	self:GetLocalPos( 2 )
+		local length = ( WPos1 - WPos2 ):Length()
 
 		local constraint, rope = constraint.Rope( Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, length, addlength, forcelimit, width, material, rigid )
 
@@ -50,18 +50,18 @@ function TOOL:LeftClick( trace )
 
 		-- Add The constraint to the players undo table
 
-		undo.Create("Rope")
+		undo.Create( "Rope" )
 		undo.AddEntity( constraint )
 		undo.AddEntity( rope )
 		undo.SetPlayer( self:GetOwner() )
 		undo.Finish()
 
-		self:GetOwner():AddCleanup( "ropeconstraints", constraint )		
+		self:GetOwner():AddCleanup( "ropeconstraints", constraint )
 		self:GetOwner():AddCleanup( "ropeconstraints", rope )
 
 	else
 	
-		self:SetStage( iNum+1 )
+		self:SetStage( iNum + 1 )
 		
 	end
 
@@ -71,7 +71,7 @@ end
 
 function TOOL:RightClick( trace )
 
-	if ( trace.Entity:IsValid() && trace.Entity:IsPlayer() ) then return end
+	if ( IsValid( trace.Entity ) && trace.Entity:IsPlayer() ) then return end
 
 	local iNum = self:NumObjects()
 
@@ -89,16 +89,16 @@ function TOOL:RightClick( trace )
 	
 		-- Get client's CVars
 		local forcelimit = self:GetClientNumber( "forcelimit" )
-		local addlength	 = self:GetClientNumber( "addlength" )
-		local material 	 = self:GetClientInfo( "material" )
-		local width 	 = self:GetClientNumber( "width" )
-		local rigid	 = self:GetClientNumber( "rigid" ) == 1
+		local addlength	= self:GetClientNumber( "addlength" )
+		local material	= self:GetClientInfo( "material" )
+		local width		= self:GetClientNumber( "width" )
+		local rigid		= self:GetClientNumber( "rigid" ) == 1
 		
 		-- Get information we're about to use
-		local Ent1,  Ent2  = self:GetEnt(1),	 self:GetEnt(2)
-		local Bone1, Bone2 = self:GetBone(1),	 self:GetBone(2)
-		local WPos1, WPos2 = self:GetPos(1),self:GetPos(2)
-		local LPos1, LPos2 = self:GetLocalPos(1),self:GetLocalPos(2)
+		local Ent1, Ent2 = self:GetEnt( 1 ),		self:GetEnt( 2 )
+		local Bone1, Bone2 = self:GetBone( 1 ),		self:GetBone( 2 )
+		local WPos1, WPos2 = self:GetPos( 1 ),		self:GetPos( 2 )
+		local LPos1, LPos2 = self:GetLocalPos( 1 ),	self:GetLocalPos( 2 )
 		local length = ( WPos1 - WPos2 ):Length()
 
 		local constraint, rope = constraint.Rope( Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, length, addlength, forcelimit, width, material, rigid )
@@ -107,22 +107,22 @@ function TOOL:RightClick( trace )
 		self:ClearObjects()
 		iNum = self:NumObjects()
 		self:SetObject( iNum + 1, Ent2, trace.HitPos, Phys, Bone2, trace.HitNormal )
-		self:SetStage( iNum+1 )
+		self:SetStage( iNum + 1 )
 
 		-- Add The constraint to the players undo table
 
-		undo.Create("Rope")
+		undo.Create( "Rope" )
 		undo.AddEntity( constraint )
-		if rope then undo.AddEntity( rope ) end
+		if ( IsValid( rope ) ) then undo.AddEntity( rope ) end
 		undo.SetPlayer( self:GetOwner() )
 		undo.Finish()
 		
-		self:GetOwner():AddCleanup( "ropeconstraints", constraint )		
+		self:GetOwner():AddCleanup( "ropeconstraints", constraint )
 		self:GetOwner():AddCleanup( "ropeconstraints", rope )
 		
 	else
 	
-		self:SetStage( iNum+1 )
+		self:SetStage( iNum + 1 )
 		
 	end
 
@@ -132,34 +132,33 @@ end
 
 function TOOL:Reload( trace )
 
-	if (!trace.Entity:IsValid() || trace.Entity:IsPlayer() ) then return false end
+	if ( !IsValid( trace.Entity ) || trace.Entity:IsPlayer() ) then return false end
 	if ( CLIENT ) then return true end
-
-	local  bool = constraint.RemoveConstraints( trace.Entity, "Rope" )
-	return bool
-
 	
+	return constraint.RemoveConstraints( trace.Entity, "Rope" )
+
 end
+
+function TOOL:Holster()
+
+	self:ClearObjects()
+
+end
+
+local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description	= "#tool.rope.help" } )
+	CPanel:AddControl( "Header", { Description = "#tool.rope.help" } )
 	
-	CPanel:AddControl( "ComboBox", 
-	{ 
-		Label = "#tool.presets",
-		MenuButton = 1,
-		Folder = "rope",
-		Options =	{ Default = {	rope_forcelimit = '0',			rope_addlength='0',		rope_width='1',		rope_material='cable/rope',		rope_rigid='0' } },
-		CVars =		{				"rope_forcelimit",				"rope_addlength",		"rope_width",		"rope_material",				"rope_rigid" } 
-	})
+	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "rope", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
 
-	CPanel:AddControl( "Slider", 		{ Label = "#tool.forcelimit",		Type = "Float", 	Command = "rope_forcelimit", 	Min = "0", 	Max = "1000", Help=true }  )
-	CPanel:AddControl( "Slider", 		{ Label = "#tool.rope.addlength",	Type = "Float", 	Command = "rope_addlength", 	Min = "-500", 	Max = "500", Help=true }  )
+	CPanel:AddControl( "Slider", { Label = "#tool.forcelimit", Command = "rope_forcelimit", Type = "Float", Min = "0", Max = "1000", Help = true } )
+	CPanel:AddControl( "Slider", { Label = "#tool.rope.addlength", Command = "rope_addlength", Type = "Float", Min = "-500", Max = "500", Help = true } )
 
-	CPanel:AddControl( "CheckBox",		{ Label = "#tool.rope.rigid",		Command = "rope_rigid", Help=true }  )
+	CPanel:AddControl( "CheckBox", { Label = "#tool.rope.rigid", Command = "rope_rigid", Help = true } )
 
-	CPanel:AddControl( "Slider", 		{ Label = "#tool.rope.width",		Type = "Float", 	Command = "rope_width", 		Min = "0", 	Max = "10" }  )
-	CPanel:AddControl( "RopeMaterial", 	{ Label = "#tool.rope.material",		convar	= "rope_material" }  )
-									
+	CPanel:AddControl( "Slider", { Label = "#tool.rope.width", Command = "rope_width", Type = "Float", Min = "0", Max = "10" } )
+	CPanel:AddControl( "RopeMaterial", { Label = "#tool.rope.material", ConVar = "rope_material" } )
+
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/slider.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/slider.lua
@@ -1,13 +1,13 @@
 
-TOOL.Category		= "Constraints"
-TOOL.Name			= "#tool.slider.name"
+TOOL.Category	= "Constraints"
+TOOL.Name		= "#tool.slider.name"
 
 TOOL.ClientConVar[ "width" ] = "1.5"
 TOOL.ClientConVar[ "material" ] = "cable/cable"
 
 function TOOL:LeftClick( trace )
 
-	if ( trace.Entity:IsValid() && trace.Entity:IsPlayer() ) then return end
+	if ( IsValid( trace.Entity ) && trace.Entity:IsPlayer() ) then return end
 	
 	-- If there's no physics object then we can't constraint it!
 	if ( SERVER && !util.IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) ) then return false end
@@ -16,6 +16,7 @@ function TOOL:LeftClick( trace )
 
 	local Phys = trace.Entity:GetPhysicsObjectNum( trace.PhysicsBone )
 	self:SetObject( iNum + 1, trace.Entity, trace.HitPos, Phys, trace.PhysicsBone, trace.HitNormal )
+	self:SetOperation( 1 )
 	
 	if ( iNum > 0 ) then
 
@@ -29,15 +30,15 @@ function TOOL:LeftClick( trace )
 		local material	= self:GetClientInfo( "material" )
 		
 		-- Get information we're about to use
-		local Ent1,  Ent2  = self:GetEnt(1),	 self:GetEnt(2)
-		local Bone1, Bone2 = self:GetBone(1),	 self:GetBone(2)
-		local LPos1, LPos2 = self:GetLocalPos(1),self:GetLocalPos(2)
+		local Ent1, Ent2 = self:GetEnt( 1 ),		self:GetEnt( 2 )
+		local Bone1, Bone2 = self:GetBone( 1 ),		self:GetBone( 2 )
+		local LPos1, LPos2 = self:GetLocalPos( 1 ),	self:GetLocalPos( 2 )
 
-		local constraint,rope = constraint.Slider( Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, width, material )
+		local constraint, rope = constraint.Slider( Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, width, material )
 
-		undo.Create("Slider")
+		undo.Create( "Slider" )
 		undo.AddEntity( constraint )
-		if rope then undo.AddEntity( rope ) end
+		if ( IsValid( rope ) ) then undo.AddEntity( rope ) end
 		undo.SetPlayer( self:GetOwner() )
 		undo.Finish()
 		
@@ -49,7 +50,7 @@ function TOOL:LeftClick( trace )
 		
 	else
 	
-		self:SetStage( iNum+1 )
+		self:SetStage( iNum + 1 )
 		
 	end
 	
@@ -59,6 +60,8 @@ end
 
 function TOOL:RightClick( trace )
 
+	if ( self:GetOperation() == 1 ) then return false end
+
 	local iNum = self:NumObjects()
 
 	local Phys = trace.Entity:GetPhysicsObjectNum( trace.PhysicsBone )
@@ -66,15 +69,14 @@ function TOOL:RightClick( trace )
 	
 	local tr = {}
 	tr.start = trace.HitPos
-	tr.endpos = tr.start + (trace.HitNormal * 16384)
-	tr.filter = {} 
+	tr.endpos = tr.start + ( trace.HitNormal * 16384 )
+	tr.filter = {}
 	tr.filter[1] = self:GetOwner()
-	if (trace.Entity:IsValid()) then
+	if ( IsValid( trace.Entity ) ) then
 		tr.filter[2] = trace.Entity
 	end
 	
 	local tr = util.TraceLine( tr )
-		
 	if ( !tr.Hit ) then
 		self:ClearObjects()
 		return
@@ -83,14 +85,14 @@ function TOOL:RightClick( trace )
 	-- Don't try to constrain world to world
 	if ( trace.HitWorld && tr.HitWorld ) then
 		self:ClearObjects()
-		return 
+		return
 	end
 	
-	if ( trace.Entity:IsValid() && trace.Entity:IsPlayer() ) then
+	if ( IsValid( trace.Entity ) && trace.Entity:IsPlayer() ) then
 		self:ClearObjects()
 		return
 	end
-	if ( tr.Entity:IsValid() && tr.Entity:IsPlayer() ) then
+	if ( IsValid( tr.Entity ) && tr.Entity:IsPlayer() ) then
 		self:ClearObjects()
 		return
 	end
@@ -107,15 +109,15 @@ function TOOL:RightClick( trace )
 	local material	= self:GetClientInfo( "material" )
 		
 	-- Get information we're about to use
-	local Ent1,  Ent2  = self:GetEnt(1),	 self:GetEnt(2)
-	local Bone1, Bone2 = self:GetBone(1),	 self:GetBone(2)
-	local LPos1, LPos2 = self:GetLocalPos(1),self:GetLocalPos(2)
+	local Ent1, Ent2 = self:GetEnt( 1 ),		self:GetEnt( 2 )
+	local Bone1, Bone2 = self:GetBone( 1 ),		self:GetBone( 2 )
+	local LPos1, LPos2 = self:GetLocalPos( 1 ),	self:GetLocalPos( 2 )
 
-	local constraint,rope = constraint.Slider( Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, width, material )
+	local constraint, rope = constraint.Slider( Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, width, material )
 
-	undo.Create("Slider")
+	undo.Create( "Slider" )
 	undo.AddEntity( constraint )
-	if rope then undo.AddEntity( rope ) end
+	if ( IsValid( rope ) ) then undo.AddEntity( rope ) end
 	undo.SetPlayer( self:GetOwner() )
 	undo.Finish()
 	
@@ -131,29 +133,28 @@ end
 
 function TOOL:Reload( trace )
 
-	if (!trace.Entity:IsValid() || trace.Entity:IsPlayer() ) then return false end
+	if ( !IsValid( trace.Entity ) || trace.Entity:IsPlayer() ) then return false end
 	if ( CLIENT ) then return true end
-	
-	local  bool = constraint.RemoveConstraints( trace.Entity, "Slider" )
-	return bool
+
+	return constraint.RemoveConstraints( trace.Entity, "Slider" )
 	
 end
 
+function TOOL:Holster()
+
+	self:ClearObjects()
+
+end
+
+local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description	= "#tool.slider.help" } )
+	CPanel:AddControl( "Header", { Description = "#tool.slider.help" } )
 	
-	CPanel:AddControl( "ComboBox", 
-	{ 
-		Label = "#tool.presets",
-		MenuButton = 1,
-		Folder = "rope",
-		Options =	{ Default = {	slider_width='1',	slider_material='cable/rope' } },
-		CVars =		{				"slider_width",		"slider_material" } 
-	})
+	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "slider", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
 
-	CPanel:AddControl( "Slider", 		{ Label = "#tool.slider.width",		Type = "Float", 	Command = "slider_width", 		Min = "0", 	Max = "10" }  )
-	CPanel:AddControl( "RopeMaterial", 	{ Label = "#tool.slider.material",	convar	= "slider_material" }  )
-									
+	CPanel:AddControl( "Slider", { Label = "#tool.slider.width", Command = "slider_width", Type = "Float", Min = "0", Max = "10" } )
+	CPanel:AddControl( "RopeMaterial", { Label = "#tool.slider.material", ConVar = "slider_material" } )
+
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/winch.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/winch.lua
@@ -1,6 +1,6 @@
 
-TOOL.Category		= "Constraints"
-TOOL.Name			= "#tool.winch.name"
+TOOL.Category	= "Constraints"
+TOOL.Name		= "#tool.winch.name"
 
 TOOL.ClientConVar[ "rope_material" ] = "cable/rope"
 TOOL.ClientConVar[ "rope_width" ] = "3"
@@ -11,7 +11,7 @@ TOOL.ClientConVar[ "bwd_group" ] = "41"
 
 function TOOL:LeftClick( trace )
 
-	if ( trace.Entity:IsValid() && trace.Entity:IsPlayer() ) then return end
+	if ( IsValid( trace.Entity ) && trace.Entity:IsPlayer() ) then return end
 	
 	-- If there's no physics object then we can't constraint it!
 	if ( SERVER && !util.IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) ) then return false end
@@ -20,6 +20,7 @@ function TOOL:LeftClick( trace )
 	
 	local Phys = trace.Entity:GetPhysicsObjectNum( trace.PhysicsBone )
 	self:SetObject( iNum + 1, trace.Entity, trace.HitPos, Phys, trace.PhysicsBone, trace.HitNormal )
+	self:SetOperation( 1 )
 	
 	if ( iNum > 0 ) then
 	
@@ -29,39 +30,38 @@ function TOOL:LeftClick( trace )
 		end
 		
 		-- Get client's CVars
-		local material		= self:GetClientInfo( "rope_material" ) or "cable/rope"
-		local width		= self:GetClientNumber( "rope_width" )  or 3
-		local fwd_bind		= self:GetClientNumber( "fwd_group" )  or 1
-		local bwd_bind		= self:GetClientNumber( "bwd_group" ) or 1
-		local fwd_speed		= self:GetClientNumber( "fwd_speed" ) or 64
-		local bwd_speed		= self:GetClientNumber( "bwd_speed" ) or 64
-		local toggle		= false
+		local material	= self:GetClientInfo( "rope_material" ) or "cable/rope"
+		local width		= self:GetClientNumber( "rope_width" ) or 3
+		local fwd_bind	= self:GetClientNumber( "fwd_group" ) or 1
+		local bwd_bind	= self:GetClientNumber( "bwd_group" ) or 1
+		local fwd_speed	= self:GetClientNumber( "fwd_speed" ) or 64
+		local bwd_speed	= self:GetClientNumber( "bwd_speed" ) or 64
+		local toggle	= false
 
 		-- Get information we're about to use
-		local Ent1,  Ent2  = self:GetEnt(1),	 self:GetEnt(2)
-		local Bone1, Bone2 = self:GetBone(1),	 self:GetBone(2)
-		local LPos1, LPos2 = self:GetLocalPos(1),self:GetLocalPos(2)
+		local Ent1, Ent2 = self:GetEnt( 1 ),		self:GetEnt( 2 )
+		local Bone1, Bone2 = self:GetBone( 1 ),		self:GetBone( 2 )
+		local LPos1, LPos2 = self:GetLocalPos( 1 ),	self:GetLocalPos( 2 )
 
-		local constraint,rope,controller = constraint.Winch( self:GetOwner(), Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, width, fwd_bind, bwd_bind, fwd_speed, bwd_speed, material, toggle )
+		local constraint, rope, controller = constraint.Winch( self:GetOwner(), Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, width, fwd_bind, bwd_bind, fwd_speed, bwd_speed, material, toggle )
 
-		undo.Create("Winch")
-		if constraint then undo.AddEntity( constraint ) end
-		if rope   then undo.AddEntity( rope ) end
-		if controller then undo.AddEntity( controller ) end
+		undo.Create( "Winch" )
+		if ( IsValid( constraint ) ) then undo.AddEntity( constraint ) end
+		if ( IsValid( rope ) ) then undo.AddEntity( rope ) end
+		if ( IsValid( controller ) ) then undo.AddEntity( controller ) end
 		undo.SetPlayer( self:GetOwner() )
 		undo.Finish()
-		
-		
-		if constraint then	self:GetOwner():AddCleanup( "ropeconstraints", constraint ) end
-		if rope then		self:GetOwner():AddCleanup( "ropeconstraints", rope ) end
-		if controller then	self:GetOwner():AddCleanup( "ropeconstraints", controller ) end
+
+		if ( IsValid( constraint ) ) then self:GetOwner():AddCleanup( "ropeconstraints", constraint ) end
+		if ( IsValid( rope ) ) then self:GetOwner():AddCleanup( "ropeconstraints", rope ) end
+		if ( IsValid( controller ) ) then self:GetOwner():AddCleanup( "ropeconstraints", controller ) end
 		
 		-- Clear the objects so we're ready to go again
 		self:ClearObjects()
 		
 	else
 	
-		self:SetStage( iNum+1 )
+		self:SetStage( iNum + 1 )
 		
 	end
 	
@@ -70,6 +70,8 @@ function TOOL:LeftClick( trace )
 end
 
 function TOOL:RightClick( trace )
+
+	if ( self:GetOperation() == 1 ) then return false end
 
 	-- If there's no physics object then we can't constraint it!
 	if ( SERVER && !util.IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) ) then return false end
@@ -81,15 +83,14 @@ function TOOL:RightClick( trace )
 	
 	local tr = {}
 	tr.start = trace.HitPos
-	tr.endpos = tr.start + (trace.HitNormal * 16384)
-	tr.filter = {} 
+	tr.endpos = tr.start + ( trace.HitNormal * 16384 )
+	tr.filter = {}
 	tr.filter[1] = self:GetOwner()
-	if (trace.Entity:IsValid()) then
+	if ( IsValid( trace.Entity ) ) then
 		tr.filter[2] = trace.Entity
 	end
 	
 	local tr = util.TraceLine( tr )
-		
 	if ( !tr.Hit ) then
 		self:ClearObjects()
 		return
@@ -98,14 +99,14 @@ function TOOL:RightClick( trace )
 	-- Don't try to constrain world to world
 	if ( trace.HitWorld && tr.HitWorld ) then
 		self:ClearObjects()
-		return 
+		return
 	end
 	
-	if ( trace.Entity:IsValid() && trace.Entity:IsPlayer() ) then
+	if ( IsValid( trace.Entity ) && trace.Entity:IsPlayer() ) then
 		self:ClearObjects()
 		return
 	end
-	if ( tr.Entity:IsValid() && tr.Entity:IsPlayer() ) then
+	if ( IsValid( tr.Entity ) && tr.Entity:IsPlayer() ) then
 		self:ClearObjects()
 		return
 	end
@@ -119,30 +120,30 @@ function TOOL:RightClick( trace )
 	end
 	
 	-- Get client's CVars
-	local material		= self:GetClientInfo( "rope_material" ) or "cable/rope"
-	local width			= self:GetClientNumber( "rope_width" ) or 3
-	local fwd_bind		= self:GetClientNumber( "fwd_group" ) or 1
-	local bwd_bind		= self:GetClientNumber( "bwd_group" ) or 1
-	local fwd_speed		= self:GetClientNumber( "fwd_speed" ) or 64
-	local bwd_speed		= self:GetClientNumber( "bwd_speed" ) or 64
+	local material	= self:GetClientInfo( "rope_material" ) or "cable/rope"
+	local width		= self:GetClientNumber( "rope_width" ) or 3
+	local fwd_bind	= self:GetClientNumber( "fwd_group" ) or 1
+	local bwd_bind	= self:GetClientNumber( "bwd_group" ) or 1
+	local fwd_speed	= self:GetClientNumber( "fwd_speed" ) or 64
+	local bwd_speed	= self:GetClientNumber( "bwd_speed" ) or 64
 		
 	-- Get information we're about to use
-	local Ent1,  Ent2  = self:GetEnt(1),	 self:GetEnt(2)
-	local Bone1, Bone2 = self:GetBone(1),	 self:GetBone(2)
-	local LPos1, LPos2 = self:GetLocalPos(1),self:GetLocalPos(2)
+	local Ent1, Ent2 = self:GetEnt( 1 ),		self:GetEnt( 2 )
+	local Bone1, Bone2 = self:GetBone( 1 ),		self:GetBone( 2 )
+	local LPos1, LPos2 = self:GetLocalPos( 1 ),	self:GetLocalPos( 2 )
 
-	local constraint,rope,controller = constraint.Winch( self:GetOwner(), Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, width, fwd_bind, bwd_bind, fwd_speed, bwd_speed, material )
+	local constraint, rope, controller = constraint.Winch( self:GetOwner(), Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, width, fwd_bind, bwd_bind, fwd_speed, bwd_speed, material )
 
-	undo.Create("Winch")
-	if constraint then undo.AddEntity( constraint ) end
-	if rope   then undo.AddEntity( rope ) end
-	if controller then undo.AddEntity( controller ) end
+	undo.Create( "Winch" )
+	if ( IsValid( constraint ) ) then undo.AddEntity( constraint ) end
+	if ( IsValid( rope ) ) then undo.AddEntity( rope ) end
+	if ( IsValid( controller ) ) then undo.AddEntity( controller ) end
 	undo.SetPlayer( self:GetOwner() )
 	undo.Finish()
 	
-	if constraint then	self:GetOwner():AddCleanup( "ropeconstraints", constraint ) end
-	if rope then		self:GetOwner():AddCleanup( "ropeconstraints", rope ) end
-	if controller then	self:GetOwner():AddCleanup( "ropeconstraints", controller ) end
+	if ( IsValid( constraint ) ) then self:GetOwner():AddCleanup( "ropeconstraints", constraint ) end
+	if ( IsValid( rope ) ) then self:GetOwner():AddCleanup( "ropeconstraints", rope ) end
+	if ( IsValid( controller ) ) then self:GetOwner():AddCleanup( "ropeconstraints", controller ) end
 
 	-- Clear the objects so we're ready to go again
 	self:ClearObjects()
@@ -153,34 +154,27 @@ end
 
 function TOOL:Reload( trace )
 
-	if (!trace.Entity:IsValid() || trace.Entity:IsPlayer() ) then return false end
+	if ( !IsValid( trace.Entity ) || trace.Entity:IsPlayer() ) then return false end
 	if ( CLIENT ) then return true end
-	
-	local  bool = constraint.RemoveConstraints( trace.Entity, "Winch" )
-	return bool
+
+	return constraint.RemoveConstraints( trace.Entity, "Winch" )
 	
 end
 
+local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description	= "#tool.winch.help" }  )
-	
-	CPanel:AddControl( "ComboBox", 
-	{ 
-		Label = "#tool.presets",
-		MenuButton = 1,
-		Folder = "winch",
-		Options =	{ Default = {	winch_rope_width = '1',		winch_fwd_speed='64',	winch_bwd_speed='64',		winch_rope_rigid='0',		winch_rope_material='cable/cable' } },
-		CVars =		{				"winch_rope_width",			"winch_fwd_speed",		"winch_bwd_speed",			"winch_rope_rigid",			"winch_rope_material" } 
-	})
+	CPanel:AddControl( "Header", { Description = "#tool.winch.help" } )
 
-	CPanel:AddControl( "Numpad",		{ Label = "#tool.winch.forward",	Command = "winch_fwd_group", Label2 = "#tool.winch.backward",	Command2 = "winch_bwd_group" } )
-	
-	CPanel:AddControl( "Slider", 		{ Label = "#tool.winch.fspeed",		Type = "Float", 	Command = "winch_fwd_speed", 	Min = "0", 	Max = "1000", Help=true }  )
-	CPanel:AddControl( "Slider", 		{ Label = "#tool.winch.bspeed",		Type = "Float", 	Command = "winch_bwd_speed", 	Min = "0", 	Max = "1000", Help=true }  )
+	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "winch", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
 
-	CPanel:AddControl( "Slider", 		{ Label = "#tool.winch.width",		Type = "Float", 	Command = "winch_rope_width", 		Min = "0", 	Max = "10" }  )
-	CPanel:AddControl( "RopeMaterial", 	{ Label = "#tool.winch.material",	convar	= "winch_rope_material" }  )
-									
+	CPanel:AddControl( "Numpad", { Label = "#tool.winch.forward", Command = "winch_fwd_group", Label2 = "#tool.winch.backward", Command2 = "winch_bwd_group" } )
+
+	CPanel:AddControl( "Slider", { Label = "#tool.winch.fspeed", Command = "winch_fwd_speed", Type = "Float", Min = "0", Max = "1000", Help = true } )
+	CPanel:AddControl( "Slider", { Label = "#tool.winch.bspeed", Command = "winch_bwd_speed", Type = "Float", Min = "0", Max = "1000", Help = true } )
+
+	CPanel:AddControl( "Slider", { Label = "#tool.winch.width", Command = "winch_rope_width", Type = "Float", Min = "0", Max = "10" } )
+	CPanel:AddControl( "RopeMaterial", { Label = "#tool.winch.material", ConVar = "winch_rope_material" } )
+
 end


### PR DESCRIPTION
- Remove all semicolons, trailing whitespace, double spaces, excessive
  tabulation
- Remove redundant code from some of the tools
- Add Set/GetOperation calls to tools that were missing it
- Switch the tools to a cleaner default preset generation
