### PR TITLE
Update of sql.TableExists function

### DIFF
--- a/garrysmod/lua/includes/util/sql.lua
+++ b/garrysmod/lua/includes/util/sql.lua
@@ -34,9 +34,7 @@ function sql.TableExists( name )
 
 	local r = sql.Query( "select name FROM sqlite_master WHERE name="..SQLStr( name ).." AND type='table'" );
 	
-	if ( r ) then return true end
-	
-	return false
+	return r
 
 end
 


### PR DESCRIPTION
The current sql.TableExists function will return true if query variable r will return true, and false if it won't.
If not found, the query will either return nil or false from my past experience, which both resort to false in case they are put in an if, so you can simply return r instead of returning either true or false.