### PR TITLE
Added net.WriteCompressed() and net.ReadCompressed()

### DIFF
--- a/garrysmod/lua/includes/extensions/net.lua
+++ b/garrysmod/lua/includes/extensions/net.lua
@@ -181,3 +181,34 @@ function net.ReadType( typeid )
 
 	error( "net.ReadType: Couldn't read type " .. typeid )
 end
+
+--
+-- Send & receive strings using compression
+-- Both text and binary are supported
+--
+do
+	local util_Compress = util.Compress
+	local net_WriteUInt = net.WriteUInt
+	local net_WriteData = net.WriteData
+
+	function net.WriteCompressed( data )
+		local compressed = ( #data ~= 0 ) and util_Compress( data ) or ""
+		local length = #compressed
+		net_WriteUInt( length, 16 )
+		net_WriteData( compressed, length )
+		return length
+	end
+
+	local net_ReadUInt = net.ReadUInt
+	local net_ReadData = net.ReadData
+	local util_Decompress = util.Decompress
+
+	function net.ReadCompressed()
+		local length = net_ReadUInt( 16 )
+		if length ~= 0 then
+			return util_Decompress( net_ReadData( length ) )
+		else
+			return ""
+		end
+	end
+end

--- a/garrysmod/lua/includes/extensions/net.lua
+++ b/garrysmod/lua/includes/extensions/net.lua
@@ -187,6 +187,9 @@ end
 -- Both text and binary are supported
 --
 do
+	local assert = assert
+	local isstring = isstring
+	local type = type
 	local util_Compress = util.Compress
 	local net_WriteUInt = net.WriteUInt
 	local net_WriteData = net.WriteData

--- a/garrysmod/lua/includes/extensions/net.lua
+++ b/garrysmod/lua/includes/extensions/net.lua
@@ -192,11 +192,17 @@ do
 	local net_WriteData = net.WriteData
 
 	function net.WriteCompressed( data )
-		local compressed = ( #data ~= 0 ) and util_Compress( data ) or ""
-		local length = #compressed
-		net_WriteUInt( length, 16 )
-		net_WriteData( compressed, length )
-		return length
+		assert( isstring( data ), "net.WriteCompressed: string expected, got " .. type( data ) )
+		if #data ~= 0 then
+			local compressed = util_Compress( data )
+			local length = #compressed
+			net_WriteUInt( length, 16 )
+			net_WriteData( compressed, length )
+			return length
+		else
+			net_WriteUInt( 0, 16 )
+			return 0
+		end
 	end
 
 	local net_ReadUInt = net.ReadUInt


### PR DESCRIPTION
Hi Willox, hi Robotboy655, hi everyone!

In order to give access to compression in net messages for little experienced Lua developers, I am giving an easy way to send strings (text or binary) using compression.

To achieve this, I have created the functions [net.WriteCompressed()](http://wiki.garrysmod.com/page/net/WriteCompressed) and [net.ReadCompressed()](http://wiki.garrysmod.com/page/net/ReadCompressed).

Hoping the best,

Momo :heart: