### PR TITLE
Clean up Poser tools

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/eyeposer.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/eyeposer.lua
@@ -1,6 +1,6 @@
 
-TOOL.Category		= "Poser"
-TOOL.Name			= "#tool.eyeposer.name"
+TOOL.Category	= "Poser"
+TOOL.Name		= "#tool.eyeposer.name"
 
 local function ConvertRelativeToEyesAttachment( Entity, Pos )
 
@@ -14,18 +14,18 @@ local function ConvertRelativeToEyesAttachment( Entity, Pos )
 	local attachment = Entity:GetAttachment( eyeattachment )
 	if ( !attachment ) then return end
 	
-	local LocalPos, LocalAng = WorldToLocal( Pos, Angle(0,0,0), attachment.Pos, attachment.Ang )
+	local LocalPos, LocalAng = WorldToLocal( Pos, Angle( 0, 0, 0 ), attachment.Pos, attachment.Ang )
 	
 	return LocalPos
 
 end
 
 --[[---------------------------------------------------------
-   Selects entity and aims their eyes
+	Selects entity and aims their eyes
 -----------------------------------------------------------]]
 function TOOL:LeftClick( trace )
 
-	if (self.SelectedEntity == nil) then
+	if ( !self.SelectedEntity ) then
 	
 		if ( !IsValid( trace.Entity ) ) then return end
 	
@@ -33,23 +33,25 @@ function TOOL:LeftClick( trace )
 		
 		self:GetWeapon():SetNetworkedEntity( 0, self.SelectedEntity )
 	
-	return end
+	return true end
 
 	local selectedent = self.SelectedEntity
 	self.SelectedEntity = nil
 	self:GetWeapon():SetNetworkedEntity( 0, NULL )
 	
-	if (!selectedent:IsValid()) then return end
+	if ( !IsValid( selectedent ) ) then return end
 	
 	local LocalPos = ConvertRelativeToEyesAttachment( selectedent, trace.HitPos )
-	if (!LocalPos) then return false end
+	if ( !LocalPos ) then return false end
 	
 	selectedent:SetEyeTarget( LocalPos )
+	
+	return true
 
 end
 
 --[[---------------------------------------------------------
-   Makes the eyes look at the player
+	Makes the eyes look at the player
 -----------------------------------------------------------]]
 function TOOL:RightClick( trace )
 
@@ -62,16 +64,18 @@ function TOOL:RightClick( trace )
 	local pos = self:GetOwner():EyePos()
 	
 	local LocalPos = ConvertRelativeToEyesAttachment( trace.Entity, pos )
-	if (!LocalPos) then return false end
+	if ( !LocalPos ) then return false end
 	
 	trace.Entity:SetEyeTarget( LocalPos )
 	
-end
+	return true
 	
+end
+
 if ( CLIENT ) then
 
 	--[[---------------------------------------------------------
-	   Draw a box indicating the face we have selected
+		Draw a box indicating the face we have selected
 	-----------------------------------------------------------]]
 	function TOOL:DrawHUD()
 	
@@ -82,19 +86,19 @@ if ( CLIENT ) then
 		local vEyePos = selected:EyePos()
 		
 		local eyeattachment = selected:LookupAttachment( "eyes" )
-		if (eyeattachment == 0) then return end
+		if ( eyeattachment == 0 ) then return end
 		
 		local attachment = selected:GetAttachment( eyeattachment )
 		local scrpos = attachment.Pos:ToScreen()
-		if (!scrpos.visible) then return end
+		if ( !scrpos.visible ) then return end
 		
 		-- Try to get each eye position.. this is a real guess and won't work on non-humans
-		local Leye = (attachment.Pos + attachment.Ang:Right() * 1.5):ToScreen()
-		local Reye = (attachment.Pos - attachment.Ang:Right() * 1.5):ToScreen()
+		local Leye = ( attachment.Pos + attachment.Ang:Right() * 1.5 ):ToScreen()
+		local Reye = ( attachment.Pos - attachment.Ang:Right() * 1.5 ):ToScreen()
 		
 		-- Work out the side distance to give a rough headsize box..
 		local player_eyes = LocalPlayer():EyeAngles()
-		local side = (attachment.Pos + player_eyes:Right() * 10):ToScreen()
+		local side = ( attachment.Pos + player_eyes:Right() * 10 ):ToScreen()
 		local size = 4
 		
 		local Owner = self:GetOwner()
@@ -112,20 +116,20 @@ if ( CLIENT ) then
 		-- Todo, make look less like ass
 		
 		surface.SetDrawColor( 0, 0, 0, 100 )
-		surface.DrawLine( Leye.x-1, Leye.y+1, x-1, y+1 )
-		surface.DrawLine( Leye.x-1, Leye.y-1, x-1, y-1 )
-		surface.DrawLine( Leye.x+1, Leye.y+1, x+1, y+1 )
-		surface.DrawLine( Leye.x+1, Leye.y-1, x+1, y-1 )
-		surface.DrawLine( Reye.x-1, Reye.y+1, x-1, y+1 )
-		surface.DrawLine( Reye.x-1, Reye.y-1, x-1, y-1 )
-		surface.DrawLine( Reye.x+1, Reye.y+1, x+1, y+1 )
-		surface.DrawLine( Reye.x+1, Reye.y-1, x+1, y-1 )
+		surface.DrawLine( Leye.x - 1, Leye.y + 1, x - 1, y + 1 )
+		surface.DrawLine( Leye.x - 1, Leye.y - 1, x - 1, y - 1 )
+		surface.DrawLine( Leye.x + 1, Leye.y + 1, x + 1, y + 1 )
+		surface.DrawLine( Leye.x + 1, Leye.y - 1, x + 1, y - 1 )
+		surface.DrawLine( Reye.x - 1, Reye.y + 1, x - 1, y + 1 )
+		surface.DrawLine( Reye.x - 1, Reye.y - 1, x - 1, y - 1 )
+		surface.DrawLine( Reye.x + 1, Reye.y + 1, x + 1, y + 1 )
+		surface.DrawLine( Reye.x + 1, Reye.y - 1, x + 1, y - 1 )
 		
 		surface.SetDrawColor( 0, 255, 0, 255 )
 		surface.DrawLine( Leye.x, Leye.y, x, y )
 		surface.DrawLine( Reye.x, Reye.y, x, y )
-		surface.DrawLine( Leye.x, Leye.y-1, x, y-1 )
-		surface.DrawLine( Reye.x, Reye.y-1, x, y-1 )
+		surface.DrawLine( Leye.x, Leye.y - 1, x, y - 1 )
+		surface.DrawLine( Reye.x, Reye.y - 1, x, y - 1 )
 	
 	end
 
