### PR TITLE
Use exponential equation to model ping on server browser

### DIFF
--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -232,7 +232,7 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 
 	data.hasmap = DoWeHaveMap( data.map );
 
-	data.recommended = math.min(0.006 * Math.pow(data.ping, 2.05), data.ping); // Model ping using an exponential equation
+	data.recommended = Math.min(0.006 * Math.pow(data.ping, 2.05), data.ping); // Model ping using an exponential equation
 
 	if ( data.players == 0 ) data.recommended += 100; // Server is empty
 	if ( data.players == data.maxplayers ) data.recommended += 75; // Server is full

--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -232,7 +232,7 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 
 	data.hasmap = DoWeHaveMap( data.map );
 
-	data.recommended = Math.min(0.006 * Math.pow(data.ping, 2.05), data.ping); // Model ping using an exponential equation
+	data.recommended = Math.min(0.05 * Math.pow(data.ping, 1.615), data.ping); // Model ping using an exponential equation
 
 	if ( data.players == 0 ) data.recommended += 100; // Server is empty
 	if ( data.players == data.maxplayers ) data.recommended += 75; // Server is full

--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -232,7 +232,8 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 
 	data.hasmap = DoWeHaveMap( data.map );
 
-	data.recommended = data.ping;
+	data.recommended = 0.006 * Math.pow(data.ping, 2.05) // Model ping using an exponential equation
+
 	if ( data.players == 0 ) data.recommended += 100; // Server is empty
 	if ( data.players == data.maxplayers ) data.recommended += 75; // Server is full
 	if ( data.pass ) data.recommended += 300; // If we can't join it, don't put it to the top

--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -232,7 +232,7 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 
 	data.hasmap = DoWeHaveMap( data.map );
 
-	data.recommended = 0.006 * Math.pow(data.ping, 2.05) // Model ping using an exponential equation
+	data.recommended = math.min(0.006 * Math.pow(data.ping, 2.05), data.ping); // Model ping using an exponential equation
 
 	if ( data.players == 0 ) data.recommended += 100; // Server is empty
 	if ( data.players == data.maxplayers ) data.recommended += 75; // Server is full


### PR DESCRIPTION
This pull request improves the server browser, by changing how ping is modeled. It prioritizes lower latency servers in a different way, which puts more good options higher up on the server browser.

**Exponential equation:** `0.05 * ping ^ 1.615`
**Sample values:** `30ms = 12.4, 60ms = 37.2, 90ms = 71.6, 120ms = 114, above 130ms = actual ping`

**How does it work?**
It puts moderate pings at a stronger position on the list if the server has lots of people playing. If the server ping is above 130ms, it reverts to the default, so clients in exotic places aren't negatively impacted.

**But, I don't like playing at higher pings**
You don't have to play with a higher ping. This just gives the user the choice to, if they're looking for more servers; instead of filling the server browser up with choices which only have a few people playing. 