### PR TITLE
Ported UTIL_ClipTraceToPlayers to util.ClipTraceToPlayers

### DIFF
--- a/garrysmod/lua/includes/extensions/util.lua
+++ b/garrysmod/lua/includes/extensions/util.lua
@@ -362,7 +362,7 @@ local function DistanceToTrace( pos, traceStart, traceEnd, along, pointOnTrace )
 		along = rangeAlong
 	end
 
-	local range
+	local range = 0
 	if rangeAlong < 0.0 then
 		range = -(pos - traceStart):Length()
 

--- a/garrysmod/lua/includes/extensions/util.lua
+++ b/garrysmod/lua/includes/extensions/util.lua
@@ -394,7 +394,7 @@ function util.ClipTraceToPlayers( vecAbsStart, vecAbsEnd, mask, filter, tr )
 	local trace = { start = vecAbsStart, endpos = vecAbsEnd, filter = filter, mask = bit.bor(mask, CONTENTS_HITBOX) }
 	
 	for _, ply in pairs(player.GetAll()) do
-		if !IsValid(ply) or !ply:Alive() then continue end
+		if !IsValid(ply) || !ply:Alive() then continue end
 		if ply:IsDormant() then continue end
 
 		local range = DistanceToTrace( ply:WorldSpaceCenter(), vecAbsStart, vecAbsEnd )

--- a/garrysmod/lua/includes/extensions/util.lua
+++ b/garrysmod/lua/includes/extensions/util.lua
@@ -367,20 +367,20 @@ local function DistanceToTrace( pos, traceStart, traceEnd, along, pointOnTrace )
 	if rangeAlong < 0.0 then
 		range = -(pos - traceStart):Length()
 
-		if pointOnRay then
-			pointOnRay = traceStart
+		if pointOnTrace then
+			pointOnTrace = traceStart
 		end
 	elseif rangeAlong > length then
 		range = -(pos - traceEnd):Length()
 
-		if pointOnRay then
-			pointOnRay = traceEnd
+		if pointOnTrace then
+			pointOnTrace = traceEnd
 		end
 	else
-		local onRay = traceStart + rangeAlong * dir
+		local onTrace = traceStart + rangeAlong * dir
 		range = (pos - onTrace):Length()
 
-		if pointOnRay then
+		if pointOnTrace then
 			pointOnTrace = onTrace
 		end
 	end

--- a/garrysmod/lua/includes/extensions/util.lua
+++ b/garrysmod/lua/includes/extensions/util.lua
@@ -355,7 +355,9 @@ end
 local function DistanceToTrace( pos, traceStart, traceEnd, along, pointOnTrace )
 	local to = pos - traceStart
 	local dir = traceEnd - traceStart
-	local length = dir:Normalize()
+	
+	dir:Normalize()
+	local length = dir
 
 	local rangeAlong = dir:Dot(to)
 	if along then

--- a/garrysmod/lua/includes/extensions/util.lua
+++ b/garrysmod/lua/includes/extensions/util.lua
@@ -355,8 +355,7 @@ end
 local function DistanceToTrace( pos, traceStart, traceEnd, along, pointOnTrace )
 	local to = pos - traceStart
 	local dir = traceEnd - traceStart
-	//Dunno if NormalizeInPlace translates to GetNormalized or Normalize
-	local length = dir:GetNormalized()
+	local length = dir:Normalize()
 
 	local rangeAlong = dir:Dot(to)
 	if along then

--- a/garrysmod/lua/includes/extensions/util.lua
+++ b/garrysmod/lua/includes/extensions/util.lua
@@ -355,9 +355,8 @@ end
 local function DistanceToTrace( pos, traceStart, traceEnd, along, pointOnTrace )
 	local to = pos - traceStart
 	local dir = traceEnd - traceStart
-	
+	local length = dir:Length()
 	dir:Normalize()
-	local length = dir
 
 	local rangeAlong = dir:Dot(to)
 	if along then

--- a/garrysmod/lua/includes/extensions/util.lua
+++ b/garrysmod/lua/includes/extensions/util.lua
@@ -352,41 +352,6 @@ end
    Name: ClipTraceToPlayers
    Desc: Traces across players and returns a modified trace
 -----------------------------------------------------------]]
-local function DistanceToTrace( pos, traceStart, traceEnd, along, pointOnTrace )
-	local to = pos - traceStart
-	local dir = traceEnd - traceStart
-	local length = dir:Length()
-	dir:Normalize()
-
-	local rangeAlong = dir:Dot(to)
-	if along then
-		along = rangeAlong
-	end
-
-	local range = 0
-	if rangeAlong < 0.0 then
-		range = -(pos - traceStart):Length()
-
-		if pointOnTrace then
-			pointOnTrace = traceStart
-		end
-	elseif rangeAlong > length then
-		range = -(pos - traceEnd):Length()
-
-		if pointOnTrace then
-			pointOnTrace = traceEnd
-		end
-	else
-		local onTrace = traceStart + rangeAlong * dir
-		range = (pos - onTrace):Length()
-
-		if pointOnTrace then
-			pointOnTrace = onTrace
-		end
-	end
-
-	return range
-end
 function util.ClipTraceToPlayers( vecAbsStart, vecAbsEnd, mask, filter, tr )
 	local smallestFraction = tr.Fraction
 	local maxRange = 60.0
@@ -397,10 +362,10 @@ function util.ClipTraceToPlayers( vecAbsStart, vecAbsEnd, mask, filter, tr )
 		if !IsValid(ply) || !ply:Alive() then continue end
 		if ply:IsDormant() then continue end
 
-		local range = DistanceToTrace( ply:WorldSpaceCenter(), vecAbsStart, vecAbsEnd )
+		//I think util.DistanceToLine is the same as DistanceToRay
+		local range = util.DistanceToLine(vecAbsStart, vecAbsEnd, ply:WorldSpaceCenter())
 		if (range < 0.0 || range > maxRange) then continue end
 
-		//I couldn't find the code for ClipRayToEntity to hopefully util.TraceEntity works the same - FMX
 		local playerTrace = util.TraceEntity( trace, ply )
 		if ( playerTrace.Fraction < smallestFraction )
 			smallestFraction = playerTrace.Fraction


### PR DESCRIPTION
Since there's no way to call it from LUA I decided to port over UTIL_ClipTraceToPlayers to LUA. I'd need someone to look this over though as some functions I do not know if they work the same as they did in the C++ version.

Check the comments I left