### PR TITLE
Fixed bug with TriggerOutput for SENTs

### DIFF
--- a/garrysmod/gamemodes/base/entities/entities/base_entity/outputs.lua
+++ b/garrysmod/gamemodes/base/entities/entities/base_entity/outputs.lua
@@ -70,7 +70,7 @@ function ENT:TriggerOutput(name, activator)
 
 	for idx = #OutputList, 1, -1 do
 
-		if ( !FireSingleOutput( OutputList[idx], self.Entity, activator ) ) then
+		if ( OutputList[idx] and !FireSingleOutput( OutputList[idx], self.Entity, activator ) ) then
 
 			self.Outputs[name][idx] = nil
 


### PR DESCRIPTION
If a single-use output is fired on a SENT, the next time the output is triggered, an error will occur.

Fixes Facepunch/garrysmod-issues#1450
