### PR TITLE
make cookie module shared

### DIFF
--- a/garrysmod/lua/includes/init.lua
+++ b/garrysmod/lua/includes/init.lua
@@ -33,12 +33,11 @@ require ( "http" )
 require ( "net" )
 require ( "properties" )
 require ( "widget" )
+require ( "cookie" )
 
 require ( "drive" )
 include ( "drive/drive_base.lua" )
 include ( "drive/drive_noclip.lua" )
-
-require ( "cookie" )
 
 --[[---------------------------------------------------------
 	Serverside only modules


### PR DESCRIPTION
I don't see why it should be client only
Would also be nice to have this easy to use abstraction layer on the server

test:
![img](http://a.pomf.se/bphqgs.png)
