### PR TITLE
Pattern (and JavaScript) escaping betterness

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stool.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stool.lua
@@ -185,6 +185,8 @@ if ( CLIENT ) then
 	--
 	search.AddProvider( function( str )
 
+		str = str:PatternSafe()
+
 		local list = {}
 
 		for k, v in pairs( TOOLS_LIST ) do

--- a/garrysmod/gamemodes/sandbox/gamemode/cl_search_models.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/cl_search_models.lua
@@ -31,6 +31,8 @@ local model_list = nil
 --
 search.AddProvider( function( str )
 
+	str = str:PatternSafe()
+
 	if ( model_list == nil ) then
 
 		model_list = {}
@@ -71,6 +73,8 @@ end );
 -- Entity, vehicles
 --
 search.AddProvider( function( str )
+
+	str = str:PatternSafe()
 
 	local results = {}
 

--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -82,7 +82,7 @@ function string.Explode(separator, str, withpattern)
 	local index,lastPosition = 1,1
 	 
 	-- Escape all magic characters in separator
-	if not withpattern then separator = string_gsub( separator, "[%-%^%$%(%)%%%.%[%]%*%+%?]", "%%%1" ) end
+	if not withpattern then separator = separator:PatternSafe() end
 	 
 	-- Find the parts
 	for startPosition,endPosition in string_gmatch( str, "()" .. separator.."()" ) do
@@ -229,7 +229,7 @@ end
 
 
 function string.Replace( str, tofind, toreplace )
-	tofind = tofind:gsub( "[%-%^%$%(%)%%%.%[%]%*%+%?]", "%%%1" )
+	tofind = tofind:PatternSafe()
 	toreplace = toreplace:gsub( "%%", "%%%1" )
 	return ( str:gsub( tofind, toreplace ) )
 end
@@ -240,7 +240,7 @@ end
 		 Optionally pass char to trim that character from the ends instead of space
 -----------------------------------------------------------]]
 function string.Trim( s, char )
-	if char then char = char:gsub( "[%-%^%$%(%)%%%.%[%]%*%+%?]", "%%%1" ) else char = "%s" end
+	if char then char = char:PatternSafe() else char = "%s" end
 	return string.match( s, "^" .. char .. "*(.-)" .. char .. "*$" ) or s
 end
 
@@ -250,7 +250,7 @@ end
 		 Optionally pass char to trim that character from the ends instead of space
 -----------------------------------------------------------]]
 function string.TrimRight( s, char )
-	if char then char = char:gsub( "[%-%^%$%(%)%%%.%[%]%*%+%?]", "%%%1" ) else char = "%s" end
+	if char then char = char:PatternSafe() else char = "%s" end
 	return string.match( s, "^(.-)" .. char .. "*$" ) or s
 end
 
@@ -260,7 +260,7 @@ end
 		 Optionally pass char to trim that character from the ends instead of space
 -----------------------------------------------------------]]
 function string.TrimLeft( s, char )
-	if char then char = char:gsub( "[%-%^%$%(%)%%%.%[%]%*%+%?]", "%%%1" ) else char = "%s" end
+	if char then char = char:PatternSafe() else char = "%s" end
 	return string.match( s, "^" .. char .. "*(.+)$" ) or s
 end
 


### PR DESCRIPTION
Makes string.JavascriptSafe work more nicely
Adds string.PatternSafe, changing current code that escapes patterns to use it
Makes default search providers for Sandbox use string.PatternSafe, stopping the spawn menu from creating errors when special characters are passed to its search box.
