### PR TITLE
Autorun lua_run entity's code if spawnflag is set

### DIFF
--- a/garrysmod/gamemodes/base/entities/entities/lua_run.lua
+++ b/garrysmod/gamemodes/base/entities/entities/lua_run.lua
@@ -13,12 +13,17 @@ end
 
 --[[---------------------------------------------------------
    Name: KeyValue
-   Desc:
+   Desc: Sets the default code and runs it if appropriate spawnflags are set
 -----------------------------------------------------------]]
 function ENT:KeyValue( key, value )
 
 	if ( key == "Code" ) then
 		self:SetDefaultCode( value )
+		
+		if self:HasSpawnFlags(1) then
+			self:RunCode( NULL, NULL, self:GetDefaultCode() ) 
+		end
+		
 	end
 
 end


### PR DESCRIPTION
This edit would run lua_run entities code when its created if its spawnflag is set. This will eliminate the need to trigger the entity with a logic_auto when all you want to do is run a piece of code once when the map loads. 
I'm running it in the KeyValue hook so it should get called before anything is created, instead after entities are spawned.

Also, does Garry's mod have an official fgd for hammer? I know there are some floating around but I feel that one should be included .
I could look into fixing one up and merge it if that is okay
