### PR TITLE
string.StartWith should be string.StartsWith

### DIFF
--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -298,7 +298,7 @@ function meta:__index( key )
 	end
 end
 
-function string.StartWith( String, Start )
+function string.StartsWith( String, Start )
 
    return string.sub( String, 1, string.len (Start ) ) == Start
 


### PR DESCRIPTION
It's inconsistent with string.EndsWith and other languages that implement equivalent functions