### PR TITLE
TTT: Replace use of 'wepswitch' command with input.SelectWeapon

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_wepswitch.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_wepswitch.lua
@@ -289,7 +289,7 @@ function WSWITCH:ConfirmSelection(noHide)
 
    for k, w in pairs(self.WeaponCache) do
       if k == self.Selected and IsValid(w) then
-         RunConsoleCommand("wepswitch", w:GetClass())
+         input.SelectWeapon(w)
          return
       end
    end


### PR DESCRIPTION
This function only exists on GMod's dev branch. It'll allow the client to predict weapon switching. That means it'll look like there is no delay when switching weapons.

I left the old command in because somebody is probably using it for something.