### PR TITLE
Add constructor arguments to PANEL:Init

### DIFF
--- a/garrysmod/lua/includes/extensions/client/panel/scriptedpanels.lua
+++ b/garrysmod/lua/includes/extensions/client/panel/scriptedpanels.lua
@@ -23,7 +23,7 @@ function vgui.Create( classname, parent, name, ... )
 
 		local metatable = PanelFactory[ classname ]
 
-		local panel = vgui.Create( metatable.Base, parent, name or classname )
+		local panel = vgui.Create( metatable.Base, parent, name or classname, ... )
 		if ( !panel ) then
 			Error( "Tried to create panel with invalid base '" .. metatable.Base .. "'\n" );
 		end
@@ -34,7 +34,7 @@ function vgui.Create( classname, parent, name, ... )
 
 		-- Call the Init function if we have it
 		if ( panel.Init ) then
-			panel:Init(...)
+			panel:Init( ... )
 		end
 
 		panel:Prepare()
@@ -51,7 +51,7 @@ function vgui.CreateFromTable( metatable, parent, name, ... )
 
 	if ( !istable( metatable ) ) then return nil end
 
-	local panel = vgui.Create( metatable.Base, parent, name )
+	local panel = vgui.Create( metatable.Base, parent, name, ... )
 
 	table.Merge( panel:GetTable(), metatable )
 	panel.BaseClass = PanelFactory[ metatable.Base ]
@@ -59,7 +59,7 @@ function vgui.CreateFromTable( metatable, parent, name, ... )
 
 	-- Call the Init function if we have it
 	if ( panel.Init ) then
-		panel:Init(...)
+		panel:Init( ... )
 	end
 
 	panel:Prepare()

--- a/garrysmod/lua/includes/extensions/client/panel/scriptedpanels.lua
+++ b/garrysmod/lua/includes/extensions/client/panel/scriptedpanels.lua
@@ -23,7 +23,7 @@ function vgui.Create( classname, parent, name, ... )
 
 		local metatable = PanelFactory[ classname ]
 
-		local panel = vgui.Create( metatable.Base, parent, name or classname, ... )
+		local panel = vgui.Create( metatable.Base, parent, name or classname )
 		if ( !panel ) then
 			Error( "Tried to create panel with invalid base '" .. metatable.Base .. "'\n" );
 		end
@@ -51,7 +51,7 @@ function vgui.CreateFromTable( metatable, parent, name, ... )
 
 	if ( !istable( metatable ) ) then return nil end
 
-	local panel = vgui.Create( metatable.Base, parent, name, ... )
+	local panel = vgui.Create( metatable.Base, parent, name )
 
 	table.Merge( panel:GetTable(), metatable )
 	panel.BaseClass = PanelFactory[ metatable.Base ]

--- a/garrysmod/lua/includes/extensions/client/panel/scriptedpanels.lua
+++ b/garrysmod/lua/includes/extensions/client/panel/scriptedpanels.lua
@@ -34,7 +34,7 @@ function vgui.Create( classname, parent, name, ... )
 
 		-- Call the Init function if we have it
 		if ( panel.Init ) then
-			panel:Init()
+			panel:Init(...)
 		end
 
 		panel:Prepare()
@@ -59,7 +59,7 @@ function vgui.CreateFromTable( metatable, parent, name, ... )
 
 	-- Call the Init function if we have it
 	if ( panel.Init ) then
-		panel:Init()
+		panel:Init(...)
 	end
 
 	panel:Prepare()


### PR DESCRIPTION
Currently there is no way to initialize a panel with some data, even though there are panels which rely on external data as a dependency. This leaves us having to create our own function just to initialize the panel, and we have to call that function after the panel was already supposed to be initialized through ```PANEL:Init```. Isn't that the whole purpose of ```PANEL:Init```? To initialize the panel and prepare it for consumption? Take an inventory system, as an example.

You have an item panel, which shows an item in your inventory. This item panel has a label and a spawn icon. Obviously this item panel relies on an actual item to show anything useful. An item panel without an item doesn't make sense. So you have an item's data that you perhaps got from a database. You pass that data to the panel, which gives the panel the necessary information to display that item.

```lua
function PANEL:Init(itemData)
	self.Label = self:Add("DLabel")
	self.SpawnIcon = self:Add("SpawnIcon")

	self.Label:SetText(itemData.Name)
	self.Label:SetColor(itemData.Color)

	self.SpawnIcon:SetModel(itemData.Model)
end

vgui.Register("MyItemPanel", PANEL, "Panel")
```

Then when you want to create the panel.

```lua
local panel = vgui.Create("MyItemPanel", nil, nil, item)
```

The two functions I've edited already take varargs, they just don't pass them to ```PANEL:Init```.