### PR TITLE
Allow multiple hooks to modify the bullet structure

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/shared.lua
+++ b/garrysmod/gamemodes/base/gamemode/shared.lua
@@ -278,3 +278,10 @@ end
 function GM:CanProperty( pl, property, ent )
 	return false
 end
+
+--[[---------------------------------------------------------
+	Allow hooks to override bullet without ignoring all other hooks
+-----------------------------------------------------------]]
+function GM:EntityFireBullets( ent, bullets )
+	return true
+end


### PR DESCRIPTION
This is very necessary if multiple things have to modify the bullet structure without breaking other hooks.
