### PR TITLE
Fixed STNDRD

### DIFF
--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -294,7 +294,7 @@ end
 local STNDRD_TBL = {"st", "nd", "rd"}
 function STNDRD( num )
 	num = num % 100
-	if ( mod100 > 10 and mod100 < 20 ) then
+	if ( num > 10 and num < 20 ) then
 		return "th"
 	end
 


### PR DESCRIPTION
With the old function, `STNDRD(111)` would return "st", and not "th" as expected.

It is also ~350% quicker in standard Lua, unsure of LuaJIT.
