### PR TITLE
Removed globals polluting global namespace in the lua_run entity

### DIFF
--- a/garrysmod/gamemodes/base/entities/entities/lua_run.lua
+++ b/garrysmod/gamemodes/base/entities/entities/lua_run.lua
@@ -5,6 +5,7 @@ ENT.DisableDuplicator = true
 AccessorFunc( ENT, "m_bDefaultCode", "DefaultCode" )
 
 function ENT:Initialize()
+	
 end
 
 function ENT:KeyValue( key, value )
@@ -15,32 +16,35 @@ function ENT:KeyValue( key, value )
 
 end
 
-function ENT:SetupGlobals( activator, caller )
-
-	ACTIVATOR = activator
-	CALLER = caller
+function ENT:SetupGlobals( activator, caller, code )
+	
+	self.compiledCode = CompileString( value, tostring(self) )
+	if ( not self.compiledCode ) then return end
+	
+	local meta = {
+		__index = _G
+	}
+	
+	local environment = {
+		ACTIVATOR = activator,
+		CALLER = caller
+	}
 
 	if ( IsValid( activator ) && activator:IsPlayer() ) then
-		TRIGGER_PLAYER = activator
+		environment.TRIGGER_PLAYER = activator
 	end
-
-end
-
-function ENT:KillGlobals()
-
-	ACTIVATOR = nil
-	CALLER = nil
-	TRIGGER_PLAYER = nil
+	
+	setmetatable( environment, meta )
+	self.compiledCode = setfenv( self.compiledCode, environment )
 
 end
 
 function ENT:RunCode( activator, caller, code )
 
-	self:SetupGlobals( activator, caller )
-
-		RunString( code )
-
-	self:KillGlobals()
+	self:SetupGlobals( activator, caller, code )
+	
+	if ( not self.compiledCode ) then return end
+	ProtectedCall( self.compiledCode )
 
 end
 


### PR DESCRIPTION
The code passed to a lua_run entity is now precompiled and sandboxed, such that the ACTIVATOR, CALLER and TRIGGER_PLAYER globals are no longer present in the global namespace, however are still present within the code to be run, allowing for backwards compatibility. This change prevents hard-to-track issues arising from the use of these named globals elsewhere in the application.

The ENT:KillGlobals() function has been removed, however this should only be called from within the entity and is therefore not a problem for backwards compatibility. The ENT:SetupGlobals( activator, caller, code ) function remains present, however its use has been greatly modified.

I have not had the opportunity to test this owing to the lack of an installed copy of Garry's Mod.