### PR TITLE
Entity:HookOutput( ), Entity:UnhookOutput( )

### DIFF
--- a/garrysmod/lua/entities/info_output_hook.lua
+++ b/garrysmod/lua/entities/info_output_hook.lua
@@ -1,7 +1,5 @@
 DEFINE_BASECLASS( "base_point" )
 
-ENT.Hooks = { }
-
 local this, meta, hooks, fmt
 
 hooks = { }
@@ -37,11 +35,10 @@ function meta:UnhookOutput( name, uid )
 end
 
 function ENT:Initialize( )
-	hook.Add( "EntityRemoved", self, self.EntityRemoved )
 end
 
 function ENT:AcceptInput( name, activator, caller, data )
-	local k, v, ok, err
+	local ok, err
 	
 	if hooks[ caller ] then
 		if hooks[ caller ][ name ] then
@@ -63,12 +60,8 @@ function ENT:AcceptInput( name, activator, caller, data )
 	return true
 end
 
-function ENT:EntityRemoved( e )
-	if not IsValid( self ) then
-		this = ents.Create( "info_output_hook" )
-			this:SetName( "__this" )
-		this:Spawn( )
-
-		hook.Add( "EntityRemoved", this, this.EntityRemoved )
-	end
+function ENT:OnRemove( )
+	this = ents.Create( "info_output_hook" )
+		this:SetName( "__this" )
+	this:Spawn( )
 end

--- a/garrysmod/lua/entities/info_output_hook.lua
+++ b/garrysmod/lua/entities/info_output_hook.lua
@@ -1,0 +1,74 @@
+DEFINE_BASECLASS( "base_point" )
+
+ENT.Hooks = { }
+
+local this, meta, hooks, fmt
+
+hooks = { }
+
+meta = FindMetaTable( "Entity" )
+
+fmt = "%s __this,%s"
+
+function meta:HookOutput( name, uid, func )
+	if not IsValid( this ) then
+		this = ents.Create( "info_output_hook" )
+			this:SetName( "__this" )
+		this:Spawn( )
+	end
+
+	hooks[ self ] = hooks[ ent ] or { }
+	hooks[ self ][ name ] = hooks[ self ][ name ] or { }
+	hooks[ self ][ name ][ uid ] = func
+
+	self:Fire( "AddOutput", fmt:format( name, name ), 0 )
+end
+
+function meta:UnhookOutput( name, uid )
+	if not IsValid( this ) then
+		this = ents.Create( "info_output_hook" )
+			this:SetName( "__this" )
+		this:Spawn( )
+	end
+
+	hooks[ self ] = hooks[ ent ] or { }
+	hooks[ self ][ name ] = hooks[ self ][ name ] or { }
+	hooks[ self ][ name ][ uid ] = nil
+end
+
+function ENT:Initialize( )
+	hook.Add( "EntityRemoved", self, self.EntityRemoved )
+end
+
+function ENT:AcceptInput( name, activator, caller, data )
+	local k, v, ok, err
+	
+	if hooks[ caller ] then
+		if hooks[ caller ][ name ] then
+			for k, v in pairs( hooks[ caller ][ name ] ) do
+				
+				if IsValid( k ) then
+					ok, err = pcall( v, k, caller, activator, data )
+				else
+					ok, err = pcall( v, caller, activator, data )
+				end
+				
+				if not ok then
+					ErrorNoHalt( "Output hook failed: " .. name .. "::" .. k .. " - " .. err .. "\n" )
+				end
+			end
+		end
+	end
+	
+	return true
+end
+
+function ENT:EntityRemoved( e )
+	if not IsValid( self ) then
+		this = ents.Create( "info_output_hook" )
+			this:SetName( "__this" )
+		this:Spawn( )
+
+		hook.Add( "EntityRemoved", this, this.EntityRemoved )
+	end
+end


### PR DESCRIPTION
Creates Entity:HookOutput( name, uid, func ) and Entity:UnhookOutput( name, uid ) to catch entity outputs, especially engine ones. Conforms to the behavior of hooks, where passing the entity as the uid causes it to be passed to the function.

Could obviously use some improvement, but it is currently the only vanilla way to do this that I know.
