### PR TITLE
Fix TTT prediction issues (BREAKING CHANGE INSIDE)

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_binoculars.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_binoculars.lua
@@ -1,5 +1,7 @@
 AddCSLuaFile()
 
+DEFINE_BASECLASS "weapon_tttbase"
+
 SWEP.HoldType               = "normal"
 
 if CLIENT then
@@ -147,6 +149,7 @@ function SWEP:IdentifyCorpse()
 end
 
 function SWEP:Think()
+   BaseClass.Think(self)
    if self.dt.processing then
       if self:IsTargetingCorpse() then
          if CurTime() > (self.dt.start_time + self.ProcessingDelay) then

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_m16.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_m16.lua
@@ -41,7 +41,6 @@ SWEP.IronSightsPos         = Vector(-7.58, -9.2, 0.55)
 SWEP.IronSightsAng         = Vector(2.599, -1.3, -3.6)
 
 function SWEP:SetZoom(state)
-   if CLIENT then return end
    if not (IsValid(self.Owner) and self.Owner:IsPlayer()) then return end
    if state then
       self.Owner:SetFOV(35, 0.5)
@@ -59,9 +58,7 @@ function SWEP:SecondaryAttack()
 
    self:SetIronsights( bIronsights )
 
-   if SERVER then
-      self:SetZoom( bIronsights )
-   end
+   self:SetZoom( bIronsights )
 
    self:SetNextSecondaryFire( CurTime() + 0.3 )
 end

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_phammer.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_phammer.lua
@@ -1,5 +1,7 @@
 AddCSLuaFile()
 
+DEFINE_BASECLASS "weapon_tttbase"
+
 SWEP.HoldType              = "ar2"
 
 if CLIENT then
@@ -202,6 +204,7 @@ if SERVER then
    local CHARGE_DELAY = 0.025
 
    function SWEP:Think()
+      BaseClass.Think(self)
       if not IsValid(self.Owner) then return end
 
       if self.IsCharging and self.Owner:KeyDown(IN_ATTACK2) then

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_push.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_push.lua
@@ -1,5 +1,7 @@
 AddCSLuaFile()
 
+DEFINE_BASECLASS "weapon_tttbase"
+
 SWEP.HoldType               = "physgun"
 
 if CLIENT then
@@ -181,6 +183,7 @@ function SWEP:Holster()
 end
 
 function SWEP:Think()
+   BaseClass.Think(self)
    if self.IsCharging and IsValid(self.Owner) and self.Owner:IsTerror() then
       -- on client this is prediction
       if not self.Owner:KeyDown(IN_ATTACK2) then

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_wtester.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_wtester.lua
@@ -2,6 +2,8 @@
 
 AddCSLuaFile()
 
+DEFINE_BASECLASS "weapon_tttbase"
+
 SWEP.HoldType              = "normal"
 
 if CLIENT then

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -244,7 +244,7 @@ function SWEP:PrimaryAttack(worldsnd)
    local owner = self.Owner
    if not IsValid(owner) or owner:IsNPC() or (not owner.ViewPunch) then return end
 
-   owner:ViewPunch( Angle( util.SharedRandom(self:GetClass(), -0.2,-0.1) * self.Primary.Recoil, util.SharedRandom(self:GetClass(), -0.1,0.1) * self.Primary.Recoil, 0 ) )
+   owner:ViewPunch( Angle( util.SharedRandom(self:GetClass(),-0.2,-0.1,0) * self.Primary.Recoil, util.SharedRandom(self:GetClass(),-0.1,0.1,1) * self.Primary.Recoil, 0 ) )
 end
 
 function SWEP:DryFire(setnext)

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -486,9 +486,10 @@ function SWEP:Initialize()
 end
 
 function SWEP:CalcViewModel()
+   if (not CLIENT) then return end
    self.bIron = self:GetIronsights()
    self.fIronTime = self:GetIronsightsTime()
-   self.fCurrentTime = CurTime()
+   self.fCurrentTime = CurTime() - SysTime()
 end
 
 function SWEP:Think()
@@ -536,7 +537,7 @@ function SWEP:GetViewModelPosition( pos, ang )
    if not self.IronSightsPos or self.bIron == nil then return pos, ang end
 
    local bIron = self.bIron
