### PR TITLE
Added: PrintExtract table conversion

### DIFF
--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -109,8 +109,16 @@ function PrintExtract(tT,sS)
 			if(type(v) == "string") then
 				Msg(vK.." = \""..v.."\"",nil)
 			else
-				Msg(vK.." = "..tostring(v),nil) end
-		else PrintExtract(v,vK) end
+				Msg(vK.." = "..tostring(v),nil)
+			end
+		else
+			if(v == tT) then
+				Msg(vK.." = "..sS)
+				return nil
+			else
+				PrintExtract(v,vK)
+			end
+		end
 	end
 end
 

--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -93,11 +93,11 @@ function PrintExtract(tT,sS)
 	local vS, vT, vK, sS = type(sS), type(tT), "", tostring(sS or "Data")
 	if(vT ~= "table") then
 		Msg("{"..vT.."}["..tostring(sS or "Data").."] = <"..tostring(tT)..">")
-		return nil 
+		return 
 	end
 	if(next(tT) == nil) then
 		Msg(sS.." = {}")
-		return nil
+		return
 	end
 	Msg(sS.." = {}")
 	for k,v in pairs(tT) do
@@ -115,7 +115,6 @@ function PrintExtract(tT,sS)
 		else
 			if(v == tT) then
 				Msg(vK.." = "..sS)
-				return nil
 			else
 				PrintExtract(v,vK)
 			end

--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -89,6 +89,24 @@ function PrintTable( t, indent, done )
 
 end
 
+function PrintExtract(tT,sS)
+	local vS, vT, vK, sS = type(sS), type(tT), "", tostring(sS or "Data")
+	if(vT ~= "table") then
+		print("{"..vT.."}["..tostring(sS or "Data").."] = <"..tostring(tT)..">",nil)
+		return nil 
+	end
+	if(next(tT) == nil) then print(sS.." = {}"); return nil end
+	print(sS.." = {}")
+	for k,v in pairs(tT) do
+		if(type(k) == "string") then vK = sS.."[\""..k.."\"]"
+		else vK = sS.."["..tostring(k).."]" end
+		if(type(v) ~= "table") then
+			if(type(v) == "string") then print(vK.." = \""..v.."\"",nil)
+			else print(vK.." = "..tostring(v),nil) end
+		else PrintExtract(v,vK) end
+	end
+end
+
 --[[---------------------------------------------------------
 	Returns a random vector
 -----------------------------------------------------------]]

--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -92,17 +92,24 @@ end
 function PrintExtract(tT,sS)
 	local vS, vT, vK, sS = type(sS), type(tT), "", tostring(sS or "Data")
 	if(vT ~= "table") then
-		print("{"..vT.."}["..tostring(sS or "Data").."] = <"..tostring(tT)..">",nil)
+		Msg("{"..vT.."}["..tostring(sS or "Data").."] = <"..tostring(tT)..">",nil)
 		return nil 
 	end
-	if(next(tT) == nil) then print(sS.." = {}"); return nil end
-	print(sS.." = {}")
+	if(next(tT) == nil) then
+		Msg(sS.." = {}")
+		return nil
+	end
+	Msg(sS.." = {}")
 	for k,v in pairs(tT) do
-		if(type(k) == "string") then vK = sS.."[\""..k.."\"]"
-		else vK = sS.."["..tostring(k).."]" end
+		if(type(k) == "string") then
+			vK = sS.."[\""..k.."\"]"
+		else
+			vK = sS.."["..tostring(k).."]" end
 		if(type(v) ~= "table") then
-			if(type(v) == "string") then print(vK.." = \""..v.."\"",nil)
-			else print(vK.." = "..tostring(v),nil) end
+			if(type(v) == "string") then
+				Msg(vK.." = \""..v.."\"",nil)
+			else
+				Msg(vK.." = "..tostring(v),nil) end
 		else PrintExtract(v,vK) end
 	end
 end

--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -92,7 +92,7 @@ end
 function PrintExtract(tT,sS)
 	local vS, vT, vK, sS = type(sS), type(tT), "", tostring(sS or "Data")
 	if(vT ~= "table") then
-		Msg("{"..vT.."}["..tostring(sS or "Data").."] = <"..tostring(tT)..">",nil)
+		Msg("{"..vT.."}["..tostring(sS or "Data").."] = <"..tostring(tT)..">")
 		return nil 
 	end
 	if(next(tT) == nil) then
@@ -104,12 +104,13 @@ function PrintExtract(tT,sS)
 		if(type(k) == "string") then
 			vK = sS.."[\""..k.."\"]"
 		else
-			vK = sS.."["..tostring(k).."]" end
+			vK = sS.."["..tostring(k).."]"
+		end
 		if(type(v) ~= "table") then
 			if(type(v) == "string") then
-				Msg(vK.." = \""..v.."\"",nil)
+				Msg(vK.." = \""..v.."\"")
 			else
-				Msg(vK.." = "..tostring(v),nil)
+				Msg(vK.." = "..tostring(v))
 			end
 		else
 			if(v == tT) then


### PR DESCRIPTION
PrintExtract is capable of extracting table data to use in 3-rd party application for testing. It distinguishes other types besides a table.

```lua
PrintExtract({function() end,2,"3",{["gmod"] = true,test=7},["5"]="asdf"},"myTable")
PrintExtract(2)
PrintExtract(function() end, "FUNC") -- The second argument is the desired export variable name
PrintExtract("2")

myTable = {}
myTable[1] = function: 0x0044df48
myTable[2] = 2
myTable[3] = "3"
myTable[4] = {}
myTable[4]["test"] = 7
myTable[4]["gmod"] = true
myTable["5"] = "asdf"
{number}[Data] = <2>
{function}[FUNC] = <function: 0x0203e648>
{string}[Data] = <2>

```

If you paste the code above for "myTable", it will create 1:1 the table provided in the agrument