@@ -133,6 +137,6 @@ end
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description	= "#tool.eyeposer.desc" }  )
+	CPanel:AddControl( "Header", { Description = "#tool.eyeposer.desc" } )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/faceposer.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/faceposer.lua
@@ -1,8 +1,7 @@
 
-TOOL.Category		= "Poser"
-TOOL.Name			= "#tool.faceposer.name"
+TOOL.Category	= "Poser"
+TOOL.Name		= "#tool.faceposer.name"
 
---local EYE_END = 11
 local gLastFacePoseEntity = NULL
 TOOL.FaceTimer = 0
 
@@ -23,51 +22,45 @@ local function IsUselessFaceFlex( strName )
 
 end
 
---[[---------------------------------------------------------
------------------------------------------------------------]]
 function TOOL:FacePoserEntity()
 	return self:GetWeapon():GetNetworkedEntity( 1 )
 end
 
---[[---------------------------------------------------------
------------------------------------------------------------]]
 function TOOL:SetFacePoserEntity( ent )
 	return self:GetWeapon():SetNetworkedEntity( 1, ent )
 end
 
---[[---------------------------------------------------------
------------------------------------------------------------]]
 function TOOL:Think()
 
 	-- If we're on the client just make sure the context menu is up to date
-	if (CLIENT) then
+	if ( CLIENT ) then
 	
 		if ( self:FacePoserEntity() == gLastFacePoseEntity ) then return end
-		gLastFacePoseEntity = self:FacePoserEntity();
-		self:UpdateFaceControlPanel();
+		gLastFacePoseEntity = self:FacePoserEntity()
+		self:UpdateFaceControlPanel()
 	
 	return end
 	
 	-- On the server we continually set the flex weights
-	if (self.FaceTimer > CurTime() ) then return end
+	if ( self.FaceTimer > CurTime() ) then return end
 	
 	local ent = self:FacePoserEntity()
 	if ( !IsValid( ent ) ) then return end
 	
 	local FlexNum = ent:GetFlexNum() - 1
-	if (FlexNum <= 0) then return end
+	if ( FlexNum <= 0 ) then return end
 	
-	for i=0, FlexNum-1 do
+	for i=0, FlexNum - 1 do
 	
 		local Name = ent:GetFlexName( i )
 			
-		if ( IsUselessFaceFlex(Name )  ) then
+		if ( IsUselessFaceFlex( Name ) ) then
 			
 			ent:SetFlexWeight( i, 0 )
-				
+			
 		else
 	
-			local num = self:GetClientNumber( "flex"..i )
+			local num = self:GetClientNumber( "flex" .. i )
 			ent:SetFlexWeight( i, num )
 			
 		end
@@ -79,8 +72,6 @@ function TOOL:Think()
 	
 end
 
-
-
 --[[---------------------------------------------------------
 	Alt fire sucks the facepose from the model's face
 -----------------------------------------------------------]]
@@ -90,25 +81,25 @@ function TOOL:RightClick( trace )
 		self:SetFacePoserEntity( trace.Entity )
 	end
 
-	if ( !IsValid( trace.Entity ) ) then return end
-	if ( trace.Entity:GetFlexNum() == 0 ) then return end
-		
+	if ( !IsValid( trace.Entity ) ) then return true end
+	if ( trace.Entity:GetFlexNum() == 0 ) then return true end
+	
 	local ent = trace.Entity
 	local FlexNum = ent:GetFlexNum()
 
 	if ( SERVER ) then
 	
-		-- This stops it applying the current sliders to the newly selected face.. 
+		-- This stops it applying the current sliders to the newly selected face..
 		-- it should probably be linked to the ping somehow.. but 1 second seems pretty safe
 		self.FaceTimer = CurTime() + 1	
-			
+		
 		-- In multiplayer the rest is only done on the client to save bandwidth.
 		-- We can't do that in single player because these functions don't get called on the client
 		if ( !game.SinglePlayer() ) then return end		
 
 	end
 	
-	for i=0, FlexNum-1 do
+	for i=0, FlexNum - 1 do
 	
 		local Weight = '0.0'
 		
@@ -116,11 +107,13 @@ function TOOL:RightClick( trace )
 			Weight = ent:GetFlexWeight( i )
 		end
 	
-		self:GetOwner():ConCommand( "faceposer_flex"..i.." " .. Weight )
+		self:GetOwner():ConCommand( "faceposer_flex" .. i .. " " .. Weight )
 	
 	end
 	
-	self:GetOwner():ConCommand( "faceposer_scale "..ent:GetFlexScale() )
+	self:GetOwner():ConCommand( "faceposer_scale " .. ent:GetFlexScale() )
+	
+	return true
 
 end
 	
@@ -135,8 +128,10 @@ if ( SERVER ) then
 		if ( !IsValid( trace.Entity ) ) then return end
 		if ( trace.Entity:GetFlexNum() == 0 ) then return end
 		
-		self.FaceTimer = 0;
+		self.FaceTimer = 0
 		self:SetFacePoserEntity( trace.Entity )
+		
+		return true
 		
 	end
 	
@@ -144,7 +139,7 @@ if ( SERVER ) then
 	
 		for i=0, 64 do
 			local num = math.Rand( 0, 1 )
-			pl:ConCommand( "faceposer_flex"..i.." " .. string.format( "%.3f", num ) )
+			pl:ConCommand( "faceposer_flex" .. i .. " " .. string.format( "%.3f", num ) )
 		end
 
 	end
@@ -155,8 +150,8 @@ end
 
 if ( CLIENT ) then
 
-	for i=0,64 do
-		TOOL.ClientConVar[ "flex"..i ] = "0"
+	for i=0, 64 do
+		TOOL.ClientConVar[ "flex" .. i ] = "0"
 	end
 	
 	TOOL.ClientConVar[ "scale" ] = "1.0"
@@ -177,21 +172,16 @@ if ( CLIENT ) then
 	--[[---------------------------------------------------------
 		Updates the Control Panel
 	-----------------------------------------------------------]]
+	local ConVarsDefault = TOOL:BuildConVarList()
+
 	function TOOL.BuildCPanel( CPanel, FaceEntity )
 
-		CPanel:AddControl( "Header", { Description	= "#tool.faceposer.desc" }  )
+		CPanel:AddControl( "Header", { Description = "#tool.faceposer.desc" } )
 	
 		if ( !IsValid( FaceEntity ) ) then return end
 
