### PR TITLE
Minor toolgun screen changes

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/cl_viewscreen.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/cl_viewscreen.lua
@@ -17,6 +17,8 @@ local function DrawScrollingText( text, y, texwide )
 	local w, h = surface.GetTextSize( text  )
 	w = w + 64
 
+	y = y - h / 2 -- Center text to y position
+
 	local x = RealTime() * 250 % w * -1
 
 	while ( x < texwide ) do
@@ -69,7 +71,7 @@ function SWEP:RenderScreen()
 		else
 			
 			surface.SetFont( "GModToolScreen" )
-			DrawScrollingText( "#tool." .. mode .. ".name", 64, TEX_SIZE )
+			DrawScrollingText( "#tool." .. mode .. ".name", 104, TEX_SIZE )
 				
 		end
 


### PR DESCRIPTION
Just a couple of changes to the toolgun's text rendering that happened to be getting on my nerves.
It pretty much looks the same, but the position of the text on the screen no longer depends on the server's uptime and the text is positioned based on its height rather than at a hardcoded position.

It'd be neat to see a nicer looking background texture for the toolgun's screen though.
