### PR TITLE
Add net overflow checking

### DIFF
--- a/garrysmod/lua/includes/extensions/net.lua
+++ b/garrysmod/lua/includes/extensions/net.lua
@@ -109,7 +109,9 @@ function net.WriteTable( tab )
 	
 	-- End of table
 	net.WriteType( nil )
-
+	
+	assert( !net.HasOverflowed(), "WriteTable overflowed" )
+	
 end
 
 function net.ReadTable()
@@ -152,7 +154,9 @@ function net.WriteType( v )
 	end
 
 	local wv = net.WriteVars[ typeid ]
-	if ( wv ) then return wv( typeid, v ) end
+	if ( wv ) then 
+		return wv( typeid, v ) 
+	end
 	
 	error( "net.WriteType: Couldn't write " .. type( v ) .. " (type " .. typeid .. ")" )
 
@@ -180,4 +184,8 @@ function net.ReadType( typeid )
 	if ( rv ) then return rv() end
 
 	error( "net.ReadType: Couldn't read type " .. typeid )
+end
+
+function net.HasOverflowed()
+	return (net.BytesWritten() or 0) >= 65536
 end


### PR DESCRIPTION
Add net.HasOverflowed() for write overflow detection.
Make net.WriteTable check for this overflow.

NOTE: This PR is more likely to provide discussion for this issue than get approved.

net.WriteTable now errors if the table is too big instead of client getting cryptic errors of failed to read tables. This can happen and too few addons check for this. If you are sending 64kb in a table you are most likely doing something wrong already. The question is should we keep graceful degradation or provide explicit error signaling. With explicit error you can still continue sending the table if you trap the WriteTable assert so this does not reduce functionality in the long run.

As further improvement net.Send\* functions could have an extra parameter to check/not check for this instead and through that provide universal signaling.

What do you think?
