### PR TITLE
Improve server browser

### DIFF
--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -235,7 +235,7 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 	data.recommended = data.ping;
 	
 	if ( data.recommended <= 30 ) data.recommended = 30 // Weight all servers bellow 30ms the same	
-	if ( data.players < 5) data.recommended += ( 5 - data.players ) * 5 // Decrease the number of empty-like servers
+	if ( data.players < 7) data.recommended += ( 7 - data.players ) * 5 // Decrease the number of empty-like servers
 	
 	if ( data.players == 0 ) data.recommended += 100; // Server is empty
 	

--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -245,6 +245,10 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 	if ( data.players >= 16 ) data.recommended -= 40;
 	if ( data.players >= 32 ) data.recommended -= 20;
 	if ( data.players >= 64 ) data.recommended -= 10;
+	
+	// Increase the impact of the server's ping on high slot servers, so they don't dominate the list
+	if ( data.maxplayers >= 50 ) data.recommended += 10
+	if ( data.maxplayers >= 100 ) data.recommended += 15
 
 	data.listen = data.desc.indexOf('[L]') >= 0;
 	if ( data.listen ) data.desc = data.desc.substr( 4 );

--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -233,6 +233,11 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 	data.hasmap = DoWeHaveMap( data.map );
 
 	data.recommended = data.ping;
+	
+	if ( data.recommended <= 30 ) data.recommended = 30 // Weight all servers bellow 30ms the same	
+	if ( data.players < 5) data.recommended += 20 // Decrease the number of empty-like servers
+	data.recommended += Math.random(15, 1) // Scatter the server list a little bit with randomization
+	
 	if ( data.players == 0 ) data.recommended += 100; // Server is empty
 	if ( data.players == data.maxplayers ) data.recommended += 75; // Server is full
 	if ( data.pass ) data.recommended += 300; // If we can't join it, don't put it to the top

--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -240,7 +240,7 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 	if ( data.players == 0 ) data.recommended += 100; // Server is empty
 	
 	if ( data.players == data.maxplayers ) data.recommended += 37; // Server is full
-	if ( data.players == data.maxplayers * 0.95 ) data.recommended += 37; // Server is almost full
+	if ( data.players >= data.maxplayers * 0.95 ) data.recommended += 37; // Server is almost full
 	
 	if ( data.pass ) data.recommended += 300; // If we can't join it, don't put it to the top
 

--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -247,8 +247,9 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 	if ( data.players >= 64 ) data.recommended -= 10;
 	
 	// Increase the impact of the server's ping on high slot servers, so they don't dominate the list
-	if ( data.maxplayers >= 50 ) data.recommended += 10
-	if ( data.maxplayers >= 100 ) data.recommended += 15
+	if ( data.maxplayers >= 50 ) data.recommended += 5
+	if ( data.maxplayers >= 75 ) data.recommended += 10
+	if ( data.maxplayers >= 100 ) data.recommended += 20
 
 	data.listen = data.desc.indexOf('[L]') >= 0;
 	if ( data.listen ) data.desc = data.desc.substr( 4 );

--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -236,7 +236,6 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 	
 	if ( data.recommended <= 30 ) data.recommended = 30 // Weight all servers bellow 30ms the same	
 	if ( data.players < 5) data.recommended += 20 // Decrease the number of empty-like servers
-	data.recommended += Math.random(15, 1) // Scatter the server list a little bit with randomization
 	
 	if ( data.players == 0 ) data.recommended += 100; // Server is empty
 	if ( data.players == data.maxplayers ) data.recommended += 75; // Server is full

--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -238,7 +238,10 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 	if ( data.players < 5) data.recommended += 20 // Decrease the number of empty-like servers
 	
 	if ( data.players == 0 ) data.recommended += 100; // Server is empty
-	if ( data.players == data.maxplayers ) data.recommended += 75; // Server is full
+	
+	if ( data.players == data.maxplayers ) data.recommended += 37; // Server is full
+	if ( data.players == data.maxplayers * 0.95 ) data.recommended += 37; // Server is almost full
+	
 	if ( data.pass ) data.recommended += 300; // If we can't join it, don't put it to the top
 
 	// The first few bunches of players reduce the impact of the server's ping on the ranking a little

--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -235,7 +235,7 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 	data.recommended = data.ping;
 	
 	if ( data.recommended <= 30 ) data.recommended = 30 // Weight all servers bellow 30ms the same	
-	if ( data.players < 5) data.recommended += 20 // Decrease the number of empty-like servers
+	if ( data.players < 5) data.recommended += ( 5 - data.players ) * 5 // Decrease the number of empty-like servers
 	
 	if ( data.players == 0 ) data.recommended += 100; // Server is empty
 	


### PR DESCRIPTION
- Weight all servers bellow 30ms the same because there is very little difference in ping.

- Stop servers with only a few people from filling up the ranking.

- Stop the list from filling up with all high slot servers because having more players weights them higher.

- Sink servers that are almost full to help seed other servers. And to ensure successful connectivity.
