### PR TITLE
Update constraint.lua

### DIFF
--- a/garrysmod/lua/includes/modules/constraint.lua
+++ b/garrysmod/lua/includes/modules/constraint.lua
@@ -161,7 +161,7 @@ end
 
 local function SetPhysicsCollisions( Ent, b )
 
-	if (!Ent || !Ent:IsValid() || !Ent:GetPhysicsObject()) then return end
+	if ( !IsValid( Ent ) || !IsValid( Ent:GetPhysicsObject() ) ) then return end
 	
 	Ent:GetPhysicsObject():EnableCollisions( b )
 


### PR DESCRIPTION
A fix for 

```

[ERROR] lua/includes/modules/constraint.lua:166: Tried to use invalid object (type IPhysicsObject) (Object was NULL or not of the right type)
  1. EnableCollisions - [C]:-1
   2. SetPhysicsCollisions - lua/includes/modules/constraint.lua:166
    3. RemoveAll - lua/includes/modules/constraint.lua:230
     4. DoRemoveEntity - gamemodes/sandbox/entities/weapons/gmod_tool/stools/remover.lua:21
      5. LeftClick - gamemodes/sandbox/entities/weapons/gmod_tool/stools/remover.lua:52
       6. unknown - gamemodes/sandbox/entities/weapons/gmod_tool/shared.lua:254
```
