### PR TITLE
 Add serverside functions for printing colored text to chat

### DIFF
--- a/garrysmod/lua/includes/init.lua
+++ b/garrysmod/lua/includes/init.lua
@@ -123,3 +123,4 @@ if ( CLIENT ) then
 
 end
 
+include ( "util/chat_print.lua" )

--- a/garrysmod/lua/includes/util/chat_print.lua
+++ b/garrysmod/lua/includes/util/chat_print.lua
@@ -10,7 +10,7 @@ if CLIENT then
 			parts[#parts + 1] = net.ReadType()
 		end
 
-		chat.AddText(parts)
+		chat.AddText(unpack(parts))
 	end)
 end
 

--- a/garrysmod/lua/includes/util/chat_print.lua
+++ b/garrysmod/lua/includes/util/chat_print.lua
@@ -27,6 +27,7 @@ end
 if CLIENT then
 	ChatPrint = chat.AddText
 else
+	-- Prints a colored message to the chat box from the client or server.
 	function ChatPrint(...)
 		net.Start("_ChatPrint")
 			WriteChatParts(...)
@@ -35,6 +36,9 @@ else
 end
 
 local PLAYER = FindMetaTable("Player")
+
+-- Prints a colored message to the chat box of the given player
+-- from the client or server.
 function PLAYER:ChatPrint(...)
 	if CLIENT then
 		if self == LocalPlayer() then

--- a/garrysmod/lua/includes/util/chat_print.lua
+++ b/garrysmod/lua/includes/util/chat_print.lua
@@ -1,52 +1,52 @@
-if SERVER then
-	util.AddNetworkString("_ChatPrint")
+if ( SERVER ) then
+	util.AddNetworkString( "_ChatPrint" )
 end
 
-if CLIENT then
-	net.Receive("_ChatPrint", function()
+if ( CLIENT ) then
+	net.Receive( "_ChatPrint", function()
 		local parts = {}
 
-		for _ = 1, net.ReadUInt(16) do
-			parts[#parts + 1] = net.ReadType()
+		for _ = 1, net.ReadUInt( 16 ) do
+			parts[ #parts + 1 ] = net.ReadType()
 		end
 
-		chat.AddText(unpack(parts))
-	end)
+		chat.AddText( unpack( parts ) )
+	end )
 end
 
-local function WriteChatParts(...)
-	local parts = {...}
+local function WriteChatParts( ... )
+	local parts = { ... }
 
-	net.WriteUInt(#parts, 16)
+	net.WriteUInt( #parts, 16 )
 
 	for i = 1, #parts do
-		net.WriteType(parts[i])
+		net.WriteType( parts[i] )
 	end
 end
 
-if CLIENT then
+if ( CLIENT ) then
 	ChatPrint = chat.AddText
 else
 	-- Prints a colored message to the chat box from the client or server.
-	function ChatPrint(...)
-		net.Start("_ChatPrint")
-			WriteChatParts(...)
+	function ChatPrint( ... )
+		net.Start( "_ChatPrint" )
+			WriteChatParts( ... )
 		net.Broadcast()
 	end
 end
 
-local PLAYER = FindMetaTable("Player")
+local PLAYER = FindMetaTable( "Player" )
 
 -- Prints a colored message to the chat box of the given player
 -- from the client or server.
-function PLAYER:ChatPrint(...)
-	if CLIENT then
-		if self == LocalPlayer() then
-			chat.AddText(...)
+function PLAYER:ChatPrint( ... )
+	if ( CLIENT ) then
+		if ( self == LocalPlayer() ) then
+			chat.AddText( ... )
 		end
 	else
-		net.Start("_ChatPrint")
-			WriteChatParts(...)
-		net.Send(self)
+		net.Start( "_ChatPrint" )
+			WriteChatParts( ... )
+		net.Send( self )
 	end
 end

--- a/garrysmod/lua/includes/util/chat_print.lua
+++ b/garrysmod/lua/includes/util/chat_print.lua
@@ -1,0 +1,48 @@
+if SERVER then
+	util.AddNetworkString("_ChatPrint")
+end
+
+if CLIENT then
+	net.Receive("_ChatPrint", function()
+		local parts = {}
+
+		for _ = 1, net.ReadUInt(16) do
+			parts[#parts + 1] = net.ReadType()
+		end
+
+		chat.AddText(parts)
+	end)
+end
+
+local function WriteChatParts(...)
+	local parts = {...}
+
+	net.WriteUInt(#parts, 16)
+
+	for i = 1, #parts do
+		net.WriteType(parts[i])
+	end
+end
+
+if CLIENT then
+	ChatPrint = chat.AddText
+else
+	function ChatPrint(...)
+		net.Start("_ChatPrint")
+			WriteChatParts(...)
+		net.Broadcast()
+	end
+end
+
+local PLAYER = FindMetaTable("Player")
+function PLAYER:ChatPrint(...)
+	if CLIENT then
+		if self == LocalPlayer() then
+			chat.AddText(...)
+		end
+	else
+		net.Start("_ChatPrint")
+			WriteChatParts(...)
+		net.Send(self)
+	end
+end

--- a/garrysmod/lua/send.txt
+++ b/garrysmod/lua/send.txt
@@ -143,6 +143,7 @@ lua\includes\util\javascript_util.lua
 lua\includes\util\workshop_files.lua
 lua\includes\util\tooltips.lua
 lua\includes\util\client.lua
+lua\includes\util\chat_print.lua
 lua\includes\gui\icon_progress.lua
 lua\includes\extensions\util\worldpicker.lua
 lua\includes\extensions\debug.lua


### PR DESCRIPTION
Fixes https://github.com/Facepunch/garrysmod-requests/issues/122

Note that this function overwrites the existing `ply:ChatPrint` function with this new behavior. Since the previous `ply:ChatPrint` function takes a single string for its parameter, the new function is backwards-compatible.

For the implementation, I offloaded as much of the work as possible to `chat.AddText` so any future enhancements to that function should work for people using these functions.