### PR TITLE
Change how RoundedBoxEx renders corners to fix 3D2D appearence

### DIFF
--- a/garrysmod/lua/includes/modules/draw.lua
+++ b/garrysmod/lua/includes/modules/draw.lua
@@ -208,25 +208,25 @@ function RoundedBoxEx( bordersize, x, y, w, h, color, a, b, c, d )
 	surface.SetTexture( tex )
 	
 	if ( a ) then
-		surface.DrawTexturedRectRotated( x + bordersize/2 , y + bordersize/2, bordersize, bordersize, 0 ) 
+		surface.DrawTexturedRectUV( x, y, bordersize, bordersize, 0, 0, 1, 1 )
 	else
 		surface.DrawRect( x, y, bordersize, bordersize )
 	end
 	
 	if ( b ) then
-		surface.DrawTexturedRectRotated( x + w - bordersize/2 , y + bordersize/2, bordersize, bordersize, 270 ) 
+		surface.DrawTexturedRectUV( x +w -bordersize, y, bordersize, bordersize, 1, 0, 0, 1 )
 	else
 		surface.DrawRect( x + w - bordersize, y, bordersize, bordersize )
 	end
  
 	if ( c ) then
-		surface.DrawTexturedRectRotated( x + bordersize/2 , y + h -bordersize/2, bordersize, bordersize, 90 )
+		surface.DrawTexturedRectUV( x, y +h -bordersize, bordersize, bordersize, 0, 1, 1, 0 )
 	else
 		surface.DrawRect( x, y + h - bordersize, bordersize, bordersize )
 	end
  
 	if ( d ) then
-		surface.DrawTexturedRectRotated( x + w - bordersize/2 , y + h - bordersize/2, bordersize, bordersize, 180 )
+		surface.DrawTexturedRectUV( x +w -bordersize, y +h -bordersize, bordersize, bordersize, 1, 1, 0, 0 )
 	else
 		surface.DrawRect( x + w - bordersize, y + h - bordersize, bordersize, bordersize )
 	end


### PR DESCRIPTION
DrawTexturedRectRotated forces the engine to use mipmaps for the corner texture, causing some transparent bleed.

This method achieves the same effect without artifacts by mirroring the corner texture, instead of rotating it.
