### PR TITLE
Added weapons/scripted_ents.PreRegistered hook

### DIFF
--- a/garrysmod/lua/includes/modules/scripted_ents.lua
+++ b/garrysmod/lua/includes/modules/scripted_ents.lua
@@ -52,6 +52,8 @@ end
 
 function Register( t, name )
 
+	if ( hook.Run( "PreSENTRegister", t, name ) == true ) then return end
+
 	local Base = t.Base
 	if ( !Base ) then Base = BaseClasses[ t.Type ] end
 

--- a/garrysmod/lua/includes/modules/scripted_ents.lua
+++ b/garrysmod/lua/includes/modules/scripted_ents.lua
@@ -52,7 +52,7 @@ end
 
 function Register( t, name )
 
-	if ( hook.Run( "PreRegisterSENT", t, name ) == true ) then return end
+	if ( hook.Run( "PreRegisterSENT", t, name ) == false ) then return end
 
 	local Base = t.Base
 	if ( !Base ) then Base = BaseClasses[ t.Type ] end

--- a/garrysmod/lua/includes/modules/scripted_ents.lua
+++ b/garrysmod/lua/includes/modules/scripted_ents.lua
@@ -52,7 +52,7 @@ end
 
 function Register( t, name )
 
-	if ( hook.Run( "PreSENTRegister", t, name ) == true ) then return end
+	if ( hook.Run( "PreRegisterSENT", t, name ) == true ) then return end
 
 	local Base = t.Base
 	if ( !Base ) then Base = BaseClasses[ t.Type ] end

--- a/garrysmod/lua/includes/modules/weapons.lua
+++ b/garrysmod/lua/includes/modules/weapons.lua
@@ -45,7 +45,7 @@ end
 -----------------------------------------------------------]]
 function Register( t, name )
 
-	if ( hook.Run( "PreWeaponRegister", t, name ) == true ) then return end
+	if ( hook.Run( "PreRegisterSWEP", t, name ) == true ) then return end
 
 	local old = WeaponList[ name ]
 

--- a/garrysmod/lua/includes/modules/weapons.lua
+++ b/garrysmod/lua/includes/modules/weapons.lua
@@ -45,6 +45,8 @@ end
 -----------------------------------------------------------]]
 function Register( t, name )
 
+	if ( hook.Run( "PreWeaponRegister", t, name ) == true ) then return end
+
 	local old = WeaponList[ name ]
 
 	t.ClassName = name

--- a/garrysmod/lua/includes/modules/weapons.lua
+++ b/garrysmod/lua/includes/modules/weapons.lua
@@ -45,7 +45,7 @@ end
 -----------------------------------------------------------]]
 function Register( t, name )
 
-	if ( hook.Run( "PreRegisterSWEP", t, name ) == true ) then return end
+	if ( hook.Run( "PreRegisterSWEP", t, name ) == false ) then return end
 
 	local old = WeaponList[ name ]
 


### PR DESCRIPTION
This allows modification to the registration table before it's registered, or block it completely. This would be useful for addons that are overriding default Lua weapons or servers that want to edit weapons in workshop addons without decompiling.
100th PR :)