### PR TITLE
Fixes error in SafeRemoveEntity/SafeRemoveEntityDelayed under certain circumstances

### DIFF
--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -181,7 +181,7 @@ end
 -----------------------------------------------------------]]
 function SafeRemoveEntity( ent )
 
-	if ( !ent || ( ent.IsValid && !ent:IsValid() ) || ent:IsPlayer() ) then return end
+	if ( !IsValid( ent ) || ent:IsPlayer() ) then return end
 	
 	ent:Remove()
 	
@@ -192,7 +192,7 @@ end
 -----------------------------------------------------------]]
 function SafeRemoveEntityDelayed( ent, timedelay )
 
-	if ( !ent || ( ent.IsValid && !ent:IsValid() ) ) then return end
+	if ( !IsValid( ent ) || ent:IsPlayer() ) then return end
 	
 	timer.Simple( timedelay, function() SafeRemoveEntity( ent ) end )
 	


### PR DESCRIPTION
Fixes issue when using SafeRemoveEntity/SafeRemoveEntityDelayed giving error on "[ERROR] lua/uncludes/util.lua:184/195: attempt to call method 'IsValid' (a nil value)" under certain circumstances when an entity is removed ( either several times using SafeRemoveEntity / Remove combo, or when trying to remove a swep that has been removed / was in the process of being removed or when trying to remove a swep that was just holstered ).

Adjusted SafeRemoveEntityDelayed spacing to match SafeRemoveEntity.
