### PR TITLE
Fix CallOnRemove on Players

### DIFF
--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -139,7 +139,8 @@ local function DoDieFunction( ent )
 
 end
 
-hook.Add( "EntityRemoved", "DoDieFunction", DoDieFunction )
+hook.Add( "EntityRemoved", "DoDieFunction", function(ent) if ent:IsPlayer() then return end return DoDieFunction(ent) end )
+hook.Add( "PlayerDisconnected", "DoDieFunction", DoDieFunction )
 
 function meta:PhysWake()
 


### PR DESCRIPTION
Fix http://wiki.garrysmod.com/page/Entity/CallOnRemove on players.
The player entity in EntityRemoved is not the player entity in PlayerDisconnected, it does not even have the old player's entity table.