### PR TITLE
Escape map names

### DIFF
--- a/garrysmod/lua/menu/getmaps.lua
+++ b/garrysmod/lua/menu/getmaps.lua
@@ -229,7 +229,7 @@ local function RefreshMaps()
 		if ( !Ignore ) then
 		
 			local Category = "Other"
-			local name = string.gsub( v, "%.bsp", "" )
+			local name = string.gsub( v, "%.bsp$", "" )
 			local lowername = string.lower( v )
 			
 			for pattern, category in pairs( MapPatterns ) do


### PR DESCRIPTION
Maps with bsp in them would be changed.
eg gm_bsptest becomes gm_test and the map is unable to be loaded from
the menu
