### PR TITLE
Add hook SANDBOX:ShouldHideTool to hide tools

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/toolpanel.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/toolpanel.lua
@@ -66,6 +66,8 @@ function PANEL:AddCategory( Name, Label, tItems )
 
 	for k, v in SortedPairs( tools ) do
 
+		if ( hook.Run( "ShouldHideTool", v.ItemName ) ) then continue end
+		
 		local item = Category:Add( v.Text )
 
 		item.DoClick = function( button )

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/toolpanel.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/toolpanel.lua
@@ -66,7 +66,7 @@ function PANEL:AddCategory( Name, Label, tItems )
 
 	for k, v in SortedPairs( tools ) do
 
-		if ( hook.Run( "ShouldHideTool", v.ItemName ) ) then continue end
+		if ( hook.Run( "ShouldHideTool", v ) ) then continue end
 		
 		local item = Category:Add( v.Text )
 


### PR DESCRIPTION
Allow addons to hide tools from the tool menu. It is already possible to disallow the use of a tool by a player by means of the SANDBOX:CanTool hook, however, tools still remain visible in the tool menu.

Adding this hook would allow server owners who wish to restrict tool use to also hide these tools.

This feature is requested from the following thread: https://facepunch.com/showthread.php?t=1545453
Feature was also requested here: https://github.com/Facepunch/garrysmod-requests/issues/612

Example usage:
```lua
hook.Add( "ShouldHideTool", "TESTING", function( tool )
	
	if ( tool.ItemName == "hoverball" ) then return true end

end)
```