### PR TITLE
Added math.Truncate( num, idp )

### DIFF
--- a/garrysmod/lua/includes/extensions/math.lua
+++ b/garrysmod/lua/includes/extensions/math.lua
@@ -195,10 +195,10 @@ end
 -----------------------------------------------------------]]
 function math.Truncate(num, idp)
 	
-	local mult = 10^d
-	local FloorOrCeil = n < 0 and math.ceil or math.floor
+	local mult = 10^(idp or 0)
+	local FloorOrCeil = num < 0 and math.ceil or math.floor
 	
-	return FloorOrCeil( n * mult ) / mult
+	return FloorOrCeil( num * mult ) / mult
 	
 end
 


### PR DESCRIPTION
**math.Round** rounds to the nearest integer.
**math.Truncate** rounds towards zero.

I needed it for some equations and thought I'd make a pull request for others.
This is practically the same function as math.Round, except it doesn't add 0.5, which makes it not rounds to the nearest integer.

``` lua
local num = 54.59874

print( math.Truncate( num, 2 ) ) -- 54.59
print( math.Round( num, 2 ) ) -- 54.6
```
