### PR TITLE
Fixed PLAYER:AddCount() causing PLAYER:GetCount() to report incorrect values

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/player_extension.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/player_extension.lua
@@ -26,8 +26,6 @@ function meta:GetCount( str, minus )
 		return self:GetNetworkedInt( "Count."..str, 0 )
 	end
 	
-	minus = minus or 0
-	
 	if ( !self:IsValid() ) then return end
 
 	local key = self:UniqueID()
@@ -52,7 +50,7 @@ function meta:GetCount( str, minus )
 	
 	end
 	
-	self:SetNetworkedInt( "Count."..str, c - minus )
+	self:SetNetworkedInt( "Count."..str, c )
 
 	return c
 
@@ -73,7 +71,7 @@ function meta:AddCount( str, ent )
 		-- Update count (for client)
 		self:GetCount( str )
 		
-		ent:CallOnRemove( "GetCountUpdate", function( ent, ply, str ) ply:GetCount(str, 1) end, self, str )
+		ent:CallOnRemove( "GetCountUpdate", function( ent, ply, str ) ply:GetCount(str) end, self, str )
 	
 	end
 


### PR DESCRIPTION
...es

About the issue: 
http://facepunch.com/showthread.php?t=1348923&p=44954712&viewfull=1#post44954712
http://facepunch.com/showthread.php?t=1348923&p=44954892&viewfull=1#post44954892
http://facepunch.com/showthread.php?t=1348923&p=44955078&viewfull=1#post44955078

Somehow this only became an issue within the last 2 months even though this file hasn't been edited for a year. 

Anyway, the whole 'minus' part about PLAYER:GetCount() and PLAYER:AddCount() is redundant because PLAYER:GetCount() already sanitizes the table of props and gets an accurate number. By subtracting 1 afterward, it is actually breaking it.
