### PR TITLE
Improve server browser #2

### DIFF
--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -237,10 +237,11 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 	if ( data.players == data.maxplayers ) data.recommended += 75; // Server is full
 	if ( data.pass ) data.recommended += 300; // If we can't join it, don't put it to the top
 
-	// The first few bunches of players reduce the impact of the server's ping on the ranking a little
-	if ( data.players >= 16 ) data.recommended -= 40;
-	if ( data.players >= 32 ) data.recommended -= 20;
-	if ( data.players >= 64 ) data.recommended -= 10;
+	// Reduce the impact of the server's ping on the ranking a little bit
+	data.recommended -= Math.min(data.players, 40);	
+	data.recommended -= Math.min(data.players, 30);	
+	data.recommended -= Math.min(data.players, 20);	
+	data.recommended -= Math.min(data.players, 10);
 
 	data.listen = data.desc.indexOf('[L]') >= 0;
 	if ( data.listen ) data.desc = data.desc.substr( 4 );
@@ -260,7 +261,6 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 	gm.order = gm.num_players + Math.random();
 
 	UpdateDigest( Scope, 50 );
-
 }
 
 function MissingGamemodeIcon( element )


### PR DESCRIPTION
This pull request sorts the player count aspect of rankings in a smarter way using a resertive technique. It also makes the server browser load faster because the math library is utilized instead of if-statements. 

The old method is highly inaccurate because it measures players in 16, 32 and 64 intervals. This one is accurate down to the exact player count and achieves the intended effect significantly better.

When combined with pull request #1358, it becomes more effective. That pull request models ping better. It will help put more high player count options closer to the top. And solve various imbalances with ping.

I took these screenshots at 12am EST. During peak hours when more people are playing, more options with higher player counts will shoot up to the top. Additional higher latency servers will also fill on the bottom.

Here's a screenshot of DarkRP with this pull request combined with #1358.
![20170522000358_1](https://cloud.githubusercontent.com/assets/9171157/26292384/7c736410-3e83-11e7-8dbb-257ac4587d93.jpg)

Here's a screenshot of TTT with this pull request combined with #1358.
![20170522003434_1](https://cloud.githubusercontent.com/assets/9171157/26292763/a0ecbdc0-3e86-11e7-8358-2c2051f44931.jpg)

