### PR TITLE
TTT: Add DrawPropSpecLabels hook

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -145,7 +145,9 @@ function GM:HUDDrawTargetID()
 
    local L = GetLang()
 
-   DrawPropSpecLabels(client)
+   if hook.Call("TTTDrawTargetID", GAMEMODE, client) != false then
+      DrawPropSpecLabels(client)
+   end
 
    local trace = client:GetEyeTrace(MASK_SHOT)
    local ent = trace.Entity

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -145,7 +145,7 @@ function GM:HUDDrawTargetID()
 
    local L = GetLang()
 
-   if hook.Call("TTTDrawTargetID", GAMEMODE, client) != false then
+   if hook.Call( "HUDShouldDraw", GAMEMODE, "TTTPropSpec" ) then
       DrawPropSpecLabels(client)
    end
 


### PR DESCRIPTION
Added a hook to disable the drawing of Spectator labels.
This allows more customization since `DrawPropSpecLabels` is a local function and can't be prevented otherwise.

I'm open for better names for the hook.

Inspired by #1359.