### PR TITLE
Sandbox prop driving prediction fixes

### DIFF
--- a/garrysmod/lua/drive/drive_sandbox.lua
+++ b/garrysmod/lua/drive/drive_sandbox.lua
@@ -43,7 +43,7 @@ drive.Register( "drive_sandbox",
 		--
 		-- If we're holding the reload key down then freeze the view angles
 		--
-		if cmd:KeyDown( IN_RELOAD ) then
+		if ( cmd:KeyDown( IN_RELOAD ) ) then
 
 			self.CameraForceViewAngles = self.CameraForceViewAngles or cmd:GetViewAngles()
 


### PR DESCRIPTION
Fixes the view being locked to the wrong angle when holding reload to rotate the entity.
Fixes prediction issue when performing turns.
