### PR TITLE
Fixed RoundedBox(Ex) using incorrect corner textures.

### DIFF
--- a/garrysmod/lua/includes/modules/draw.lua
+++ b/garrysmod/lua/includes/modules/draw.lua
@@ -206,7 +206,7 @@ function RoundedBoxEx( bordersize, x, y, w, h, color, tl, tr, bl, br )
 
 	local tex = tex_corner8
 	if ( bordersize > 8 ) then tex = tex_corner16 end
-	if ( bordersize > 32 ) then tex = tex_corner64 end
+	if ( bordersize > 16 ) then tex = tex_corner64 end
 
 	surface.SetTexture( tex )
 


### PR DESCRIPTION
People who want rounded boxes shouldn't get a pixel-y mess when the border side is between 16 and 32 ☹️ 