### PR TITLE
MouseInput for Loading Screen

### DIFF
--- a/garrysmod/lua/menu/loading.lua
+++ b/garrysmod/lua/menu/loading.lua
@@ -20,7 +20,7 @@ local PANEL = {}
 function PANEL:Init()
 
 	self:SetSize( ScrW(), ScrH() )
-	
+
 end
 
 
@@ -41,7 +41,7 @@ function PANEL:ShowURL( url, force )
 	self.HTML:SetSize( ScrW(), ScrH() );
 	self.HTML:Dock( FILL )
 	self.HTML:OpenURL( url )
-			
+		
 	self:InvalidateLayout()
 	
 	self.LoadedURL = url
@@ -249,7 +249,7 @@ function GameDetails( servername, serverurl, mapname, maxplayers, steamid, gamem
 	if ( engine.IsPlayingDemo() ) then return end
 
 	g_ServerName	= servername
-	g_MapNamew		= mapname
+	g_MapName		= mapname
 	g_ServerURL		= serverurl
 	g_MaxPlayers	= maxplayers
 	g_SteamID		= steamid

--- a/garrysmod/lua/menu/loading.lua
+++ b/garrysmod/lua/menu/loading.lua
@@ -119,6 +119,7 @@ function PANEL:Think()
 	
 	self:CheckForStatusChanges()
 	self:CheckDownloadTables()
+	self:MousePos()
 	
 end
 
@@ -239,6 +240,9 @@ function UpdateLoadPanel( strJavascript )
 
 end
 
+function PANEL:MousePos()
+	pnlLoading.JavascriptRun = string.format( "if ( window.MousePos ) MousePos( %i, %i );", gui.MouseX(), gui.MouseY() )
+end
 
 function GameDetails( servername, serverurl, mapname, maxplayers, steamid, gamemode )
 

--- a/garrysmod/lua/menu/loading.lua
+++ b/garrysmod/lua/menu/loading.lua
@@ -20,7 +20,7 @@ local PANEL = {}
 function PANEL:Init()
 
 	self:SetSize( ScrW(), ScrH() )
-
+	
 end
 
 
@@ -41,7 +41,7 @@ function PANEL:ShowURL( url, force )
 	self.HTML:SetSize( ScrW(), ScrH() );
 	self.HTML:Dock( FILL )
 	self.HTML:OpenURL( url )
-		
+			
 	self:InvalidateLayout()
 	
 	self.LoadedURL = url
@@ -241,7 +241,7 @@ function UpdateLoadPanel( strJavascript )
 end
 
 function PANEL:MouseInput()
-	pnlLoading.JavascriptRun = string.format( "if ( window.MouseInput ) MouseInput( %i, %i );", gui.MouseX(), gui.MouseY() )
+	pnlLoading.JavascriptRun = string.format( "if ( window.MouseInput ) MouseInput( %i, %i, \"%s\", \"%s\" );", gui.MouseX(), gui.MouseY(), input.IsMouseDown(MOUSE_LEFT), input.IsMouseDown(MOUSE_RIGHT) )
 end
 
 function GameDetails( servername, serverurl, mapname, maxplayers, steamid, gamemode )
@@ -249,7 +249,7 @@ function GameDetails( servername, serverurl, mapname, maxplayers, steamid, gamem
 	if ( engine.IsPlayingDemo() ) then return end
 
 	g_ServerName	= servername
-	g_MapName		= mapname
+	g_MapNamew		= mapname
 	g_ServerURL		= serverurl
 	g_MaxPlayers	= maxplayers
 	g_SteamID		= steamid

--- a/garrysmod/lua/menu/loading.lua
+++ b/garrysmod/lua/menu/loading.lua
@@ -119,7 +119,7 @@ function PANEL:Think()
 	
 	self:CheckForStatusChanges()
 	self:CheckDownloadTables()
-	self:MousePos()
+	self:MouseInput()
 	
 end
 
@@ -240,8 +240,8 @@ function UpdateLoadPanel( strJavascript )
 
 end
 
-function PANEL:MousePos()
-	pnlLoading.JavascriptRun = string.format( "if ( window.MousePos ) MousePos( %i, %i );", gui.MouseX(), gui.MouseY() )
+function PANEL:MouseInput()
+	pnlLoading.JavascriptRun = string.format( "if ( window.MouseInput ) MouseInput( %i, %i );", gui.MouseX(), gui.MouseY() )
 end
 
 function GameDetails( servername, serverurl, mapname, maxplayers, steamid, gamemode )


### PR DESCRIPTION
This will allow server owners to design loading screen with the ability to detect the X and Y and also when a users presses a Mouse Left+Right. This can be very useful and would make loading screen less static.

Only issue is sometimes it doesn't get called. But I think it has to do with the high intensive loading.