-		local Presets = vgui.Create( "ControlPresets", CPanel )
-			Presets:SetPreset( "face" )
-			
-			for i=0, 64 do
-				Presets:AddConVar( "faceposer_flex"..i )
-			end
-			
-		CPanel:AddItem( Presets )
-		
+		CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "face", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+
 		local QuickFace = vgui.Create( "MatSelect", CPanel )
 		QuickFace:SetItemWidth( 64 )
 		QuickFace:SetItemHeight( 32 )
@@ -205,7 +195,7 @@ if ( CLIENT ) then
 		
 		local Clear = {}
 		for i=0, 64 do
-			Clear[ "faceposer_flex"..i ] = 0
+			Clear[ "faceposer_flex" .. i ] = 0
 		end
 	
 		QuickFace:AddMaterialEx( "#faceposer.clear", "vgui/face/clear", nil, Clear )
@@ -221,8 +211,8 @@ if ( CLIENT ) then
 			faceposer_flex7	= "0",
 			faceposer_flex8	= "0",
 			faceposer_flex9	= "0"
-		})
-				
+		} )
+		
 		QuickFace:AddMaterialEx( "#faceposer.closeeyes", "vgui/face/close_eyes", nil, {
 			faceposer_flex0	= "0",
 			faceposer_flex1	= "0",
@@ -234,8 +224,8 @@ if ( CLIENT ) then
 			faceposer_flex7	= "1",
 			faceposer_flex8	= "1",
 			faceposer_flex9	= "1"
-		})
-				
+		} )
+		
 		QuickFace:AddMaterialEx( "#faceposer.angryeyebrows", "vgui/face/angry_eyebrows", nil, {
 			faceposer_flex10 = "0",
 			faceposer_flex11 = "0",
@@ -243,8 +233,8 @@ if ( CLIENT ) then
 			faceposer_flex13 = "1",
 			faceposer_flex14 = "0.5",
 			faceposer_flex15 = "0.5"
-		})
-					
+		} )
+		
 		QuickFace:AddMaterialEx( "#faceposer.normaleyebrows", "vgui/face/normal_eyebrows", nil, {			
 			faceposer_flex10 = "0",
 			faceposer_flex11 = "0",
@@ -252,7 +242,7 @@ if ( CLIENT ) then
 			faceposer_flex13 = "0",
 			faceposer_flex14 = "0",
 			faceposer_flex15 = "0"
-		})
+		} )
 		
 		QuickFace:AddMaterialEx( "#faceposer.sorryeyebrows", "vgui/face/sorry_eyebrows", nil, {
 			faceposer_flex10 = "1",
@@ -261,7 +251,7 @@ if ( CLIENT ) then
 			faceposer_flex13 = "0",
 			faceposer_flex14 = "0",
 			faceposer_flex15 = "0"
-		})
+		} )
 
 		QuickFace:AddMaterialEx( "#faceposer.grin", "vgui/face/grin", nil, {
 			faceposer_flex20 = "1",
@@ -288,7 +278,7 @@ if ( CLIENT ) then
 			faceposer_flex41 = "0",
 			faceposer_flex42 = "1",
 			faceposer_flex43 = "1"
-		})
+		} )
 
 		QuickFace:AddMaterialEx( "#faceposer.sad", "vgui/face/sad", nil, {
 			faceposer_flex20 = "0",
@@ -315,8 +305,8 @@ if ( CLIENT ) then
 			faceposer_flex41 = "0",
 			faceposer_flex42 = "0",
 			faceposer_flex43 = "0"
-		})
-				
+		} )
+		
 		QuickFace:AddMaterialEx( "#faceposer.smile", "vgui/face/smile", nil, {
 			faceposer_flex20 = "1",
 			faceposer_flex21 = "1",
@@ -343,39 +333,22 @@ if ( CLIENT ) then
 			faceposer_flex42 = "0",
 			faceposer_flex43 = "0",
 			faceposer_flex44 = "0",
-		})
-				
+		} )
+		
 		CPanel:AddItem( QuickFace )
 
-		local FlexNum = FaceEntity:GetFlexNum()
-		
-		local params = {}
-			params.Label = "#tool.faceposer.scale"
-			params.Help = true
-			params.Type = "Float"
-			params.Min = "-1"
-			params.Max = "5"
-			params.Command = "faceposer_scale"
-		CPanel:AddControl( "Slider", params )
-			
-		local params = {}
-			params.Text = "#tool.faceposer.randomize"
-			params.Command = "faceposer_randomize"
-		CPanel:AddControl( "Button", params )
-		
-		for i=0, FlexNum-1 do
+		CPanel:AddControl( "Slider", { Label = "#tool.faceposer.scale", Command = "faceposer_scale", Type = "Float", Min = "-5", Max = "5", Help = true } )
+		CPanel:AddControl( "Button", { Text = "#tool.faceposer.randomize", Command = "faceposer_randomize" } )
+
+		for i=0, FaceEntity:GetFlexNum() - 1 do
 		
 			local Name = FaceEntity:GetFlexName( i )
 			
-			if ( !IsUselessFaceFlex(Name )  ) then
+			if ( !IsUselessFaceFlex( Name ) ) then
 			
-				local params = {}
-				params.Label = Name
-				params.Type = "Float"
-				params.Min, params.Max = FaceEntity:GetFlexBounds( i )
-				params.Command = "faceposer_flex"..i
-				
-				local ctrl = CPanel:AddControl( "Slider", params )
+				local min, max = FaceEntity:GetFlexBounds( i )
+
+				local ctrl = CPanel:AddControl( "Slider", { Label = Name, Command = "faceposer_flex" .. i, Type = "Float", Min = min, Max = max } )
 
 				--
 				-- this makes the controls all bunched up like how we want
@@ -391,7 +364,7 @@ if ( CLIENT ) then
 	local FacePoser	= surface.GetTextureID( "gui/faceposer_indicator" )
 	
 	--[[---------------------------------------------------------
-	   Draw a box indicating the face we have selected
+		Draw a box indicating the face we have selected
 	-----------------------------------------------------------]]
 	function TOOL:DrawHUD()
 
@@ -403,21 +376,21 @@ if ( CLIENT ) then
 		local vEyePos = selected:EyePos()
 		
 		local eyeattachment = selected:LookupAttachment( "eyes" )
-		if (eyeattachment == 0) then return end
+		if ( eyeattachment == 0 ) then return end
 		
 		local attachment = selected:GetAttachment( eyeattachment )
 		local scrpos = attachment.Pos:ToScreen()
