### PR TITLE
Add CompoundLerp

### DIFF
--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -219,6 +219,22 @@ function Lerp( delta, from, to )
 end
 
 --[[---------------------------------------------------------
+	Compound lerp
+-----------------------------------------------------------]]
+function CompoundLerp( percent, delta, from, to )
+	
+	if ( percent >= 1 ) then return to end
+	if ( percent <= 0 ) then return from end
+	
+	if ( delta <= 0 ) then return from end
+	
+	local t = 1 - ( 1 - percent ) ^ delta
+	
+	return from + t * ( from - to )
+	
+end
+
+--[[---------------------------------------------------------
 	Convert Var to Bool
 -----------------------------------------------------------]]
 function tobool( val )


### PR DESCRIPTION
Allows you to lerp variables smoothly every frame regardless of FPS/tick rate in Think/Render hooks, for example:

```Lua
-- after 1 second self.Var will be 95% from its initial position to 8
self.Var = CompoundLerp( 0.95, FrameTime(), self.Var, 8 )

-- after 3 seconds self.Var will be 65% from its initial position to 8
self.Var = CompoundLerp( 0.65, 0.33 * FrameTime(), self.Var, 8 )
```