### PR TITLE
Automatically exec server.cfg

### DIFF
--- a/garrysmod/cfg/valve.rc
+++ b/garrysmod/cfg/valve.rc
@@ -5,6 +5,7 @@ exec joystick.cfg
 
 // run a user script file if present
 exec autoexec.cfg
+exec server.cfg
 
 // Run network settings
 exec network.cfg


### PR DESCRIPTION
No reason server owners should have to put exec server.cfg in the autoexec.cfg.