-		if (!scrpos.visible) then return end
+		if ( !scrpos.visible ) then return end
 		
 		-- Work out the side distance to give a rough headsize box..
 		local player_eyes = LocalPlayer():EyeAngles()
-		local side = (attachment.Pos + player_eyes:Right() * 20):ToScreen()
+		local side = ( attachment.Pos + player_eyes:Right() * 20 ):ToScreen()
 		local size = math.abs( side.x - scrpos.x )
 		
 		surface.SetDrawColor( 255, 255, 255, 255 )
 		surface.SetTexture( FacePoser )
-		surface.DrawTexturedRect( scrpos.x-size, scrpos.y-size, size*2, size*2 )
+		surface.DrawTexturedRect( scrpos.x - size, scrpos.y - size, size * 2, size * 2 )
 
 	end
-	
+
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/finger.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/finger.lua
@@ -1,17 +1,16 @@
 
-TOOL.Category		= "Poser"
-TOOL.Name			= "#tool.finger.name"
+TOOL.Category	= "Poser"
+TOOL.Name		= "#tool.finger.name"
 
 TOOL.RequiresTraceHit = true
 
-local VarsOnHand = 5 * 3
+local VarsOnHand = 15
 local FingerVars = VarsOnHand * 2
-
 
 --[[------------------------------------------------------------
 	Name: HasTF2Hands
 	Desc: Returns true if it has TF2 hands
---------------------------------------------------------------]] 
+--------------------------------------------------------------]]
 local function HasTF2Hands( pEntity )
 	return pEntity:LookupBone( "bip_hand_L" ) != nil
 end
@@ -19,74 +18,74 @@ end
 --[[------------------------------------------------------------
 	Name: HasZenoHands
 	Desc: Returns true if it has Zeno Clash hands
---------------------------------------------------------------]] 
+--------------------------------------------------------------]]
 local function HasZenoHands( pEntity )
 	return pEntity:LookupBone( "Bip01_L_Hand" ) != nil
 end
 
 local TranslateTable_TF2 = {}
-	TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger0" ] = "bip_thumb_0_L"
-	TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger01" ] = "bip_thumb_1_L"
-	TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger02" ] = "bip_thumb_2_L"
-	TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger1" ] = "bip_index_0_L"
-	TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger11" ] = "bip_index_1_L"
-	TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger12" ] = "bip_index_2_L"
-	TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger2" ] = "bip_middle_0_L"
-	TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger21" ] = "bip_middle_1_L"
-	TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger22" ] = "bip_middle_2_L"
-	TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger3" ] = "bip_ring_0_L"
-	TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger31" ] = "bip_ring_1_L"
-	TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger32" ] = "bip_ring_2_L"
-	TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger4" ] = "bip_pinky_0_L"
-	TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger41" ] = "bip_pinky_1_L"
-	TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger42" ] = "bip_pinky_2_L"
-	TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger0" ] = "bip_thumb_0_R"
-	TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger01" ] = "bip_thumb_1_R"
-	TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger02" ] = "bip_thumb_2_R"
-	TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger1" ] = "bip_index_0_R"
-	TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger11" ] = "bip_index_1_R"
-	TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger12" ] = "bip_index_2_R"
-	TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger2" ] = "bip_middle_0_R"
-	TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger21" ] = "bip_middle_1_R"
-	TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger22" ] = "bip_middle_2_R"
-	TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger3" ] = "bip_ring_0_R"
-	TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger31" ] = "bip_ring_1_R"
-	TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger32" ] = "bip_ring_2_R"
-	TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger4" ] = "bip_pinky_0_R"
-	TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger41" ] = "bip_pinky_1_R"
-	TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger42" ] = "bip_pinky_2_R"
-	
+TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger0" ] = "bip_thumb_0_L"
+TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger01" ] = "bip_thumb_1_L"
+TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger02" ] = "bip_thumb_2_L"
+TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger1" ] = "bip_index_0_L"
+TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger11" ] = "bip_index_1_L"
+TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger12" ] = "bip_index_2_L"
+TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger2" ] = "bip_middle_0_L"
+TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger21" ] = "bip_middle_1_L"
+TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger22" ] = "bip_middle_2_L"
+TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger3" ] = "bip_ring_0_L"
+TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger31" ] = "bip_ring_1_L"
+TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger32" ] = "bip_ring_2_L"
+TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger4" ] = "bip_pinky_0_L"
+TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger41" ] = "bip_pinky_1_L"
+TranslateTable_TF2[ "ValveBiped.Bip01_L_Finger42" ] = "bip_pinky_2_L"
+TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger0" ] = "bip_thumb_0_R"
+TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger01" ] = "bip_thumb_1_R"
+TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger02" ] = "bip_thumb_2_R"
+TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger1" ] = "bip_index_0_R"
+TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger11" ] = "bip_index_1_R"
+TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger12" ] = "bip_index_2_R"
+TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger2" ] = "bip_middle_0_R"
+TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger21" ] = "bip_middle_1_R"
+TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger22" ] = "bip_middle_2_R"
+TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger3" ] = "bip_ring_0_R"
+TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger31" ] = "bip_ring_1_R"
+TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger32" ] = "bip_ring_2_R"
+TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger4" ] = "bip_pinky_0_R"
+TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger41" ] = "bip_pinky_1_R"
+TranslateTable_TF2[ "ValveBiped.Bip01_R_Finger42" ] = "bip_pinky_2_R"
+
 local TranslateTable_Zeno = {}
