### PR TITLE
Removed redundant GetSortValue calls in DListView

### DIFF
--- a/garrysmod/lua/vgui/dlistview.lua
+++ b/garrysmod/lua/vgui/dlistview.lua
@@ -470,8 +470,8 @@ function PANEL:SortByColumn( ColumnID, Desc )
 			a, b = b, a
 		end
 
-		local aval = a:GetSortValue( ColumnID ) && a:GetSortValue( ColumnID ) || a:GetColumnText( ColumnID )
-		local bval = b:GetSortValue( ColumnID ) && b:GetSortValue( ColumnID ) || b:GetColumnText( ColumnID )
+		local aval = a:GetSortValue( ColumnID ) || a:GetColumnText( ColumnID )
+		local bval = b:GetSortValue( ColumnID ) || b:GetColumnText( ColumnID )
 
 		return aval < bval
 


### PR DESCRIPTION
The extra GetSortValue call is not needed. Both forms below (with and without it) are equivalent.


#### When SetSortValue is set to anything truthy:
```
1 and 1 or "A"   == 1   (w/ extra call)
      1 or "A"   == 1   (w/o)
```

#### When SetSortValue is not set:
```
nil and nil or "A"   == "A"    (w/ extra call)
        nil or "A"   == "A"    (w/o)
```