### PR TITLE
Allow for custom tooltip panels

### DIFF
--- a/garrysmod/lua/includes/util/tooltips.lua
+++ b/garrysmod/lua/includes/util/tooltips.lua
@@ -55,7 +55,15 @@ function ChangeTooltip( panel )
 	
 	if ( !Text && !Panel ) then return end
 
-	Tooltip = vgui.Create( "DTooltip" )
+	if ( Panel ) then
+
+		Tooltip = vgui.Create( Panel )
+
+	else
+	
+		Tooltip = vgui.Create( "DTooltip" )
+
+	end
 	
 	if ( Text ) then
 	


### PR DESCRIPTION
This allows for Tooltip to be a custom panel if you do PANEL:SetTooltipPanel( panel ) on it.

If no panel are set it will just default to DToolTip.

Very neat if you switch between several different tooltips for different menus.