-	TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger0" ] = "Bip01_L_Finger0"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger01" ] = "Bip01_L_Finger01"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger02" ] = "Bip01_L_Finger02"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger1" ] = "Bip01_L_Finger1"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger11" ] = "Bip01_L_Finger11"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger12" ] = "Bip01_L_Finger12"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger2" ] = "Bip01_L_Finger2"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger21" ] = "Bip01_L_Finger21"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger22" ] = "Bip01_L_Finger22"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger3" ] = "Bip01_L_Finger3"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger31" ] = "Bip01_L_Finger31"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger32" ] = "Bip01_L_Finger32"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger4" ] = "Bip01_L_Finger4"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger41" ] = "Bip01_L_Finger41"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger42" ] = "Bip01_L_Finger42"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger0" ] = "Bip01_R_Finger0"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger01" ] = "Bip01_R_Finger01"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger02" ] = "Bip01_R_Finger02"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger1" ] = "Bip01_R_Finger1"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger11" ] = "Bip01_R_Finger11"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger12" ] = "Bip01_R_Finger12"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger2" ] = "Bip01_R_Finger2"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger21" ] = "Bip01_R_Finger21"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger22" ] = "Bip01_R_Finger22"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger3" ] = "Bip01_R_Finger3"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger31" ] = "Bip01_R_Finger31"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger32" ] = "Bip01_R_Finger32"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger4" ] = "Bip01_R_Finger4"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger41" ] = "Bip01_R_Finger41"
-	TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger42" ] = "Bip01_R_Finger42"
+TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger0" ] = "Bip01_L_Finger0"
+TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger01" ] = "Bip01_L_Finger01"
+TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger02" ] = "Bip01_L_Finger02"
+TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger1" ] = "Bip01_L_Finger1"
+TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger11" ] = "Bip01_L_Finger11"
+TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger12" ] = "Bip01_L_Finger12"
+TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger2" ] = "Bip01_L_Finger2"
+TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger21" ] = "Bip01_L_Finger21"
+TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger22" ] = "Bip01_L_Finger22"
+TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger3" ] = "Bip01_L_Finger3"
+TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger31" ] = "Bip01_L_Finger31"
+TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger32" ] = "Bip01_L_Finger32"
+TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger4" ] = "Bip01_L_Finger4"
+TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger41" ] = "Bip01_L_Finger41"
+TranslateTable_Zeno[ "ValveBiped.Bip01_L_Finger42" ] = "Bip01_L_Finger42"
+TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger0" ] = "Bip01_R_Finger0"
+TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger01" ] = "Bip01_R_Finger01"
+TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger02" ] = "Bip01_R_Finger02"
+TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger1" ] = "Bip01_R_Finger1"
+TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger11" ] = "Bip01_R_Finger11"
+TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger12" ] = "Bip01_R_Finger12"
+TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger2" ] = "Bip01_R_Finger2"
+TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger21" ] = "Bip01_R_Finger21"
+TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger22" ] = "Bip01_R_Finger22"
+TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger3" ] = "Bip01_R_Finger3"
+TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger31" ] = "Bip01_R_Finger31"
+TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger32" ] = "Bip01_R_Finger32"
+TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger4" ] = "Bip01_R_Finger4"
+TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger41" ] = "Bip01_R_Finger41"
+TranslateTable_Zeno[ "ValveBiped.Bip01_R_Finger42" ] = "Bip01_R_Finger42"
 
 --[[---------------------------------------------------------
 	Name: HandEntity
@@ -110,34 +109,32 @@ function TOOL:SetHand( ent, iHand )
 	self:GetWeapon():SetNetworkedInt( "HandNum", iHand )
 end
 
-
 --[[------------------------------------------------------------
 	Name: GetFingerBone
 	Desc: Translate the fingernum, part and hand into an real bone number
---------------------------------------------------------------]] 
+--------------------------------------------------------------]]
 local function GetFingerBone( self, fingernum, part, hand )
 
 	---- START HL2 BONE LOOKUP ----------------------------------
-	local Name = "ValveBiped.Bip01_L_Finger"..fingernum
-	if ( hand == 1 ) then Name = "ValveBiped.Bip01_R_Finger"..fingernum end
+	local Name = "ValveBiped.Bip01_L_Finger" .. fingernum
+	if ( hand == 1 ) then Name = "ValveBiped.Bip01_R_Finger" .. fingernum end
 	if ( part != 0 ) then Name = Name .. part end
 
 	local bone = self:LookupBone( Name )
 	if ( bone ) then return bone end
 	---- END HL2 BONE LOOKUP ----------------------------------
-	
-	
+
 	---- START TF BONE LOOKUP ----------------------------------
 	local TranslatedName = TranslateTable_TF2[ Name ]
-	if ( TranslatedName ) then 
+	if ( TranslatedName ) then
 		local bone = self:LookupBone( TranslatedName )
 		if ( bone ) then return bone end
 	end
 	---- END TF BONE LOOKUP ----------------------------------
-	
+
 	---- START Zeno BONE LOOKUP ----------------------------------
 	local TranslatedName = TranslateTable_Zeno[ Name ]
-	if ( TranslatedName ) then 
+	if ( TranslatedName ) then
 		local bone = self:LookupBone( TranslatedName )
 		if ( bone ) then return bone end
 	end
@@ -148,11 +145,11 @@ end
 --[[------------------------------------------------------------
 	Name: SetupFingers
 	Desc: Cache the finger bone numbers for faster access
---------------------------------------------------------------]] 
+--------------------------------------------------------------]]
 local function SetupFingers( self )
 
 	if ( self.FingerIndex ) then return end
-		
+	
 	self.FingerIndex = {}
 
 	local i = 1
@@ -176,89 +173,86 @@ end
 -----------------------------------------------------------]]
 function TOOL:ApplyValues( pEntity, iHand )
 
-	if (CLIENT) then return end
+	if ( CLIENT ) then return end
 
 	SetupFingers( pEntity )
 
-	local bTF2 = HasTF2Hands( pEntity );
+	local bTF2 = HasTF2Hands( pEntity )
 
-	for i=0, VarsOnHand-1 do
+	for i=0, VarsOnHand - 1 do
 	
 		local Var = self:GetClientInfo( i )
 		local VecComp = string.Explode( " ", Var )
 		
 		local sin = math.sin( CurTime() * 10 ) * 10
 
-		local Ang = nil;
+		local Ang = nil
 
 		if ( bTF2 ) then
 					
 			if ( i < 3 ) then
-				Ang = Angle( 0, tonumber(VecComp[2]), tonumber(VecComp[1]) )
+				Ang = Angle( 0, tonumber( VecComp[2] ), tonumber( VecComp[1] ) )
 			else
-				Ang = Angle( 0, tonumber(VecComp[1]), -tonumber(VecComp[2]) )
+				Ang = Angle( 0, tonumber( VecComp[1] ), -tonumber( VecComp[2] ) )
 			end
 
 		else
 			if ( i < 3 ) then
-				Ang = Angle( tonumber(VecComp[2]), tonumber(VecComp[1]), 0 )		
+				Ang = Angle( tonumber( VecComp[2] ), tonumber( VecComp[1] ), 0 )
 			else
-				Ang = Angle( tonumber(VecComp[1]), tonumber(VecComp[2]), 0 )
+				Ang = Angle( tonumber( VecComp[1] ), tonumber( VecComp[2] ), 0 )
 			end
 		end
 
