### PR TITLE
Made Material return 1 argument

### DIFF
--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -25,7 +25,7 @@ function Material( name, words )
 	str = str .. (words:find("noclamp") and "1" or "0")
 	str = str .. (words:find("smooth") and "1" or "0")
 	
-	return C_Material( name, str )
+	return select( 1, C_Material( name, str ) )
 
 end
 


### PR DESCRIPTION
At the moment, Material returns 2 arguments, the IMaterial as well as the time taken. This makes Material impossible to use in a table:
```
local images = { Material( "icon16/coins.png" ), Material( "icon16/star.png" ), Material( "icon16/heart.png" ) }
PrintTable( images )
-- 1	=	Material [icon16/coins]
-- 2	=	Material [icon16/star]
-- 3	=	Material [icon16/heart]
-- 4	=	1.9379468882248e-06
```
It would make much more sense to remove this last argument, as I can't imagine it was ever used in the first place.
I'm not implying the way to do this is to use select though, it should be done in C itself.