### PR TITLE
Added draw.DrawTextWordWrap()

### DIFF
--- a/garrysmod/lua/includes/modules/draw.lua
+++ b/garrysmod/lua/includes/modules/draw.lua
@@ -228,8 +228,18 @@ do
 							insert( textLines, line )
 						else
 							local spaceExploded = {}
+							local wasEmpty = true
 							for word in gmatch( line, "[^%s]*" ) do
-								insert( spaceExploded, word )
+								if len( word )==0 then
+									if wasEmpty then
+										insert( spaceExploded, word )
+									else
+										wasEmpty = true -- avoid output of an extra space after every word
+									end
+								else
+									wasEmpty = false
+									insert( spaceExploded, word )
+								end
 							end
 							local startConcat = 1
 							while startConcat<=#spaceExploded do -- while there are words to process

--- a/garrysmod/lua/includes/modules/draw.lua
+++ b/garrysmod/lua/includes/modules/draw.lua
@@ -261,6 +261,7 @@ do
 		local lineW,lineH
 		local lineX,lineY
 		lineY = y
+		local fullHeight = 0
 		SetTextColor( color.r,color.g,color.b,color.a )
 		for _,line in ipairs( textLines ) do
 			lineW,lineH = GetTextSize( line )
@@ -268,7 +269,9 @@ do
 			SetTextPos( lineX,lineY )
 			DrawText( line )
 			lineY = lineY+lineH
+			fullHeight = fullHeight+lineH
 		end
+		return fullHeight
 	end
 end
 


### PR DESCRIPTION
Hi!

`draw.DrawTextWordWrap()` allows to draw a text with word wrap (if too many words on a line, draw on next line). Spaces and tabs are displayed as spaces. New lines properly displayed. Alignment is fine too.

I know that you do not like my coding style and the performance of my code. I know that whatever I do, it already exists anyway. Please stay sweet, I did my best to add a nice feature.

Momo :heart: