### PR TITLE
Fixed DFileBrowser not working properly with a blank root folder.

### DIFF
--- a/garrysmod/lua/vgui/dfilebrowser.lua
+++ b/garrysmod/lua/vgui/dfilebrowser.lua
@@ -180,13 +180,13 @@ function PANEL:SetupFiles()
 		self.FileHeader = self.Files:AddColumn( "Files" ).Header
 
 		self.Files.DoDoubleClick = function( pnl, _, line )
-			self:OnDoubleClick( self:GetCurrentFolder() .. "/" .. line:GetColumnText( 1 ), line )
+			self:OnDoubleClick( string.Trim( self:GetCurrentFolder() .. "/" .. line:GetColumnText( 1 ), "/" ), line )
 		end
 		self.Files.OnRowSelected = function( pnl, _, line )
-			self:OnSelect( self:GetCurrentFolder() .. "/" .. line:GetColumnText( 1 ), line )
+			self:OnSelect( string.Trim( self:GetCurrentFolder() .. "/" .. line:GetColumnText( 1 ), "/" ), line )
 		end
 		self.Files.OnRowRightClick = function( pnl, _, line )
-			self:OnRightClick( self:GetCurrentFolder() .. "/" .. line:GetColumnText( 1 ), line )
+			self:OnRightClick( string.Trim( self:GetCurrentFolder() .. "/" .. line:GetColumnText( 1 ), "/" ), line )
 		end
 	end
 	self.Divider:SetRight( self.Files )

--- a/garrysmod/lua/vgui/dtree_node.lua
+++ b/garrysmod/lua/vgui/dtree_node.lua
@@ -426,7 +426,7 @@ function PANEL:FilePopulateCallback( files, folders, foldername, path, bAndChild
 		for k, File in SortedPairsByValue( folders ) do
 
 			local Node = self:AddNode( File )
-			Node:MakeFolder( foldername .. "/" .. File, path, showfiles, wildcard, true )
+			Node:MakeFolder( string.Trim( foldername .. "/" .. File, "/" ), path, showfiles, wildcard, true )
 			FileCount = FileCount + 1
 
 		end
@@ -440,7 +440,7 @@ function PANEL:FilePopulateCallback( files, folders, foldername, path, bAndChild
 			local icon = "icon16/page_white.png"
 
 			local Node = self:AddNode( File, icon )
-			Node:SetFileName( foldername .. "/" .. File )
+			Node:SetFileName( string.Trim( foldername .. "/" .. File, "/" ) )
 			FileCount = FileCount + 1
 
 		end
@@ -475,8 +475,9 @@ function PANEL:FilePopulate( bAndChildren, bExpand )
 	local wildcard = self:GetWildCard()
 
 	if ( !folder || !wildcard || !path ) then return false end
-
-	local files, folders = file.Find( folder .. "/" .. wildcard, path )
+	
+	local files, folders = file.Find( string.Trim( folder .. "/" .. wildcard, "/" ), path )
+	if folders[1] == "/" then table.remove(folders, 1) end
 
 	self:SetNeedsPopulating( false )
 	self:SetNeedsChildSearch( false )


### PR DESCRIPTION
If I create a DFileBrowser as below, the folder list will not populate, and the filenames will have a slash at the beginning.

local browser = vgui.Create("DFileBrowser", cpanel)
browser:Dock(TOP)
browser:DockPadding(10, 10, 10, 0)
browser:SetMinimumSize(100, 200)
browser:SetPath("GAME")
browser:SetBaseFolder("")
browser:SetName("root")
browser:SetFileTypes( "*.mid" )

My change fixes this.