### PR TITLE
Added player class Death hook

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/player.lua
+++ b/garrysmod/gamemodes/base/gamemode/player.lua
@@ -175,6 +175,8 @@ function GM:PlayerDeath( ply, inflictor, attacker )
 
 	end
 
+	player_manager.RunClass( ply, "Death", inflictor, attacker )
+
 	if ( attacker == ply ) then
 	
 		net.Start( "PlayerKilledSelf" )

--- a/garrysmod/gamemodes/base/gamemode/player_class/player_default.lua
+++ b/garrysmod/gamemodes/base/gamemode/player_class/player_default.lua
@@ -71,6 +71,9 @@ function PLAYER:SetModel()
 
 end
 
+function PLAYER:Death( inflictor, attacker )
+end
+
 -- Clientside only
 function PLAYER:CalcView( view ) end		-- Setup the player's view
 function PLAYER:CreateMove( cmd ) end		-- Creates the user command on the client


### PR DESCRIPTION
A curious omission from the player class library. Would make it easier (and cleaner) to write player classes without any extra hook nonsense.
