### PR TITLE
Base: Add Identifier to RunString on lua_run Entity

### DIFF
--- a/garrysmod/gamemodes/base/entities/entities/lua_run.lua
+++ b/garrysmod/gamemodes/base/entities/entities/lua_run.lua
@@ -5,6 +5,9 @@ ENT.DisableDuplicator = true
 AccessorFunc( ENT, "m_bDefaultCode", "DefaultCode" )
 
 function ENT:Initialize()
+
+	self.RunStringID = game.GetMap() .. ":" .. self:MapCreationID()
+
 end
 
 function ENT:KeyValue( key, value )
@@ -38,7 +41,7 @@ function ENT:RunCode( activator, caller, code )
 
 	self:SetupGlobals( activator, caller )
 
-		RunString( code )
+		RunString( code, self.RunStringID )
 
 	self:KillGlobals()
 


### PR DESCRIPTION
If a map causes an lua error message, it is indicated that it comes through this by adding the map name as identifier.

Can be very useful when searching the source of an error message that is caused by this.