### PR TITLE
Added utf8.sub and utf8.idx

### DIFF
--- a/garrysmod/lua/includes/modules/utf8.lua
+++ b/garrysmod/lua/includes/modules/utf8.lua
@@ -351,7 +351,7 @@ end
 --
 -- UTF-8 compilant version of str[idx]
 --
-function idx( str, idx )
+function GetChar( str, idx )
 	idx = strRelToAbsChar( str, idx )
 
 	if idx == 0 then return "" end
@@ -370,7 +370,7 @@ function sub( str, charstart, charend )
 
 	local buf = {}
 	for i = charstart, charend do
-		buf[#buf + 1] = idx( str, i )
+		buf[#buf + 1] = GetChar( str, i )
 	end
 
 	return table.concat( buf )

--- a/garrysmod/lua/includes/modules/utf8.lua
+++ b/garrysmod/lua/includes/modules/utf8.lua
@@ -75,7 +75,7 @@ local function decode( str, startPos )
 
 	-- Validate our continuation bytes
 	for _, bX in ipairs { str:byte( startPos + 1, endPos ) } do
-		
+
 		-- Invalid continuation byte hit
 		if bit.band( bX, 0xC0 ) ~= 0x80 then
 			return nil
@@ -316,7 +316,7 @@ function force( str )
 	end
 
 	repeat
-		
+
 		local seqStartPos, seqEndPos = decode( str, curPos )
 
 		if not seqStartPos then
@@ -335,4 +335,43 @@ function force( str )
 
 	return table.concat( buf, "" )
 
+end
+
+--
+-- Converts a relative index to an absolute
+-- This is different from the above in that it cares about characters and not bytes
+--
+local function strRelToAbsChar( str, pos )
+	if pos < 0 then
+		pos = math.max( pos + utf8.len( str ) + 1, 0 )
+	end
+	return pos
+end
+
+--
+-- UTF-8 compilant version of str[idx]
+--
+function idx( str, idx )
+	idx = strRelToAbsChar( str, idx )
+
+	if idx == 0 then return "" end
+	if idx > utf8.len( str ) then return "" end
+
+	local offset = utf8.offset( str, idx - 1 )
+	return utf8.char( utf8.codepoint( str, offset ) )
+end
+
+--
+-- UTF-8 compilant version of string.sub
+--
+function sub( str, charstart, charend )
+	charstart = strRelToAbsChar( str, charstart )
+	charend = strRelToAbsChar( str, charend )
+
+	local buf = {}
+	for i = charstart, charend do
+		buf[#buf + 1] = utf8.idx( str, i )
+	end
+
+	return table.concat( buf )
 end

--- a/garrysmod/lua/includes/modules/utf8.lua
+++ b/garrysmod/lua/includes/modules/utf8.lua
@@ -343,7 +343,7 @@ end
 --
 local function strRelToAbsChar( str, pos )
 	if pos < 0 then
-		pos = math.max( pos + utf8.len( str ) + 1, 0 )
+		pos = math.max( pos + len( str ) + 1, 0 )
 	end
 	return pos
 end
@@ -355,10 +355,10 @@ function idx( str, idx )
 	idx = strRelToAbsChar( str, idx )
 
 	if idx == 0 then return "" end
-	if idx > utf8.len( str ) then return "" end
+	if idx > len( str ) then return "" end
 
-	local offset = utf8.offset( str, idx - 1 )
-	return utf8.char( utf8.codepoint( str, offset ) )
+	local off = offset( str, idx - 1 )
+	return char( codepoint( str, off ) )
 end
 
 --
@@ -366,11 +366,11 @@ end
 --
 function sub( str, charstart, charend )
 	charstart = strRelToAbsChar( str, charstart )
-	charend = strRelToAbsChar( str, charend )
+	charend = strRelToAbsChar( str, charend or -1 )
 
 	local buf = {}
 	for i = charstart, charend do
-		buf[#buf + 1] = utf8.idx( str, i )
+		buf[#buf + 1] = idx( str, i )
 	end
 
 	return table.concat( buf )


### PR DESCRIPTION
This is a WIP proposal sort of really. I admit I don't know a lot about UTF-8 but I was fixing up this chatbox which had really poor UTF-8 support and I figured that a simple string.sub and str[idx] would be really dandy. After some tinkering this is what I came up with, and the replacement worked perfectly. I thought other people could have use of this aswell, as the utf8 library is much of a mystery to most people. These functions are intended to remove that mystery so we (the people) get more UTF-8 support!

I'm gladly accepting criticism on if/how this could be done in a more optimized and better fashion.

utf8.idx could maybe be renamed to utf8.GetChar to match