### PR TITLE
Net improvements

### DIFF
--- a/garrysmod/lua/includes/modules/net.lua
+++ b/garrysmod/lua/includes/modules/net.lua
@@ -39,7 +39,9 @@ end
 net.WriteBool = net.WriteBit
 
 function net.ReadBool()
+
 	return net.ReadBit() == 1
+	
 end
 
 --


### PR DESCRIPTION
It makes no sense to force developers to use net.ReadBit and net.WriteBit, as they only lead to complications. This just adds net.ReadBool and net.WriteBool and makes net.WriteType and net.ReadType use them.
