### PR TITLE
TTT: Update cl_equip.lua

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -163,7 +163,7 @@ local function TraitorMenuPopup()
    local can_order = credits > 0
 
    local dframe = vgui.Create("DFrame")
-   local w, h = 500, 350
+   local w, h = 570, 412
    dframe:SetSize(w, h)
    dframe:Center()
    dframe:SetTitle(GetTranslation("equip_title"))
@@ -209,7 +209,7 @@ local function TraitorMenuPopup()
    --- Construct icon listing
    local dlist = vgui.Create("EquipSelect", dequip)
    dlist:SetPos(0,0)
-   dlist:SetSize(154, h - 75)
+   dlist:SetSize(216, h - 75)
    dlist:EnableVerticalScrollbar(true)
    dlist:EnableHorizontal(true)
    dlist:SetPadding(4)
@@ -293,7 +293,7 @@ local function TraitorMenuPopup()
       dlist:AddPanel(ic)
    end
 
-   local dlistw = 154
+   local dlistw = 216
 
    local bw, bh = 100, 25
 


### PR DESCRIPTION
Make the buy menu bigger. Fits 12 items before scrolling is required (previously 6). This allows for all default Traitor items + 3 custom items before scrolling is required. (Previously required scrolling with just default Traitor items).