-
-		local bone = pEntity.FingerIndex[ i + iHand*VarsOnHand + 1 ] 
+		local bone = pEntity.FingerIndex[ i + iHand * VarsOnHand + 1 ]
 		if ( bone ) then
 			pEntity:ManipulateBoneAngles( bone, Ang )
 		end
 		
 	end
 
-
 end
 
 --[[------------------------------------------------------------
 	Name: GetHandPositions
-	Desc: Hope we don't have any one armed models	
---------------------------------------------------------------]] 
+	Desc: Hope we don't have any one armed models
+--------------------------------------------------------------]]
 function TOOL:GetHandPositions( pEntity )
 
 	local LeftHand = pEntity:LookupBone( "ValveBiped.Bip01_L_Hand" )
-	if (!LeftHand) then LeftHand = pEntity:LookupBone( "bip_hand_L" ) end
-	if (!LeftHand) then LeftHand = pEntity:LookupBone( "Bip01_L_Hand" ) end
+	if ( !LeftHand ) then LeftHand = pEntity:LookupBone( "bip_hand_L" ) end
+	if ( !LeftHand ) then LeftHand = pEntity:LookupBone( "Bip01_L_Hand" ) end
 	
 	local RightHand = pEntity:LookupBone( "ValveBiped.Bip01_R_Hand" )
-	if (!RightHand) then RightHand = pEntity:LookupBone( "bip_hand_R" ) end
-	if (!RightHand) then RightHand = pEntity:LookupBone( "Bip01_R_Hand" ) end
+	if ( !RightHand ) then RightHand = pEntity:LookupBone( "bip_hand_R" ) end
+	if ( !RightHand ) then RightHand = pEntity:LookupBone( "Bip01_R_Hand" ) end
 	
-	if (!LeftHand || !RightHand) then return false end
+	if ( !LeftHand || !RightHand ) then return false end
 	
-	local LeftHand = pEntity:GetBoneMatrix( LeftHand )	
+	local LeftHand = pEntity:GetBoneMatrix( LeftHand )
 	local RightHand = pEntity:GetBoneMatrix( RightHand )
-	if (!LeftHand || !RightHand) then return false end
+	if ( !LeftHand || !RightHand ) then return false end
 
 	return LeftHand, RightHand
 	
 end
 
-
 --[[------------------------------------------------------------
 	Name: LeftClick
 	Desc: Applies current convar hand to picked hand
---------------------------------------------------------------]] 
+--------------------------------------------------------------]]
 function TOOL:LeftClick( trace )
 
-	if ( trace.Entity:IsValid() && trace.Entity:IsPlayer() ) then return false end
+	if ( IsValid( trace.Entity ) && trace.Entity:IsPlayer() ) then return false end
 	if ( trace.Entity:GetClass() != "prop_ragdoll" && !trace.Entity:IsNPC() ) then return false end
 	
 	local LeftHand, RightHand = self:GetHandPositions( trace.Entity )
 	
-	if (!LeftHand) then return false end
+	if ( !LeftHand ) then return false end
 	if ( CLIENT ) then return true end
 	
-	local LeftHand = (LeftHand:GetTranslation() - trace.HitPos):Length()
-	local RightHand = (RightHand:GetTranslation() - trace.HitPos):Length()
+	local LeftHand = ( LeftHand:GetTranslation() - trace.HitPos ):Length()
+	local RightHand = ( RightHand:GetTranslation() - trace.HitPos ):Length()
 	
 	if ( LeftHand < RightHand ) then
 	
@@ -269,23 +263,20 @@ function TOOL:LeftClick( trace )
 		self:ApplyValues( trace.Entity, 1 )
 	
 	end
-	
-	
+
 	return true
 
 end
 
-
 --[[------------------------------------------------------------
 	Name: RightClick
 	Desc: Selects picked hand and sucks off convars
---------------------------------------------------------------]] 
+--------------------------------------------------------------]]
 function TOOL:RightClick( trace )
 
-	local ent = trace.Entity;
+	local ent = trace.Entity
 
-	if ( !IsValid( ent ) ) then return false end
-	if ( ent:IsPlayer() ) then return false end
+	if ( !IsValid( ent ) || ent:IsPlayer() ) then self:SetHand( NULL, 0 ) return true end
 	if ( ent:GetClass() != "prop_ragdoll" && !ent:IsNPC() ) then return false end
 
 	if ( CLIENT ) then return false end
@@ -293,17 +284,17 @@ function TOOL:RightClick( trace )
 	local LeftHand, RightHand = self:GetHandPositions( ent )
 	if ( !LeftHand ) then return false end
 	
-	local LeftHand = (LeftHand:GetTranslation() - trace.HitPos):Length()
-	local RightHand = (RightHand:GetTranslation() - trace.HitPos):Length()
+	local LeftHand = ( LeftHand:GetTranslation() - trace.HitPos ):Length()
+	local RightHand = ( RightHand:GetTranslation() - trace.HitPos ):Length()
 	
 	local Hand = 0
 	if ( LeftHand < RightHand ) then
 	
-		self:SetHand( ent, 0, false )
+		self:SetHand( ent, 0 )
 	
 	else
 	
-		self:SetHand( ent, 1, false )
+		self:SetHand( ent, 1 )
 		Hand = 1
 	
 	end
@@ -311,16 +302,16 @@ function TOOL:RightClick( trace )
 	--
 	-- Make sure entity has fingers set up!
 	--
-	SetupFingers( ent );
+	SetupFingers( ent )
 
-	local bTF2 = HasTF2Hands( ent );
+	local bTF2 = HasTF2Hands( ent )
 
 	--
 	-- Rwead the variables from the angles of the fingers, into our convars
 	--
 	for i=0, VarsOnHand-1 do
 	
-		local bone = ent.FingerIndex[ i + Hand*VarsOnHand + 1 ] 
+		local bone = ent.FingerIndex[ i + Hand * VarsOnHand + 1 ]
 		if ( bone ) then
 
 			local Ang = ent:GetManipulateBoneAngles( bone )
@@ -331,16 +322,14 @@ function TOOL:RightClick( trace )
 					self:GetOwner():ConCommand( Format( "finger_%s %.1f %.1f", i, Ang.Roll, Ang.Yaw ) )
 				else
 					self:GetOwner():ConCommand( Format( "finger_%s %.1f %.1f", i, Ang.Yaw, -Ang.Roll ) )
-				end		
+				end
 			else
