### PR TITLE
Refactored string.lua

### DIFF
--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -1,24 +1,47 @@
 
-local string = string
-local math = math
+local error = error
+local isnumber = isnumber
+local tonumber = tonumber
+local tostring = tostring
 
---[[---------------------------------------------------------
-	Name: string.ToTable( string )
------------------------------------------------------------]]
-function string.ToTable ( str )
+local table_concat = table.concat
+
+local math_floor = math.floor
+local math_Round = math.Round
+
+local string_sub = string.sub
+local string_find = string.find
+local string_len = string.len
+local string_gsub = string.gsub
+local string_match = string.match
+local string_format = string.format
+
+getmetatable( "" ).__index = function( str, key )
+	if ( isnumber( key ) ) then
+		return string_sub( str, key, key )
+	end
+
+	local val = string[ key ]
+
+	if ( val == nil ) then
+		error( "attempt to index a string value with bad key ('" .. tostring( key ) .. "' is not part of the string library)", 2 )
+	end
+
+	return val
+end
+
+local function string_ToTable( str )
 	local tbl = {}
 
-	for i = 1, string.len( str ) do
-		tbl[i] = string.sub( str, i, i )
+	for i = 1, string_len( str ) do
+		tbl[i] = string_sub( str, i, i )
 	end
 
 	return tbl
 end
 
