### PR TITLE
Small PrintTable() iteration optimisation

### DIFF
--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -66,6 +66,8 @@ function PrintTable( t, indent, done )
 		return tostring( a ) < tostring( b )
 	end )
 
+	done[ t ] = true
+
 	for i = 1, #keys do
 		local key = keys[ i ]
 		local value = t[ key ]


### PR DESCRIPTION
While using PrintTable()'s code as base for my own lua implementation I came across the fact that PrintTable() also iterates over the table it is already processing, making it produce more noise then necessary. (always kind of bothered me in gmod itself so here's two flies squashed)

This change is especially useful for `PrintTable( _G )` where it significantly reduces the output (and iterations with that) and so also applies to other areas, no more need to do `PrintTable( _G, 0, { [_G] = true } )` and the like.