-					if ( i < 3 ) then
+				if ( i < 3 ) then
 					self:GetOwner():ConCommand( Format( "finger_%s %.1f %.1f", i, Ang.Yaw, Ang.Pitch ) )
 				else
 					self:GetOwner():ConCommand( Format( "finger_%s %.1f %.1f", i, Ang.Pitch, Ang.Yaw ) )
-				end		
+				end
 			end
-
-
 
 		end
 		
@@ -351,7 +340,7 @@ function TOOL:RightClick( trace )
 	-- We need to wait until they convars get updated with the sucked pose
 	self.NextUpdate = CurTime() + 0.5
 	
-	return false
+	return true
 	
 end
 
@@ -363,7 +352,7 @@ local OldEntity = nil
 	Desc: Updates the selected entity with the values from the convars
 			Also, on the client it rebuilds the control panel if we have
 			selected a new entity or hand
---------------------------------------------------------------]] 
+--------------------------------------------------------------]]
 function TOOL:Think()
 	
 	local selected = self:HandEntity()
@@ -391,25 +380,18 @@ function TOOL:Think()
 
 end
 
-if ( !CLIENT ) then return end
+if ( SERVER ) then return end
 -- Notice the return above.
 -- The rest of this file CLIENT ONLY.
 
-function TOOL.BuildCPanel( CPanel )
-
-	CPanel:AddControl( "Header", { Description	= "#tool.finger.desc" }  )
-
-end
-
 for i=0, VarsOnHand do
-	TOOL.ClientConVar[ ""..i ] = "0 0"
+	TOOL.ClientConVar[ "" .. i ] = "0 0"
 end
-
 
 --[[------------------------------------------------------------
 	Name: RebuildControlPanel
 	Desc: Rebuilds the context menu based on the current selected entity/hand
---------------------------------------------------------------]] 
+--------------------------------------------------------------]]
 function TOOL:RebuildControlPanel( hand )
 
 	-- We've selected a new entity - rebuild the controls list
@@ -417,36 +399,29 @@ function TOOL:RebuildControlPanel( hand )
 	if ( !CPanel ) then return end
 	
 	CPanel:ClearControls()
-	
-	self.BuildCPanel( CPanel )
-	
-	local Ent = self:HandEntity()
-	if ( !IsValid( Ent ) ) then return end
-		
-	local CVars = {}
-	
-	local Default = {}
-	for i=0, VarsOnHand do
-		table.insert( CVars, "finger_"..i )
-		Default[ "finger_"..i ] = "0 0 0"
-	end
-	
-	CPanel:AddControl( "ComboBox", { Label = "#tool.presets", 
-									MenuButton = 1,
-									Folder = "finger",
-									CVars = CVars,
-									Options = { default = Default }
-									} )
-	
-	SetupFingers( Ent );
+	self.BuildCPanel( CPanel, self:HandEntity() )
 
-	if ( !Ent.FingerIndex ) then return end
+end
+
+local ConVarsDefault = TOOL:BuildConVarList()
+
+function TOOL.BuildCPanel( CPanel, ent )
+
+	CPanel:AddControl( "Header", { Description = "#tool.finger.desc" } )
+
+	if ( !IsValid( ent ) ) then return end
+
+	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "finger", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+
+	SetupFingers( ent )
+
+	if ( !ent.FingerIndex ) then return end
+	
 	-- Detect mitten hands
-	local NumVars = table.Count( Ent.FingerIndex )
+	local NumVars = table.Count( ent.FingerIndex )
 	
-	CPanel:AddControl( "FingerPoser", { hand = hand, numvars = NumVars } )
-	
-	
+	CPanel:AddControl( "fingerposer", { hand = hand, numvars = NumVars } )
+
 	CPanel:AddControl( "Checkbox", { Label = "#tool.finger.restrict_axis", Command = "finger_restrict" } )
 
 end
@@ -456,7 +431,7 @@ local FacePoser	= surface.GetTextureID( "gui/faceposer_indicator" )
 --[[------------------------------------------------------------
 	Name: DrawHUD
 	Desc: Draw a circle around the selected hand
---------------------------------------------------------------]] 
+--------------------------------------------------------------]]
 function TOOL:DrawHUD()
 
 	local selected = self:HandEntity()
@@ -471,20 +446,20 @@ function TOOL:DrawHUD()
 	
 	local BoneMatrix = lefthand
 	if ( hand == 1 ) then BoneMatrix = righthand end
-	if (!BoneMatrix) then return end
+	if ( !BoneMatrix ) then return end
 	
 	local vPos = BoneMatrix:GetTranslation()
 	
 	local scrpos = vPos:ToScreen()
-	if (!scrpos.visible) then return end
+	if ( !scrpos.visible ) then return end
 	
 	-- Work out the side distance to give a rough headsize box..
 	local player_eyes = LocalPlayer():EyeAngles()
-	local side = (vPos + player_eyes:Right() * 20):ToScreen()
+	local side = ( vPos + player_eyes:Right() * 20 ):ToScreen()
 	local size = math.abs( side.x - scrpos.x )
 	
 	surface.SetDrawColor( 255, 255, 255, 255 )
 	surface.SetTexture( FacePoser )
-	surface.DrawTexturedRect( scrpos.x-size, scrpos.y-size, size*2, size*2 )
+	surface.DrawTexturedRect( scrpos.x - size, scrpos.y - size, size * 2, size * 2 )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/inflator.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/inflator.lua
@@ -1,6 +1,6 @@
 
-TOOL.Category		= "Poser"
-TOOL.Name			= "#tool.inflator.name"
+TOOL.Category	= "Poser"
+TOOL.Name		= "#tool.inflator.name"
 
 TOOL.LeftClickAutomatic = true
 TOOL.RightClickAutomatic = true
@@ -10,27 +10,28 @@ if ( CLIENT ) then
 
 	function TOOL.BuildCPanel( CPanel )
 
-		CPanel:AddControl( "Header", { Description	= "#tool.inflator.desc" }  )
+		CPanel:AddControl( "Header", { Description = "#tool.inflator.desc" } )
 	
 	end
 
 end
 
