### PR TITLE
Unrestrict thin ropes.

### DIFF
--- a/garrysmod/lua/includes/modules/constraint.lua
+++ b/garrysmod/lua/includes/modules/constraint.lua
@@ -327,7 +327,7 @@ function CreateKeyframeRope( Pos, width, material, Constraint, Ent1, LPos1, Bone
 	if ( width <= 0 ) then return nil end
 	
 	-- Clamp the rope to a sensible width
-	width = math.Clamp( width, 1, 100 )
+	width = math.Clamp( width, 0, 100 )
 
 	local rope = ents.Create( "keyframe_rope" )
 	rope:SetPos( Pos )

--- a/garrysmod/lua/includes/modules/constraint.lua
+++ b/garrysmod/lua/includes/modules/constraint.lua
@@ -327,7 +327,7 @@ function CreateKeyframeRope( Pos, width, material, Constraint, Ent1, LPos1, Bone
 	if ( width <= 0 ) then return nil end
 	
 	-- Clamp the rope to a sensible width
-	width = math.min( width, 100 )
+	width = math.Clamp( width, 0.2, 100 )
 
 	local rope = ents.Create( "keyframe_rope" )
 	rope:SetPos( Pos )

--- a/garrysmod/lua/includes/modules/constraint.lua
+++ b/garrysmod/lua/includes/modules/constraint.lua
@@ -327,7 +327,7 @@ function CreateKeyframeRope( Pos, width, material, Constraint, Ent1, LPos1, Bone
 	if ( width <= 0 ) then return nil end
 	
 	-- Clamp the rope to a sensible width
-	width = math.Clamp( width, 0, 100 )
+	width = math.min( width, 100 )
 
 	local rope = ents.Create( "keyframe_rope" )
 	rope:SetPos( Pos )


### PR DESCRIPTION
Will ignore ropes with 0 width, but should allow ropes with width < 1.
