### PR TITLE
make Player:SetPData and Player:RemovePData actually return a boolean

### DIFF
--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -177,8 +177,13 @@ end
 function meta:SetPData( name, value )
 
 	name = Format( "%s[%s]", self:UniqueID(), name )
-	sql.Query( "REPLACE INTO playerpdata ( infoid, value ) VALUES ( " .. SQLStr( name ) .. ", " .. SQLStr( value ) .. " )" )
-
+	local ok = sql.Query( "REPLACE INTO playerpdata ( infoid, value ) VALUES ( " .. SQLStr( name ) .. ", " .. SQLStr( value ) .. " )" )
+	if not ok then
+		error(sql.LastError())
+		return false
+	end
+	return true
+	
 end
 
 --[[---------------------------------------------------------
@@ -188,8 +193,13 @@ end
 function meta:RemovePData( name )
 
 	name = Format( "%s[%s]", self:UniqueID(), name )
-	sql.Query( "DELETE FROM playerpdata WHERE infoid = " .. SQLStr( name ) )
-
+	local ok = sql.Query( "DELETE FROM playerpdata WHERE infoid = " .. SQLStr( name ) )
+	if not ok then
+		error(sql.LastError())
+		return false
+	end
+	return true
+	
 end
 
 --

--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -178,11 +178,7 @@ function meta:SetPData( name, value )
 
 	name = Format( "%s[%s]", self:UniqueID(), name )
 	local ok = sql.Query( "REPLACE INTO playerpdata ( infoid, value ) VALUES ( " .. SQLStr( name ) .. ", " .. SQLStr( value ) .. " )" )
-	if not ok then
-		error(sql.LastError())
-		return false
-	end
-	return true
+	return ok
 	
 end
 
@@ -194,11 +190,7 @@ function meta:RemovePData( name )
 
 	name = Format( "%s[%s]", self:UniqueID(), name )
 	local ok = sql.Query( "DELETE FROM playerpdata WHERE infoid = " .. SQLStr( name ) )
-	if not ok then
-		error(sql.LastError())
-		return false
-	end
-	return true
+	return ok
 	
 end
 

--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -178,7 +178,7 @@ function meta:SetPData( name, value )
 
 	name = Format( "%s[%s]", self:UniqueID(), name )
 	return sql.Query( "REPLACE INTO playerpdata ( infoid, value ) VALUES ( " .. SQLStr( name ) .. ", " .. SQLStr( value ) .. " )" ) ~= false
-	
+
 end
 
 --[[---------------------------------------------------------
@@ -189,7 +189,7 @@ function meta:RemovePData( name )
 
 	name = Format( "%s[%s]", self:UniqueID(), name )
 	return sql.Query( "DELETE FROM playerpdata WHERE infoid = " .. SQLStr( name ) ) ~= false
-	
+
 end
 
 --

--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -177,8 +177,7 @@ end
 function meta:SetPData( name, value )
 
 	name = Format( "%s[%s]", self:UniqueID(), name )
-	local ok = sql.Query( "REPLACE INTO playerpdata ( infoid, value ) VALUES ( " .. SQLStr( name ) .. ", " .. SQLStr( value ) .. " )" )
-	return ok
+	return sql.Query( "REPLACE INTO playerpdata ( infoid, value ) VALUES ( " .. SQLStr( name ) .. ", " .. SQLStr( value ) .. " )" ) ~= false
 	
 end
 
@@ -189,8 +188,7 @@ end
 function meta:RemovePData( name )
 
 	name = Format( "%s[%s]", self:UniqueID(), name )
-	local ok = sql.Query( "DELETE FROM playerpdata WHERE infoid = " .. SQLStr( name ) )
-	return ok
+	return sql.Query( "DELETE FROM playerpdata WHERE infoid = " .. SQLStr( name ) ) ~= false
 	
 end
 


### PR DESCRIPTION
According to the wiki [SetPData](https://wiki.garrysmod.com/page/Player/SetPData) and [RemovePData](https://wiki.garrysmod.com/page/Player/RemovePData) should return a boolean on success/failure which at the moment they're not.

Additionally it would be optimal if they would also throw an error (sql.LastError()) if it fails so people actually know why their stuff didn't get stored.

I'm not sure if I should just throw `error` like that or it might be better if it's done in the sql.Query function itself.