-local ScaleYZ = { "ValveBiped.Bip01_L_UpperArm", 
-						  "ValveBiped.Bip01_L_Forearm", 
-						  "ValveBiped.Bip01_L_Thigh",
-						  "ValveBiped.Bip01_L_Calf",
-						  "ValveBiped.Bip01_R_UpperArm",
-						  "ValveBiped.Bip01_R_Forearm",
-						  "ValveBiped.Bip01_R_Thigh",
-						  "ValveBiped.Bip01_R_Calf",
-						  "ValveBiped.Bip01_Spine2",
-						  "ValveBiped.Bip01_Spine1",
-						  "ValveBiped.Bip01_Spine",
-						  "ValveBiped.Bip01_Spinebut" }
-						  
+local ScaleYZ = {
+	"ValveBiped.Bip01_L_UpperArm",
+	"ValveBiped.Bip01_L_Forearm",
+	"ValveBiped.Bip01_L_Thigh",
+	"ValveBiped.Bip01_L_Calf",
+	"ValveBiped.Bip01_R_UpperArm",
+	"ValveBiped.Bip01_R_Forearm",
+	"ValveBiped.Bip01_R_Thigh",
+	"ValveBiped.Bip01_R_Calf",
+	"ValveBiped.Bip01_Spine2",
+	"ValveBiped.Bip01_Spine1",
+	"ValveBiped.Bip01_Spine",
+	"ValveBiped.Bip01_Spinebut"
+}
+
 local ScaleXZ = { "ValveBiped.Bip01_pelvis" }
-		
 
 local function GetNiceBoneScale( name, scale )
 
@@ -45,8 +46,6 @@ local function GetNiceBoneScale( name, scale )
 	return Vector( scale, scale, scale )
 
 end
-
-
 
 local ScaleBone = nil
 
@@ -66,9 +65,7 @@ local function ScaleNeighbourBones( Entity, Pos, Bone, Scale, type )
 		local children = Entity:GetChildBones( Bone )
 
 		for k, v in pairs( children ) do
-
 			ScaleBone( Entity, Pos, v, Scale, 1 )
-
 		end
 
 	end
@@ -76,10 +73,8 @@ local function ScaleNeighbourBones( Entity, Pos, Bone, Scale, type )
 end
 
 --[[------------------------------------------------------------
-
 	Scale the specified bone by Scale
-	
---------------------------------------------------------------]]   
+--------------------------------------------------------------]]
 ScaleBone = function( Entity, Pos, Bone, Scale, type )
 
 	--local Bone, BonePos = Entity:FindNearestBone( Pos )
@@ -87,78 +82,71 @@ ScaleBone = function( Entity, Pos, Bone, Scale, type )
 
 	-- Some bones are scaled only in certain directions (like legs don't scale on length)
 	local v = GetNiceBoneScale( Entity:GetBoneName( Bone ), Scale ) * 0.1
-	local TargetScale = Entity:GetManipulateBoneScale( Bone ) + v * 0.1;
+	local TargetScale = Entity:GetManipulateBoneScale( Bone ) + v * 0.1
 	
-	if ( TargetScale.x < 0 ) then TargetScale.x = 0; end
-	if ( TargetScale.y < 0 ) then TargetScale.y = 0; end
-	if ( TargetScale.z < 0 ) then TargetScale.z = 0; end
+	if ( TargetScale.x < 0 ) then TargetScale.x = 0 end
+	if ( TargetScale.y < 0 ) then TargetScale.y = 0 end
+	if ( TargetScale.z < 0 ) then TargetScale.z = 0 end
 
 	Entity:ManipulateBoneScale( Bone, TargetScale )
 
-	ScaleNeighbourBones( Entity, Pos, Bone, Scale * 0.5, type );
+	ScaleNeighbourBones( Entity, Pos, Bone, Scale * 0.5, type )
 
 end
 
-
 --[[------------------------------------------------------------
-
 	Scale UP
-	
---------------------------------------------------------------]] 
+--------------------------------------------------------------]]
 function TOOL:LeftClick( trace )
 
-	if ( trace.Entity:IsValid() && trace.Entity:IsPlayer() ) then return false end
+	if ( IsValid( trace.Entity ) && trace.Entity:IsPlayer() ) then return false end
 	if ( !trace.Entity:IsNPC() && trace.Entity:GetClass() != "prop_ragdoll" ) then return false end
 	
 	local Bone = trace.Entity:TranslatePhysBoneToBone( trace.PhysicsBone )
-	ScaleBone( trace.Entity, trace.HitPos, Bone, 1 )	
+	ScaleBone( trace.Entity, trace.HitPos, Bone, 1 )
 	self:GetWeapon():SetNextPrimaryFire( CurTime() + 0.01 )
 
 	local effectdata = EffectData()
-		effectdata:SetOrigin( trace.HitPos )
+	effectdata:SetOrigin( trace.HitPos )
 	util.Effect( "inflator_magic", effectdata )
 	
 	return false
 
 end
 
-
 --[[------------------------------------------------------------
-
 	Scale DOWN
-	
---------------------------------------------------------------]] 
+--------------------------------------------------------------]]
 function TOOL:RightClick( trace )
 
-	if ( trace.Entity:IsValid() && trace.Entity:IsPlayer() ) then return false end
+	if ( IsValid( trace.Entity ) && trace.Entity:IsPlayer() ) then return false end
 	if ( !trace.Entity:IsNPC() && trace.Entity:GetClass() != "prop_ragdoll" ) then return false end
 	
 	local Bone = trace.Entity:TranslatePhysBoneToBone( trace.PhysicsBone )
-	ScaleBone( trace.Entity, trace.HitPos, Bone, -1 )	
+	ScaleBone( trace.Entity, trace.HitPos, Bone, -1 )
 	self:GetWeapon():SetNextSecondaryFire( CurTime() + 0.01 )
 	
 	local effectdata = EffectData()
-		effectdata:SetOrigin( trace.HitPos )
+	effectdata:SetOrigin( trace.HitPos )
 	util.Effect( "inflator_magic", effectdata )
 
 	return false
 	
 end
 
-
 --[[------------------------------------------------------------
-
 	Remove Scaling
-	
---------------------------------------------------------------]] 
+--------------------------------------------------------------]]
 function TOOL:Reload( trace )
 	
-	if ( trace.Entity:IsValid() && trace.Entity:IsPlayer() ) then return false end
+	if ( IsValid( trace.Entity ) && trace.Entity:IsPlayer() ) then return false end
 	if ( !trace.Entity:IsNPC() && trace.Entity:GetClass() != "prop_ragdoll" ) then return false end
 	if ( CLIENT ) then return false end
 	
 	for i=0, trace.Entity:GetBoneCount() do
 		trace.Entity:ManipulateBoneScale( i, Vector(1, 1, 1) )
 	end
+	
+	return true
 	
 end


### PR DESCRIPTION
- Remove all semicolons, trailing whitespace, double spaces, excessive
  tabulation
- Remove redundant code from some of the tools
- Switch the tools to a cleaner default preset generation
- Fix return values for some of the tools to correctly display tool
  tracer where needed