-   local time = self.fCurrentTime
+   local time = self.fCurrentTime + SysTime()
 
    if bIron then
       self.SwayScale = 0.3

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -454,6 +454,12 @@ function SWEP:SetIronsights(ironsights)
    end
 end
 
+--- Dummy functions that will be replaced when SetupDataTables runs. These are
+--- here for when that does not happen (due to e.g. stacking base classes)
+function SWEP:GetIronsightsPredicted() return false end
+function SWEP:SetIronsightsPredicted() end
+
+
 -- Set up ironsights dt bool. Weapons using their own DT vars will have to make
 -- sure they call this.
 function SWEP:SetupDataTables()

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_tttbasegrenade.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_tttbasegrenade.lua
@@ -2,6 +2,8 @@
 
 AddCSLuaFile()
 
+DEFINE_BASECLASS "weapon_tttbase"
+
 SWEP.HoldReady             = "grenade"
 SWEP.HoldNormal            = "slam"
 
@@ -84,6 +86,7 @@ end
 
 
 function SWEP:Think()
+   BaseClass.Think(self)
    local ply = self.Owner
    if not IsValid(ply) then return end
 

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
@@ -2,6 +2,8 @@
 
 AddCSLuaFile()
 
+DEFINE_BASECLASS "weapon_tttbase"
+
 SWEP.HoldType               = "pistol"
 
 if CLIENT then
@@ -167,6 +169,7 @@ local ent_diff_time = CurTime()
 
 local stand_time = 0
 function SWEP:Think()
+   BaseClass.Think(self)
    if not self:CheckValidity() then return end
 
    -- If we are too far from our object, force a drop. To avoid doing this

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_rifle.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_rifle.lua
@@ -45,9 +45,7 @@ SWEP.IronSightsPos         = Vector( 5, -15, -2 )
 SWEP.IronSightsAng         = Vector( 2.6, 1.37, 3.5 )
 
 function SWEP:SetZoom(state)
-   if CLIENT then
-      return
-   elseif IsValid(self.Owner) and self.Owner:IsPlayer() then
+   if IsValid(self.Owner) and self.Owner:IsPlayer() then
       if state then
          self.Owner:SetFOV(20, 0.3)
       else
@@ -70,9 +68,8 @@ function SWEP:SecondaryAttack()
 
    self:SetIronsights( bIronsights )
 
-   if SERVER then
-      self:SetZoom(bIronsights)
-   else
+   self:SetZoom(bIronsights)
+   if (CLIENT) then
       self:EmitSound(self.Secondary.Sound)
    end
 

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_shotgun.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_shotgun.lua
@@ -1,5 +1,7 @@
 AddCSLuaFile()
 
+DEFINE_BASECLASS "weapon_tttbase"
+
 SWEP.HoldType              = "shotgun"
 
 if CLIENT then
@@ -46,7 +48,7 @@ SWEP.reloadtimer           = 0
 function SWEP:SetupDataTables()
    self:DTVar("Bool", 0, "reloading")
 
-   return self.BaseClass.SetupDataTables(self)
+   return BaseClass.SetupDataTables(self)
 end
 
 function SWEP:Reload()
@@ -134,6 +136,7 @@ function SWEP:CanPrimaryAttack()
 end
 
 function SWEP:Think()
+   BaseClass.Think(self)
    if self.dt.reloading and IsFirstTimePredicted() then
       if self.Owner:KeyDown(IN_ATTACK) then
          self:FinishReload()
@@ -157,7 +160,7 @@ end
 function SWEP:Deploy()
    self.dt.reloading = false
    self.reloadtimer = 0
-   return self.BaseClass.Deploy(self)
+   return BaseClass.Deploy(self)
 end
 
 -- The shotgun's headshot damage multiplier is based on distance. The closer it

--- a/garrysmod/gamemodes/terrortown/gamemode/player.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player.lua
@@ -1090,14 +1090,6 @@ function GM:Tick()
             ply.drowning = nil
          end
 
-         -- Slow down ironsighters
-         local wep = ply:GetActiveWeapon()
-         if IsValid(wep) and wep.GetIronsights and wep:GetIronsights() then
-            ply:SetSpeed(true)
-         else
-            ply:SetSpeed(false)
-         end
-
          -- Run DNA Scanner think also when it is not deployed
          if IsValid(ply.scanner_weapon) and wep != ply.scanner_weapon then
             ply.scanner_weapon:Think()

