### PR TITLE
Fix error sometimes breaking the TTT gamemode

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/ent_replace.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/ent_replace.lua
@@ -175,7 +175,7 @@ local broken_parenting_ents = {
 function ents.TTT.FixParentedPreCleanup()
    for _, rcls in pairs(broken_parenting_ents) do
       for k,v in pairs(ents.FindByClass(rcls)) do
-         if IsValid(v:GetParent()) then
+         if v.GetParent and IsValid(v:GetParent()) then
             v.CachedParentName = v:GetParent():GetName()
             v:SetParent(nil)
 


### PR DESCRIPTION
v.GetParent sometimes doesn't exist on the "broken_parenting_ents", it's a rare issue but it breaks the gamemode as the map needs to be manually changed if it happens
