### PR TITLE
Fixed longstanding thruster crash

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/thruster.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/thruster.lua
@@ -25,7 +25,7 @@ function TOOL:LeftClick( trace )
 	
 	local ply = self:GetOwner()
 	
-	local force			= self:GetClientNumber( "force" )
+	local force			= math.Clamp( self:GetClientNumber( "force" ), 0, 1E35 ) -- prevent high force value crash
 	local model			= self:GetClientInfo( "model" )
 	local key 			= self:GetClientNumber( "keygroup" ) 
 	local key_bk 		= self:GetClientNumber( "keygroup_back" ) 
@@ -124,7 +124,9 @@ if (SERVER) then
 		thruster:SetAngles( Ang )
 		thruster:SetPos( Pos )
 		thruster:Spawn()
-
+		
+		force = math.Clamp( force, 0, 1E35 ) -- prevent high force value crash
+		
 		thruster:SetEffect( effect )
 		thruster:SetForce( force )
 		thruster:SetToggle( toggle == 1 )


### PR DESCRIPTION
Through testing, I've found that setting the force to a number larger than 36 digits long will instantly crash the server when activated. The thruster tool allow users to enter any unclamped force value they want. This has been an issue for many years.

If this pull request isn't accepted due to differing methods of solving this problem, please at least address it with an official patch.

Thanks.