--- a/garrysmod/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player_ext.lua
@@ -205,16 +205,7 @@ end
 
 
 function plymeta:SetSpeed(slowed)
-   local mul = hook.Call("TTTPlayerSpeed", GAMEMODE, self, slowed) or 1
-   if slowed then
-      self:SetWalkSpeed(120 * mul)
-      self:SetRunSpeed(120 * mul)
-      self:SetMaxSpeed(120 * mul)
-   else
-      self:SetWalkSpeed(220 * mul)
-      self:SetRunSpeed(220 * mul)
-      self:SetMaxSpeed(220 * mul)
-   end
+   error "Player:SetSpeed is deprecated - please remove this call"
 end
 
 function plymeta:ResetLastWords()
@@ -307,7 +298,6 @@ function plymeta:InitialSpawn()
    -- Change some gmod defaults
    self:SetCanZoom(false)
    self:SetJumpPower(160)
-   self:SetSpeed(false)
    self:SetCrouchedWalkSpeed(0.3)
 
    -- Always spawn innocent initially, traitor will be selected later

--- a/garrysmod/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player_ext.lua
@@ -205,7 +205,7 @@ end
 
 
 function plymeta:SetSpeed(slowed)
-   error "Player:SetSpeed is deprecated - please remove this call and use the TTTPlayerSpeedModifier hook in a predicted environment"
+   error "Player:SetSpeed is deprecated - please remove this call and use the TTTPlayerSpeedModifier hook in both CLIENT and SERVER states"
 end
 
 function plymeta:ResetLastWords()

--- a/garrysmod/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player_ext.lua
@@ -205,7 +205,7 @@ end
 
 
 function plymeta:SetSpeed(slowed)
-   error "Player:SetSpeed is deprecated - please remove this call"
+   error "Player:SetSpeed is deprecated - please remove this call and use the TTTPlayerSpeedModifier hook in a predicted environment"
 end
 
 function plymeta:ResetLastWords()

--- a/garrysmod/gamemodes/terrortown/gamemode/shared.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/shared.lua
@@ -174,7 +174,7 @@ function GM:SetupMove(ply, mv, cmd)
       if IsValid(wep) and wep.GetIronsights and wep:GetIronsights() then
          basespeed = 120
       end
-      local mul = hook.Call("TTTPlayerSpeed", GAMEMODE, self, slowed) or 1
+      local mul = hook.Call("TTTPlayerSpeedModifier", GAMEMODE, self, slowed) or 1
       mv:SetMaxClientSpeed(basespeed * mul)
    end
 end

--- a/garrysmod/gamemodes/terrortown/gamemode/shared.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/shared.lua
@@ -164,6 +164,21 @@ function GM:PlayerFootstep(ply, pos, foot, sound, volume, rf)
    end
 end
 
+-- Predicted move speed changes
+function GM:SetupMove(ply, mv, cmd)
+   if (ply:Alive() and ply:Team() == TEAM_TERROR) then
+
+      local basespeed = 220
+      -- Slow down ironsighters
+      local wep = ply:GetActiveWeapon()
+      if IsValid(wep) and wep.GetIronsights and wep:GetIronsights() then
+         basespeed = 120
+      end
+      local mul = hook.Call("TTTPlayerSpeed", GAMEMODE, self, slowed) or 1
+      mv:SetMaxClientSpeed(basespeed * mul)
+   end
+end
+
 
 -- Weapons and items that come with TTT. Weapons that are not in this list will
 -- get a little marker on their icon if they're buyable, showing they are custom


### PR DESCRIPTION
`Player:SetSpeed()` and `TTTPlayerSpeed` is removed in favor of using the new hook `TTTPlayerSpeedModifier`
- Fixed weapon_zm_rifle + weapon_ttt_m16 scoping prediction errors
- Fixed shooting prediction errors
- Fixed viewpunch prediction issue (not replicated)
- Fixed movement prediction error when scoping / unscoping
- Fixed scoping animation lag
- Fixed SetFOV prediction error (likely from old code)
- Fixed Shotgun reloading (sorta - weird still dunno why)