### PR TITLE
Added Combo control for DProperties

### DIFF
--- a/garrysmod/lua/vgui/prop_combo.lua
+++ b/garrysmod/lua/vgui/prop_combo.lua
@@ -1,0 +1,45 @@
+local PANEL = {}
+
+function PANEL:Init()
+end
+
+function PANEL:Setup( vars )
+	
+	self:Clear()
+	
+	local combo = vgui.Create( "DComboBox", self )
+	combo:Dock( FILL )
+	combo:SetValue( vars or "Select..." )
+	
+	self.IsEditing = function( self )
+		return combo:IsMenuOpen()
+	end
+	
+	self.SetValue = function( self, id )
+		combo:ChooseOptionID( id )
+	end
+	
+	combo.OnSelect = function( _, id, val, data )
+		self:ValueChanged( { Index = id, Value = val, Data = data }, true )
+	end
+	
+	combo.Paint = function( combo, w, h )
+		
+		if self:IsEditing() or self:GetRow():IsHovered() or self:GetRow():IsChildHovered( 6 ) then
+			DComboBox.Paint( combo, w, h )
+		end
+		
+	end
+	
+	self:GetRow().AddChoice = function( self, value, data, select )
+		combo:AddChoice( value, data, select )
+	end
+	
+	self:GetRow().SetSelected = function( self, id )
+		combo:ChooseOptionID( id )
+	end
+	
+
+end
+
+derma.DefineControl( "DProperty_Combo", "", PANEL, "DProperty_Generic" )


### PR DESCRIPTION
![prop_combo](https://cloud.githubusercontent.com/assets/3105615/3893078/d9b42c4c-2237-11e4-8259-1ca153a56d11.png)
Usage:

``` lua
local DP = vgui.Create( "DProperties",  Panel )

local choice = DP:CreateRow( "Choices", "Combo #2: Custom default text" )
choice:Setup( "Combo", "Select type..." )
choice:AddChoice( "Table", {} )
choice:AddChoice( "Function", function()end )
choice:AddChoice( "String", "Hello world" )
choice.DataChanged = function( self, data )
    for k, v in pairs( data ) do
        print( k, v )
    end
end
```

I will make fully documented wiki pages if merged.
