### PR TITLE
Added notice about mount.cfg to gameinfo.txt

### DIFF
--- a/garrysmod/gameinfo.txt
+++ b/garrysmod/gameinfo.txt
@@ -17,6 +17,7 @@
 		SearchPaths
 		{
 			// None of this matters really
+			// Game content mounting is controlled by cfg/mount.cfg, and not here!
 			game+mod			garrysmod/addons/*
 
 			game+mod			garrysmod/garrysmod.vpk


### PR DESCRIPTION
Had a lot of headscratching because hammer didn't listen at all to the changes I did to this file, realised Garrysmod uses mount.cfg instead of gameinfo.txt for mounting.