### PR TITLE
Removed effects.halo.Add for good

### DIFF
--- a/garrysmod/lua/includes/init.lua
+++ b/garrysmod/lua/includes/init.lua
@@ -3,8 +3,8 @@
 	Non-Module includes
 -----------------------------------------------------------]]
 
-include ( "util.lua" )			-- Misc Utilities	
-include ( "util/sql.lua" )		-- Include sql here so it's 
+include ( "util.lua" )			-- Misc Utilities
+include ( "util/sql.lua" )		-- Include sql here so it's
 								-- available at loadtime to modules.
 
 --[[---------------------------------------------------------
@@ -14,9 +14,9 @@ include ( "util/sql.lua" )		-- Include sql here so it's
 require ( "baseclass" )
 require ( "concommand" )		-- Console Commands
 require ( "saverestore" )		-- Save/Restore
+require ( "hook" )				-- Gamemode hooks
 require ( "gamemode" )			-- Gamemode manager
 require ( "weapons" )			-- SWEP manager
-require ( "hook" )				-- Gamemode hooks
 require ( "scripted_ents" )		-- Scripted Entities
 require ( "player_manager" )	-- Player models/class manager
 require ( "numpad" )
@@ -25,7 +25,7 @@ require ( "undo" )
 require ( "cleanup" )
 require ( "duplicator" )
 require ( "constraint" )
-require ( "construct" )	
+require ( "construct" )
 require ( "usermessage" )
 require ( "list" )
 require ( "cvars" )
@@ -68,10 +68,10 @@ if ( CLIENT ) then
 	require ( "cookie" )
 	require ( "menubar" )
 	require ( "matproxy" )
-	
+
 	include( "util/model_database.lua" )	-- Store information on models as they're loaded
 	include( "util/vgui_showlayout.lua" ) 	-- VGUI Performance Debug
-	include( "util/tooltips.lua" )	
+	include( "util/tooltips.lua" )
 	include( "util/client.lua" )
 	include( "util/javascript_util.lua" )
 	include( "util/workshop_files.lua" )
@@ -87,9 +87,9 @@ include( "gmsave.lua" )
 
 --[[---------------------------------------------------------
 	Extensions
-	
+
 	Load extensions that we specifically need for the menu,
-	to reduce the chances of loading something that might 
+	to reduce the chances of loading something that might
 	cause errors.
 -----------------------------------------------------------]]
 
@@ -98,7 +98,7 @@ include ( "extensions/angle.lua" )
 include ( "extensions/debug.lua" )
 include ( "extensions/entity.lua" )
 include ( "extensions/ents.lua" )
-include ( "extensions/math.lua" )	
+include ( "extensions/math.lua" )
 include ( "extensions/player.lua" )
 include ( "extensions/player_auth.lua" )
 include ( "extensions/string.lua" )

--- a/garrysmod/lua/includes/modules/effects.lua
+++ b/garrysmod/lua/includes/modules/effects.lua
@@ -1,9 +1,13 @@
+local ents = ents
+local pairs = pairs
+local string = string
+local table = table
 
 --[[---------------------------------------------------------
    Name: effects
    Desc: Engine effects hooking
 -----------------------------------------------------------]]
-module( "effects", package.seeall )
+module( "effects" )
 
 local EffectList = {}
 
@@ -16,7 +20,7 @@ function Register( t, name )
 
 	name = string.lower(name)
 	EffectList[ name ] = t
-	
+
 	--
 	-- If we're reloading this entity class
 	-- then refresh all the existing entities.
@@ -26,13 +30,13 @@ function Register( t, name )
 		--
 		-- Foreach entity using this class
 		--
-		table.ForEach( ents.FindByClass( name ), function( _, entity ) 
-		
+		table.ForEach( ents.FindByClass( name ), function( _, entity )
+
 			--
 			-- Replace the contents with this entity table
 			--
 			table.Merge( entity, t )
-		
+
 		end )
 
 	end
@@ -46,21 +50,21 @@ end
 function Create( name )
 
 	name = string.lower(name)
-	 
+
 	--Msg( "Create.. ".. name .. "\n" )
 
 	if (EffectList[ name ] == nil) then return nil end
 
 	local NewEffect = {}
-	
-	for k, v in pairs( EffectList[ name ] ) do 
-	
+
+	for k, v in pairs( EffectList[ name ] ) do
+
 		NewEffect[k] = v
-		
+
 	end
-	
+
 	table.Merge( NewEffect, EffectList[ "base" ] )
-	
+
 	return NewEffect
-	
+
 end

--- a/garrysmod/lua/includes/modules/gamemode.lua
+++ b/garrysmod/lua/includes/modules/gamemode.lua
@@ -1,7 +1,5 @@
 
-require( "hook" )
-
--- Globals that we need 
+-- Globals that we need
 local gmod 			= gmod
 local pairs 		= pairs
 local Msg 			= Msg
@@ -27,7 +25,7 @@ local GameList = {}
 function Register( t, name, derived )
 
 	local CurrentGM = gmod.GetGamemode()
-	
+
 	if ( CurrentGM ) then
 
 		if ( CurrentGM.FolderName == name ) then
@@ -81,11 +79,11 @@ end
 function Call( name, ... )
 
 	local CurrentGM = gmod.GetGamemode()
-	
+
 	-- If the gamemode function doesn't exist just return false
 	if ( CurrentGM && CurrentGM[name] == nil ) then return false end
-	
+
 	return hook.Call( name, CurrentGM, ... )
-	
+
 end
 


### PR DESCRIPTION
You can still do

``` lua
baseclass.cleanup.constraint.controlpanel.cookie.duplicator.matproxy.notification.player_manager.preset.properties.scripted_ents.search.spawnmenu.team.undo.weapons.halo.Add
```

or

``` lua
halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.halo.Add
```

But those can be sorted later. At least effects.halo is gone.