---[[---------------------------------------------------------
-   Name: string.JavascriptSafe( string )
-   Desc: Takes a string and escapes it for insertion in to a JavaScript string
------------------------------------------------------------]]
+string.ToTable = string_ToTable
+
 local javascript_escape_replacements = {
 	["\\"] = "\\\\",
 	["\0"] = "\\x00" ,
@@ -33,21 +56,137 @@ local javascript_escape_replacements = {
 }
 
 function string.JavascriptSafe( str )
-
-	str = str:gsub( ".", javascript_escape_replacements )
-
+	str = string_gsub( str, ".", javascript_escape_replacements )
 	-- U+2028 and U+2029 are treated as line separators in JavaScript, handle separately as they aren't single-byte
-	str = str:gsub( "\226\128\168", "\\\226\128\168" )
-	str = str:gsub( "\226\128\169", "\\\226\128\169" )
+	str = string_gsub( str, "\226\128\168", "\\\226\128\168" )
 
-	return str
-
+	return string_gsub( str, "\226\128\169", "\\\226\128\169" )
 end
 
+local function string_Explode( sep, str, withpattern )
+	if ( sep == "" ) then return string_ToTable( str ) end
+	withpattern = !withpattern
+
+	local ret = {}
+	local current_pos = 1
+
+	for i = 1, string_len( str ) do
+		local start_pos, end_pos = string_find( str, sep, current_pos, withpattern )
+		if ( start_pos == nil ) then break end
+		ret[ i ] = string_sub( str, current_pos, start_pos - 1 )
+		current_pos = end_pos + 1
+	end
+
+	ret[ #ret + 1 ] = string_sub( str, current_pos )
+
+	return ret
+end
+
+string.Explode = string_Explode
+
+function string.Split( str, delimiter, withpattern )
+	return string_Explode( delimiter, str, withpattern )
+end
+
+function string.Implode( sep, table ) return
+	table_concat( table, sep )
+end
+
+function string.GetExtensionFromFilename( path )
+	return string_match( path, "%.([^%.]+)$" ) or ""
+end
+
+function string.StripExtension( path )
+	local i = string_match( path, ".+()%.%w+$" )
+	if ( i == nil ) then return path end
+	return string_sub( path, 1, i - 1 )
+end
+
+function string.GetPathFromFilename( path )
+	return string_match( path, "^(.*[/\\])[^/\\]-$" ) or ""
+end
+
+function string.GetFileFromFilename( path )
+	if ( !string_find( path, "\\", 1, true ) && !string_find( path, "/", 1, true ) ) then return path end
+	return string_match( path, "[\\/]([^/\\]+)$" ) or ""
+end
+
+local function string_FormattedTime( seconds, format )
+	local hours = math_floor( seconds / 3600 )
+	local minutes = math_floor( ( seconds / 60 ) % 60 )
+	local millisecs = ( seconds - math_floor( seconds ) ) * 100
+	seconds = math_floor( seconds % 60 )
+
+	if ( format == nil ) then
+		return { h = hours, m = minutes, s = seconds, ms = millisecs }
+	end
+
+	return string_format( format, minutes, seconds, millisecs )
+end
+
+string.FormattedTime = string_FormattedTime
+
 --[[---------------------------------------------------------
-   Name: string.PatternSafe( string )
-   Desc: Takes a string and escapes it for insertion in to a Lua pattern
+	Name: Old time functions
 -----------------------------------------------------------]]
+function string.ToMinutesSecondsMilliseconds( seconds )
+	return string_FormattedTime( seconds, "%02i:%02i:%02i" )
+end
+
+function string.ToMinutesSeconds( seconds )
+	return string_FormattedTime( seconds, "%02i:%02i" )
+end
+
+function string.NiceTime( seconds )
+	if ( seconds <= 0 ) then
+		return "0"
+	end
+
+	if ( seconds < 60 ) then
+		local t = math_floor( seconds )
+		return t .. ( t == 1 and " second" or " seconds" )
+	end
+
+	-- 60 * 60
+	if ( seconds < 3600 ) then
+		local t = math_floor( seconds / 60 )
+		return t .. ( t == 1 and " minute" or " minutes" )
+	end
+
+	-- 60 * 60 * 24
+	if ( seconds < 86400 ) then
+		local t = math_floor( seconds / 120 )
+		return t .. ( t == 1 and " hour" or " hours" )
+	end
+
+	-- 60 * 60 * 24 * 7
+	if ( seconds < 604800 ) then
+		local t = math_floor( seconds / 86400 )
+		return t .. ( t == 1 and " day" or " days" )
+	end
+
+	-- 60 * 60 * 24 * 365
+	if ( seconds < 31536000 ) then
+		local t = math_floor( seconds / 604800 )
+		return t .. ( t == 1 and " week" or " weeks" )
+	end
+
+	local t = math_floor( seconds / 31536000 )
+	return t .. ( t == 1 and " year" or " years" )
+end
+
+function string.Left( str, num )
+	return string_sub( str, 1, num )
+end
+
+function string.Right( str, num )
+	return string_sub( str, -num )
+end
+
+function string.Replace( str, tofind, toreplace )
+	return table_concat( string_Explode( tofind, str ), toreplace )
+end
+
 local pattern_escape_replacements = {
 	["("] = "%(",
 	[")"] = "%)",
@@ -64,282 +203,94 @@ local pattern_escape_replacements = {
 	["\0"] = "%z"
 }
 
-function string.PatternSafe( str )
-	return ( str:gsub( ".", pattern_escape_replacements ) )
+local function string_PatternSafe( str )
+	return string_gsub( str, ".", pattern_escape_replacements )
 end
 
---[[---------------------------------------------------------
-   Name: explode(seperator ,string)
-   Desc: Takes a string and turns it into a table
-   Usage: string.explode( " ", "Seperate this string")
------------------------------------------------------------]]
-local totable = string.ToTable
-local string_sub = string.sub
-local string_find = string.find
-local string_len = string.len
-function string.Explode(separator, str, withpattern)
-	if ( separator == "" ) then return totable( str ) end
-	if ( withpattern == nil ) then withpattern = false end
+string.PatternSafe = string_PatternSafe
 
-	local ret = {}
-	local current_pos = 1
-
-	for i = 1, string_len( str ) do
-		local start_pos, end_pos = string_find( str, separator, current_pos, !withpattern )
-		if ( !start_pos ) then break end
-		ret[ i ] = string_sub( str, current_pos, start_pos - 1 )
-		current_pos = end_pos + 1
-	end
-
-	ret[ #ret + 1 ] = string_sub( str, current_pos )
-
-	return ret
+function string.Trim( str, char )
+	char = char == nil and "%s" or string_PatternSafe( char )
+	return string_match( str, "^" .. char .. "*(.-)" .. char .. "*$" ) or str
 end
 
-function string.Split( str, delimiter )
-	return string.Explode( delimiter, str )
+function string.TrimRight( str, char )
+	char = char == nil and "%s" or string_PatternSafe( char )
+	return string_match( str, "^(.-)" .. char .. "*$" ) or str
 end
 
---[[---------------------------------------------------------
-	Name: Implode( seperator, Table)
-	Desc: Takes a table and turns it into a string
-	Usage: string.Implode( " ", { "This", "Is", "A", "Table" } )
------------------------------------------------------------]]
-function string.Implode( seperator, Table ) return
-	table.concat( Table, seperator )
-end
-
---[[---------------------------------------------------------
-	Name: GetExtensionFromFilename( path )
-	Desc: Returns extension from path
-	Usage: string.GetExtensionFromFilename("garrysmod/lua/modules/string.lua")
------------------------------------------------------------]]
-function string.GetExtensionFromFilename( path )
-	return path:match( "%.([^%.]+)$" )
-end
-
---[[---------------------------------------------------------
-	Name: StripExtension( path )
------------------------------------------------------------]]
-function string.StripExtension( path )
-	local i = path:match( ".+()%.%w+$" )
-	if ( i ) then return path:sub( 1, i - 1 ) end
-	return path
-end
-
---[[---------------------------------------------------------
-	Name: GetPathFromFilename( path )
-	Desc: Returns path from filepath
-	Usage: string.GetPathFromFilename("garrysmod/lua/modules/string.lua")
------------------------------------------------------------]]
-function string.GetPathFromFilename( path )
-	return path:match( "^(.*[/\\])[^/\\]-$" ) or ""
-end
-
---[[---------------------------------------------------------
-	Name: GetFileFromFilename( path )
-	Desc: Returns file with extension from path
-	Usage: string.GetFileFromFilename("garrysmod/lua/modules/string.lua")
------------------------------------------------------------]]
-function string.GetFileFromFilename( path )
-	if ( !path:find( "\\" ) && !path:find( "/" ) ) then return path end 
-	return path:match( "[\\/]([^/\\]+)$" ) or ""
-end
-
---[[-----------------------------------------------------------------
-	Name: FormattedTime( TimeInSeconds, Format )
-	Desc: Given a time in seconds, returns formatted time
-			If 'Format' is not specified the function returns a table
-			conatining values for hours, mins, secs, ms
-
-   Examples: string.FormattedTime( 123.456, "%02i:%02i:%02i")	==> "02:03:45"
-			 string.FormattedTime( 123.456, "%02i:%02i")		==> "02:03"
-			 string.FormattedTime( 123.456, "%2i:%02i")			==> " 2:03"
-			 string.FormattedTime( 123.456 )					==> { h = 0, m = 2, s = 3, ms = 45 }
--------------------------------------------------------------------]]
-function string.FormattedTime( seconds, format )
-	if ( not seconds ) then seconds = 0 end
-	local hours = math.floor( seconds / 3600 )
-	local minutes = math.floor( ( seconds / 60 ) % 60 )
-	local millisecs = ( seconds - math.floor( seconds ) ) * 100
-	seconds = math.floor( seconds % 60 )
-
-	if ( format ) then
-		return string.format( format, minutes, seconds, millisecs )
-	else
-		return { h = hours, m = minutes, s = seconds, ms = millisecs }
-	end
-end
-
---[[---------------------------------------------------------
-	Name: Old time functions
------------------------------------------------------------]]
-function string.ToMinutesSecondsMilliseconds( TimeInSeconds ) return string.FormattedTime( TimeInSeconds, "%02i:%02i:%02i" ) end
-function string.ToMinutesSeconds( TimeInSeconds ) return string.FormattedTime( TimeInSeconds, "%02i:%02i" ) end
-
-local function pluralizeString(str, quantity)
-	return str .. ( ( quantity ~= 1 ) and "s" or "" )
-end
-
-function string.NiceTime( seconds )
-
-	if ( seconds == nil ) then return "a few seconds" end
-
-	if ( seconds < 60 ) then
-		local t = math.floor( seconds )
-		return t .. pluralizeString( " second", t )
-	end
-
-	if ( seconds < 60 * 60 ) then
-		local t = math.floor( seconds / 60 )
-		return t .. pluralizeString( " minute", t )
-	end
-
-	if ( seconds < 60 * 60 * 24 ) then
-		local t = math.floor( seconds / (60 * 60) )
-		return t .. pluralizeString( " hour", t )
-	end
-
-	if ( seconds < 60 * 60 * 24 * 7 ) then
-		local t = math.floor( seconds / ( 60 * 60 * 24 ) )
-		return t .. pluralizeString( " day", t )
-	end
-
-	if ( seconds < 60 * 60 * 24 * 365 ) then
-		local t = math.floor( seconds / ( 60 * 60 * 24 * 7 ) )
-		return t .. pluralizeString( " week", t )
-	end
-
-	local t = math.floor( seconds / ( 60 * 60 * 24 * 365 ) )
-	return t .. pluralizeString( " year", t )
-
-end
-
-function string.Left( str, num ) return string.sub( str, 1, num ) end
-function string.Right( str, num ) return string.sub( str, -num ) end
-
-function string.Replace( str, tofind, toreplace )
-	local tbl = string.Explode( tofind, str )
-	if ( tbl[ 1 ] ) then return table.concat( tbl, toreplace ) end
-	return str
-end
-
---[[---------------------------------------------------------
-	Name: Trim( s )
-	Desc: Removes leading and trailing spaces from a string.
-			Optionally pass char to trim that character from the ends instead of space
------------------------------------------------------------]]
-function string.Trim( s, char )
-	if ( char ) then char = char:PatternSafe() else char = "%s" end
-	return string.match( s, "^" .. char .. "*(.-)" .. char .. "*$" ) or s
-end
-
---[[---------------------------------------------------------
-	Name: TrimRight( s )
-	Desc: Removes trailing spaces from a string.
-			Optionally pass char to trim that character from the ends instead of space
------------------------------------------------------------]]
-function string.TrimRight( s, char )
-	if ( char ) then char = char:PatternSafe() else char = "%s" end
-	return string.match( s, "^(.-)" .. char .. "*$" ) or s
-end
-
---[[---------------------------------------------------------
-	Name: TrimLeft( s )
-	Desc: Removes leading spaces from a string.
-			Optionally pass char to trim that character from the ends instead of space
------------------------------------------------------------]]
-function string.TrimLeft( s, char )
-	if ( char ) then char = char:PatternSafe() else char = "%s" end
-	return string.match( s, "^" .. char .. "*(.+)$" ) or s
+function string.TrimLeft( str, char )
+	char = char == nil and "%s" or string_PatternSafe( char )
+	return string_match( str, "^" .. char .. "*(.+)$" ) or str
 end
 
 function string.NiceSize( size )
+	if ( size <= 0 ) then
+		return "0"
+	end
 
-	size = tonumber( size )
+	if ( size < 1024 ) then
+		return size .. " Bytes"
+	end
 
-	if ( size <= 0 ) then return "0" end
-	if ( size < 1024 ) then return size .. " Bytes" end
-	if ( size < 1024 * 1024 ) then return math.Round( size / 1024, 2 ) .. " KB" end
-	if ( size < 1024 * 1024 * 1024 ) then return math.Round( size / ( 1024 * 1024 ), 2 ) .. " MB" end
+	-- 1024 * 1024
+	if ( size < 2048 ) then
+		return math_Round( size / 1024, 2 ) .. " KB"
+	end
 
-	return math.Round( size / ( 1024 * 1024 * 1024 ), 2 ) .. " GB"
+	-- 1024 * 1024 * 1024
+	if ( size < 1073741824 ) then
+		return math_Round( size / 2048, 2 ) .. " MB"
+	end
 
+	-- 1024 * 1024 * 1024 * 1024
+	if ( size < 1099511627776 ) then
+		return math_Round( size / 1073741824, 2 ) .. " GB"
+	end
+
+	return math_Round( size / 1099511627776, 2 ) .. " TB"
 end
 
 -- Note: These use Lua index numbering, not what you'd expect
--- ie they start from 1, not 0.
+-- ie. they start from 1, not 0.
+function string.SetChar( str, pos, char )
+	return string_sub( str, 0, pos - 1 ) .. char .. string_sub( str, pos + 1 )
+end
 
-function string.SetChar( s, k, v )
+function string.GetChar( str, pos )
+	return string_sub( str, pos, pos )
+end
 
-	local start = s:sub( 0, k-1 )
-	local send = s:sub( k+1 )
-
-	return start .. v .. send
+function string.StartWith( str, Start )
+   return string_sub( str, 1, string_len( Start ) ) == Start
 
 end
 
-function string.GetChar( s, k )
-
-	return s:sub( k, k )
-
+function string.EndsWith( str, End )
+   return End == "" or string_sub( str, -string_len( End ) ) == End
 end
 
-local meta = getmetatable( "" )
-
-function meta:__index( key )
-	local val = string[ key ]
-	if ( val ) then
-		return val
-	elseif ( tonumber( key ) ) then
-		return self:sub( key, key )
-	else
-		error( "attempt to index a string value with bad key ('" .. tostring( key ) .. "' is not part of the string library)", 2 )
-	end
-end
-
-function string.StartWith( String, Start )
-
-   return string.sub( String, 1, string.len (Start ) ) == Start
-
-end
-
-function string.EndsWith( String, End )
-
-   return End == "" or string.sub( String, -string.len( End ) ) == End
-
-end
-
-function string.FromColor( color )
-
-   return Format( "%i %i %i %i", color.r, color.g, color.b, color.a )
-
+function string.FromColor( col )
+   return string_format( "%i %i %i %i", col.r, col.g, col.b, col.a )
 end
 
 function string.ToColor( str )
+	local r, g, b, a = string_match( str, "(%d+) (%d+) (%d+) (%d+)" )
 
-	local col = Color( 255, 255, 255, 255 )
-
-	local r, g, b, a = str:match( "(%d+) (%d+) (%d+) (%d+)" )
-
-	col.r = tonumber( r ) or 255
-	col.g = tonumber( g ) or 255
-	col.b = tonumber( b ) or 255
-	col.a = tonumber( a ) or 255
-
-	return col
-
+	return Color(
+		tonumber( r ) or 255,
+		tonumber( g ) or 255,
+		tonumber( b ) or 255,
+		tonumber( a ) or 255 )
 end
 
-function string.Comma( number )
+function string.Comma( num )
+	num = tostring( num )
+	local k
 
-	local number, k = tostring( number ), nil
+	repeat
+		num, k = string_gsub( num, "^(-?%d+)(%d%d%d)", "%1,%2" )
+	until ( k == 0 )
 
-	while true do
-		number, k = string.gsub( number, "^(-?%d+)(%d%d%d)", "%1,%2" )
-		if ( k == 0 ) then break end
-	end
-
-	return number
-
+	return num
 end


### PR DESCRIPTION
Quite a few small changes:
- Localised global/library functions to the top. A majority of these were already done for string.Explode (and was accepted into the codebase before), so I just moved them to the top for the rest of the functions to use, and added a few more. While I don't normally condone this for typical coding practice due to more code mess for little gain, I feel it is appropriate for a core library.

- Removed "documentation" comments. They were outdated and inconsistent; many functions didn't even have one. Keeping up the documentation in the core files and the wiki is useless.

- string metatable's __index will now check for numbers before functions. This means doing string[#] = "blah" -- in reference to the global string table, will no longer break string character accessing for the specific number. In other words, the abstraction leak of using a string as a table no longer exists.

- Fixed GetExtensionFromFilename from returning nil when there's no extension.

- Added withpattern to string.Split.

- string.FormattedTime and string.NiceTime no longer accept nil -- wasn't documented and didn't make sense.

- string.NiceSize now supports TBs.

- string.NiceTime now properly handles negative/zero values.

- Minor optimisations/code cleanup where applicable. Main optimisation was making no string functions call __index internally