### PR TITLE
Fixed multiple line breaks in a row not appearing properly

### DIFF
--- a/garrysmod/lua/includes/modules/draw.lua
+++ b/garrysmod/lua/includes/modules/draw.lua
@@ -163,7 +163,7 @@ function DrawText(text, font, x, y, colour, xalign )
 			else -- there's no tabs, this is easy
 				SimpleText( str, font, curX, curY, colour, xalign )
 			end
-			
+		else
 			curX = x
 			curY = curY + (lineHeight/2)
 		end


### PR DESCRIPTION
Fixes a small mistake that made multiple line breaks in a row (for example "\n\n\n") not appear properly.
