### PR TITLE
Updated gameinfo.txt with VPK file paths

### DIFF
--- a/garrysmod/gameinfo.txt
+++ b/garrysmod/gameinfo.txt
@@ -1,24 +1,64 @@
 "GameInfo"
 {
-	game	"Garry's Mod"
-	title	""
-	title2	""
-	type 	multiplayer_only
+game "Garry's Mod"
+title ""
+title2 ""
+type multiplayer_only
 
-	"developer" 		"TEAM GARRY"
-	"developer_url" 	"http://www.garrysmod.com/"
-	"manual"           	"http://wiki.garrysmod.com/"
+"developer" "TEAM GARRY"
+"developer_url" "http://www.garrysmod.com/"
+"manual" "http://wiki.garrysmod.com/"
 
-	FileSystem
-	{
-		SteamAppId				4000 // 218
-		ToolsAppId				211
-		
-		SearchPaths
-		{
-			Game				|gameinfo_path|.
-			Game				hl2
-			Game                            |all_source_engine_paths|hl2
-		}
-	}
+FileSystem
+{
+SteamAppId 4000 // 218
+ToolsAppId 211
+
+SearchPaths
+{
+// First, mount all user customizations. This will search for VPKs and subfolders
+// and mount them in alphabetical order. The easiest way to distribute a mod is to
+// pack up the custom content into a VPK. To "install" a mod, just drop it in this
+// folder.
+//
+// Note that this folder is scanned only when the game is booted.
+game+mod garrysmod/custom/*
+
+// Now search loose files. We'll set the directory containing the gameinfo.txt file
+// as the first "mod" search path (after any user customizations). This is also the one
+// that's used when writing to the "mod" path.
+game+mod+mod_write+default_write_path |gameinfo_path|.
+gamebin |gameinfo_path|bin
+
+// We search VPK files before ordinary folders, because most files will be found in
+// VPK and we can avoid making thousands of file system calls to attempt to open files
+// in folders where they don't exist. (Searching a VPK is much faster than making an operating
+// system call.)
+game+mod garrysmod/garrysmod.vpk
+game+mod garrysmod/fallbacks.vpk
+game |all_source_engine_paths|hl2/hl2_english.vpk
+game |all_source_engine_paths|hl2/hl2_pak.vpk
+game |all_source_engine_paths|hl2/hl2_textures.vpk
+game |all_source_engine_paths|hl2/hl2_sound_vo_english.vpk
+game |all_source_engine_paths|hl2/hl2_sound_misc.vpk
+game |all_source_engine_paths|hl2/hl2_misc.vpk
+platform |all_source_engine_paths|platform/platform_misc.vpk
+
+// Add the HL2 directory as a game search path. This is also where where writes
+// to the "game" path go.
+game+game_write hl2
+
+// Where the game's binaries are
+gamebin garrysmod/bin
+
+// Last, mount in shared HL2 loose files
+game |all_source_engine_paths|hl2mp
+game |all_source_engine_paths|hl2
+platform |all_source_engine_paths|platform
+
+// Last, do the actual gmod default gameinfo.
+game hl2
+game |all_source_engine_paths|hl2
 }
+}
+} 


### PR DESCRIPTION
An updated gameinfo.txt that finally adds proper VPK file paths. This means that modders (especially Hammer users) will not have to copy and paste the file paths again if gameinfo.txt is modified; which happens occasionally after an update.
