### PR TITLE
Fix PANEL.InvalidateChildren always being recursive

### DIFF
--- a/garrysmod/lua/includes/extensions/client/panel.lua
+++ b/garrysmod/lua/includes/extensions/client/panel.lua
@@ -414,7 +414,7 @@ function meta:InvalidateChildren( bRecurse )
 		if ( bRecurse ) then
 			v:InvalidateChildren( true )
 		else
-			v:InvalidateChildren( false )
+			v:InvalidateLayout( true )
 		end
 
 	end


### PR DESCRIPTION
Wether you passed true or false as an argument, PANEL.InvalidateChildren would've been called on the childs, which recurse.