### PR TITLE
Fix indexing nil field ''ActivityTranslate'

### DIFF
--- a/garrysmod/gamemodes/base/entities/weapons/weapon_base/sh_anim.lua
+++ b/garrysmod/gamemodes/base/entities/weapons/weapon_base/sh_anim.lua
@@ -71,6 +71,10 @@ SWEP:SetWeaponHoldType( "pistol" )
 -----------------------------------------------------------]]
 function SWEP:TranslateActivity( act )
 
+	if self.ActivityTranslateAI == nil then
+		return -1
+	end
+	
 	if ( self.Owner:IsNPC() ) then
 		if ( self.ActivityTranslateAI[ act ] ) then
 			return self.ActivityTranslateAI[ act ]


### PR DESCRIPTION
```
XXX|137|STEAM_0:0

[ERROR] gamemodes/base/entities/weapons/weapon_base/sh_anim.lua:81: attempt to index field 'ActivityTranslate' (a nil value)
  1. unknown - gamemodes/base/entities/weapons/weapon_base/sh_anim.lua:81
   2. TranslateWeaponActivity - [C]:-1
    3. unknown - gamemodes/base/gamemode/animations.lua:335
```
