### PR TITLE
Fix panel childrens remove when panel is removed

### DIFF
--- a/garrysmod/lua/vgui/dmenubar.lua
+++ b/garrysmod/lua/vgui/dmenubar.lua
@@ -73,6 +73,10 @@ end
 
 function PANEL:OnRemove()
 
+	for _, childItem in pairs( self:GetChildren() ) do
+		childItem:Remove()
+	end
+
 	for id, pnl in pairs( self.Menus ) do
 		pnl:Remove()
 	end


### PR DESCRIPTION
When panel is removed other child objects of this panel are not removed.

For example try:
menubar.Control:Remove()
and menu elements are stay and if click at its cause lua errors