### PR TITLE
Add min/max functionality to DFrame

### DIFF
--- a/garrysmod/lua/skins/default.lua
+++ b/garrysmod/lua/skins/default.lua
@@ -598,11 +598,23 @@ function SKIN:PaintWindowMaximizeButton( panel, w, h )
 	end
 	
 	if ( panel.Depressed || panel:IsSelected() ) then
-		return self.tex.Window.Maxi_Down( 0, 0, w, h )
+		if ( panel.bMaximized || panel.bMinimized ) then
+			return self.tex.Window.Restore_Down( 0, 0, w, h )
+		else
+			return self.tex.Window.Maxi_Down( 0, 0, w, h )
+		end
 	end
 	
 	if ( panel.Hovered ) then
-		return self.tex.Window.Maxi_Hover( 0, 0, w, h )
+		if ( panel.bMaximized || panel.bMinimized ) then
+			return self.tex.Window.Restore_Hover( 0, 0, w, h )
+		else
+			return self.tex.Window.Maxi_Hover( 0, 0, w, h )
+		end
+	end
+
+	if ( panel.bMaximized || panel.bMinimized ) then
+		return self.tex.Window.Restore( 0, 0, w, h )
 	end
 
 	self.tex.Window.Maxi( 0, 0, w, h )


### PR DESCRIPTION
**Adds Get/Set methods for minimise, maximise and min/max animations, and integrates this functionality in the control box buttons.**
- Uses panel's native animations (optionally disabled).
- Adds OnMinimized, OnMaximized and OnRestored hooks.
- Updates maxmise button paint function in default skin for min/max restore.
- Uses Americanised keywords to match Garry's usage.
- Max/min state hierarchy and button icons matched to standard GUI windows:
  - Maximise button restores minimised window
  - Minimise button minimises even when maximised
  - Window is maximised on restore if was so before minimised
  - Restore icon shown in maximise button if minimised or maximised
