### PR TITLE
Add table.ShallowCopy and use it instead of table.Copy in SortedPairs* and RandomPairs

### DIFF
--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -514,7 +514,7 @@ end
 -----------------------------------------------------------]]
 function SortedPairs( pTable, Desc )
 
-	pTable = table.Copy( pTable )
+	pTable = table.ShallowCopy( pTable )
 
 	local SortedIndex = {}
 	for k, v in pairs( pTable ) do
@@ -539,7 +539,7 @@ end
 -----------------------------------------------------------]]
 function SortedPairsByValue( pTable, Desc )
 
-	pTable = table.Copy( pTable )
+	pTable = table.ShallowCopy( pTable )
 
 	local SortedIndex = {}
 	for k, v in pairs( pTable ) do
@@ -568,7 +568,7 @@ end
 -----------------------------------------------------------]]
 function SortedPairsByMemberValue( pTable, pValueName, Desc )
 
-	pTable = table.Copy( pTable )
+	pTable = table.ShallowCopy( pTable )
 	Desc = Desc or false
 
 	local pSortedTable = table.ClearKeys( pTable, true )
@@ -591,7 +591,7 @@ end
 -----------------------------------------------------------]]
 function RandomPairs( pTable, Desc )
 
-	pTable = table.Copy( pTable )
+	pTable = table.ShallowCopy( pTable )
 
 	local SortedIndex = {}
 	for k, v in pairs( pTable ) do

--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -43,6 +43,23 @@ function table.Copy( t, lookup_table )
 end
 
 --[[---------------------------------------------------------
+	Name: ShallowCopy( source_table )
+	Desc: Copies a table without recursively copying
+		tables that are members.
+-----------------------------------------------------------]]
+function table.ShallowCopy( source_table )
+	if ( source_table == nil ) then return end
+
+	local copy = {}
+
+	for k, v in pairs( source_table ) do
+		copy[ k ] = v
+	end
+
+	return copy
+end
+
+--[[---------------------------------------------------------
 	Name: Empty( tab )
 	Desc: Empty a table
 -----------------------------------------------------------]]


### PR DESCRIPTION
Previously, said functions were unnecessarily creating deep copies of the input table, which is slower than a simple shallow copy. I have also made it a function in the table library so others can use it without writing extra code.

This fixes Facepunch/garrysmod-issues#2183