### PR TITLE
Fixed TTT toggle disguiser hotkey spam

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_keys.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_keys.lua
@@ -116,6 +116,7 @@ function GM:KeyRelease(ply, key)
 end
 
 function GM:PlayerButtonUp(ply, btn)
+   if not IsFirstTimePredicted() then return end
    -- Would be nice to clean up this whole "all key handling in massive
    -- functions" thing. oh well
    if btn == KEY_PAD_ENTER then


### PR DESCRIPTION
The TTT default hotkey for toggling the disguiser was firing multiple times on each press. This fixes it.