### PR TITLE
Workaround to fix -console until a proper fix is made

### DIFF
--- a/garrysmod/lua/menu/mainmenu.lua
+++ b/garrysmod/lua/menu/mainmenu.lua
@@ -313,10 +313,16 @@ end );
 --
 -- Initialize
 --
+
+
+RawConsoleCommand( "toggleconsole" )
+
 timer.Simple( 0, function()
 
 	pnlMainMenu = vgui.Create( "MainMenuPanel" );
 	pnlMainMenu:Call( "UpdateVersion( '"..VERSIONSTR.."', '"..BRANCH.."' )" );
+
+	RawConsoleCommand( "toggleconsole" )
 
 	local language = GetConVarString( "gmod_language" )
 	LanguageChanged( language )


### PR DESCRIPTION
This works and it won't flash console window for non "-console" users due to the console fade delay.

The console window would be created anyway even if console is not opened so there's no performance penalty that I'm aware of.

Believe me, I tried to find a better fix, but it's not possible. There's no way to have a background window with keyboard focus using Lua only that I'm aware of.
