### PR TITLE
TTT: fix potential abuse for network overflowing clients

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/scoring.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/scoring.lua
@@ -244,9 +244,11 @@ function SCORE:StreamToClients()
 
    local parts = #cut
    for k, bit in pairs(cut) do
-      net.Start("TTT_ReportStream")
-      net.WriteBit((k != parts)) -- continuation bit, 1 if there's more coming
-      net.WriteString(bit)
-      net.Broadcast()
+      timer.Simple((k - 1) * 1, function()
+         net.Start("TTT_ReportStream")
+         net.WriteBit((k != parts)) -- continuation bit, 1 if there's more coming
+         net.WriteString(bit)
+         net.Broadcast()
+      end)
    end
 end


### PR DESCRIPTION
net messages are mostly sent at the exact same time. this slows it down to prevent overflows.