### PR TITLE
prevent player getting killed if spawnpoint is too close to world origin

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/player.lua
+++ b/garrysmod/gamemodes/base/gamemode/player.lua
@@ -354,7 +354,7 @@ function GM:IsSpawnpointSuitable( pl, spawnpointent, bMakeSuitable )
 	local Blockers = 0
 	
 	for k, v in pairs( Ents ) do
-		if ( IsValid( v ) && v:GetClass() == "player" && v:Alive() ) then
+		if ( IsValid( v ) && v != pl && v:GetClass() == "player" && v:Alive() ) then
 		
 			Blockers = Blockers + 1
 			


### PR DESCRIPTION
Since a player spawns at the world origin until being moved to a spawnpoint the IsSpawnpointSuiteable function is detecting the player inside the range, make the loop ignore that to prevent the function killing the player on his initial spawn.
