### PR TITLE
Add utf8.sub

### DIFF
--- a/garrysmod/lua/includes/modules/utf8.lua
+++ b/garrysmod/lua/includes/modules/utf8.lua
@@ -331,3 +331,25 @@ function force( str )
 	return table.concat( buf, "" )
 
 end
+
+--
+-- Returns a substring consisting given range (as measured in utf8-characters)
+--
+function sub( str, startPos, endPos )
+
+	local startOffset = utf8.offset( str, startPos - 1 )
+
+	local endOffset
+	if endPos then
+		-- convert negative endPos to a absolute positive position
+		endPos = ( endPos > 0 ) and endPos or ( utf8.len( str ) + 1 + endPos )
+
+		-- utf8.offset returns the start byte for given position, so due to
+		-- endPos being exclusive we can subtract one to get end-byte of last 
+		-- utf8 character
+		endOffset = utf8.offset( str, endPos ) - 1
+	end
+
+	return string.sub( str, startOffset, endOffset )
+
+end


### PR DESCRIPTION
Tests used ( @willox can you verify that I did not miss some crucial testcase ):

``` lua

local ssub, usub = string.sub, utf8.sub

assert(ssub("abcabc", 2) == usub("abcabc", 2))
assert(ssub("abcabc", 3, 5) == usub("abcabc", 3, 5))
assert(ssub("abcabc", 3, -2) == usub("abcabc", 3, -2))
assert(ssub("abcabc", 3, -10) == usub("abcabc", 3, -10))

assert(utf8.sub("ääaää", 2) == "äaää")
assert(utf8.sub("ääaää", 1, 3) == "ääa")
assert(utf8.sub("ääaää", 3, -2) == "aä")
assert(utf8.sub("ääaää", 3, -4) == "")
```
