### PR TITLE
Fix DFrame buttons height

### DIFF
--- a/garrysmod/lua/skins/default.lua
+++ b/garrysmod/lua/skins/default.lua
@@ -123,24 +123,24 @@ SKIN.tex.Tab_Bar					= GWEN.CreateTextureBorder( 128, 352, 127, 31, 4, 4, 4, 4 )
 
 SKIN.tex.Window = {}
 
-SKIN.tex.Window.Normal			= GWEN.CreateTextureBorder( 0, 0, 127, 127, 8, 32, 8, 8 )
-SKIN.tex.Window.Inactive		= GWEN.CreateTextureBorder( 128, 0, 127, 127, 8, 32, 8, 8 )
+SKIN.tex.Window.Normal			= GWEN.CreateTextureBorder( 0, 0, 127, 127, 8, 24, 8, 8 )
+SKIN.tex.Window.Inactive		= GWEN.CreateTextureBorder( 128, 0, 127, 127, 8, 24, 8, 8 )
 
-SKIN.tex.Window.Close			= GWEN.CreateTextureNormal( 32, 448, 31, 31 )
-SKIN.tex.Window.Close_Hover		= GWEN.CreateTextureNormal( 64, 448, 31, 31 )
-SKIN.tex.Window.Close_Down		= GWEN.CreateTextureNormal( 96, 448, 31, 31 )
+SKIN.tex.Window.Close			= GWEN.CreateTextureNormal( 32, 448, 31, 24 )
+SKIN.tex.Window.Close_Hover		= GWEN.CreateTextureNormal( 64, 448, 31, 24 )
+SKIN.tex.Window.Close_Down		= GWEN.CreateTextureNormal( 96, 448, 31, 24 )
 
-SKIN.tex.Window.Maxi			= GWEN.CreateTextureNormal( 32 + 96 * 2, 448, 31, 31 )
-SKIN.tex.Window.Maxi_Hover		= GWEN.CreateTextureNormal( 64 + 96 * 2, 448, 31, 31 )
-SKIN.tex.Window.Maxi_Down		= GWEN.CreateTextureNormal( 96 + 96 * 2, 448, 31, 31 )
+SKIN.tex.Window.Maxi			= GWEN.CreateTextureNormal( 32 + 96 * 2, 448, 31, 24 )
+SKIN.tex.Window.Maxi_Hover		= GWEN.CreateTextureNormal( 64 + 96 * 2, 448, 31, 24 )
+SKIN.tex.Window.Maxi_Down		= GWEN.CreateTextureNormal( 96 + 96 * 2, 448, 31, 24 )
 
-SKIN.tex.Window.Restore			= GWEN.CreateTextureNormal( 32 + 96 * 2, 448 + 32, 31, 31 )
-SKIN.tex.Window.Restore_Hover	= GWEN.CreateTextureNormal( 64 + 96 * 2, 448 + 32, 31, 31 )
-SKIN.tex.Window.Restore_Down	= GWEN.CreateTextureNormal( 96 + 96 * 2, 448 + 32, 31, 31 )
+SKIN.tex.Window.Restore			= GWEN.CreateTextureNormal( 32 + 96 * 2, 448 + 32, 31, 24 )
+SKIN.tex.Window.Restore_Hover	= GWEN.CreateTextureNormal( 64 + 96 * 2, 448 + 32, 31, 24 )
+SKIN.tex.Window.Restore_Down	= GWEN.CreateTextureNormal( 96 + 96 * 2, 448 + 32, 31, 24 )
 
-SKIN.tex.Window.Mini			= GWEN.CreateTextureNormal( 32 + 96, 448, 31, 31 )
-SKIN.tex.Window.Mini_Hover		= GWEN.CreateTextureNormal( 64 + 96, 448, 31, 31 )
-SKIN.tex.Window.Mini_Down		= GWEN.CreateTextureNormal( 96 + 96, 448, 31, 31 )
+SKIN.tex.Window.Mini			= GWEN.CreateTextureNormal( 32 + 96, 448, 31, 24 )
+SKIN.tex.Window.Mini_Hover		= GWEN.CreateTextureNormal( 64 + 96, 448, 31, 24 )
+SKIN.tex.Window.Mini_Down		= GWEN.CreateTextureNormal( 96 + 96, 448, 31, 24 )
 
 SKIN.tex.Scroller = {}
 SKIN.tex.Scroller.TrackV				= GWEN.CreateTextureBorder( 384,		208, 15, 127, 4, 4, 4, 4 )

--- a/garrysmod/lua/vgui/dframe.lua
+++ b/garrysmod/lua/vgui/dframe.lua
@@ -8,10 +8,10 @@ AccessorFunc( PANEL, "m_bScreenLock",		"ScreenLock",		FORCE_BOOL )
 AccessorFunc( PANEL, "m_bDeleteOnClose",	"DeleteOnClose",	FORCE_BOOL )
 AccessorFunc( PANEL, "m_bPaintShadow",		"PaintShadow",		FORCE_BOOL )
 
-AccessorFunc( PANEL, "m_iMinWidth", "MinWidth" )
-AccessorFunc( PANEL, "m_iMinHeight", "MinHeight" )
+AccessorFunc( PANEL, "m_iMinWidth",			"MinWidth",			FORCE_NUMBER )
+AccessorFunc( PANEL, "m_iMinHeight",		"MinHeight",		FORCE_NUMBER )
 
-AccessorFunc( PANEL, "m_bBackgroundBlur", "BackgroundBlur", FORCE_BOOL )
+AccessorFunc( PANEL, "m_bBackgroundBlur",	"BackgroundBlur",	FORCE_BOOL )
 
 function PANEL:Init()
 
@@ -240,13 +240,13 @@ function PANEL:PerformLayout()
 	end
 
 	self.btnClose:SetPos( self:GetWide() - 31 - 4, 0 )
-	self.btnClose:SetSize( 31, 31 )
+	self.btnClose:SetSize( 31, 24 )
 
 	self.btnMaxim:SetPos( self:GetWide() - 31 * 2 - 4, 0 )
-	self.btnMaxim:SetSize( 31, 31 )
+	self.btnMaxim:SetSize( 31, 24 )
 
 	self.btnMinim:SetPos( self:GetWide() - 31 * 3 - 4, 0 )
-	self.btnMinim:SetSize( 31, 31 )
+	self.btnMinim:SetSize( 31, 24 )
 
 	self.lblTitle:SetPos( 8 + titlePush, 2 )
 	self.lblTitle:SetSize( self:GetWide() - 25 - titlePush, 20 )


### PR DESCRIPTION
If you have ever noticed, the buttons in DFrame (Close, Maximize and Minimize) are taller than they appear.
They are painted 24 pixels tall and seem to be aligned with the dark gray part of the header (which is 24 pixels tall), but they are actually not. These buttons are 31 pixels tall, that's why if you hover or click the frame just below those buttons they get triggered.

This PR makes these buttons 24 pixels tall to be aligned with the draggable header of the frame and adjusts the default skin to work correctly with this change.

![](https://i.imgur.com/MRkMzc6.gif)