### PR TITLE
Player:Remove() kicks the player instead of removing the entity.

### DIFF
--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -274,6 +274,6 @@ end
 -----------------------------------------------------------]]  
 function meta:Remove()
     if SERVER then
-		self:Kick( "Player has been removed from the server." )
+	self:Kick( "Player has been removed from the server." )
     end
 end


### PR DESCRIPTION
This is mostly for the upcoming scripted player bots and also fixes a few scripters' bad habits of removing players and leaving the actual clients still connected ingame unable to do anything.
Mind you this is the first time I used pull requests and I suck at it.
