### PR TITLE
Add min, max args to Vector/AngleRand

### DIFF
--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -90,13 +90,13 @@ function PrintTable( t, indent, done )
 end
 
 function VectorRand( min --[[= -1]], max --[[= 1]] )
-	min = min or -1
-	max = max or 1
+	min = min || -1
+	max = max || 1
 	return Vector( math.Rand( min, max ), math.Rand( min, max ), math.Rand( min, max ) )
 end
 
 function AngleRand( min --[[-90 pitch, -180 yaw/roll]], max --[[= 90 pitch, 180 yaw/roll]] )
-	return Angle( math.Rand( min or -90, max or 90 ), math.Rand( min or -180, max or 180 ), math.Rand( min or -180, max or 180 ) )
+	return Angle( math.Rand( min || -90, max || 90 ), math.Rand( min || -180, max || 180 ), math.Rand( min || -180, max || 180 ) )
 end
 
 --[[---------------------------------------------------------

--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -89,13 +89,13 @@ function PrintTable( t, indent, done )
 
 end
 
-function VectorRand( min --[[= -1]], max --[[= 1]] )
+function VectorRand( min, max )
 	min = min || -1
 	max = max || 1
 	return Vector( math.Rand( min, max ), math.Rand( min, max ), math.Rand( min, max ) )
 end
 
-function AngleRand( min --[[-90 pitch, -180 yaw/roll]], max --[[= 90 pitch, 180 yaw/roll]] )
+function AngleRand( min, max )
 	return Angle( math.Rand( min || -90, max || 90 ), math.Rand( min || -180, max || 180 ), math.Rand( min || -180, max || 180 ) )
 end
 

--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -89,18 +89,14 @@ function PrintTable( t, indent, done )
 
 end
 
---[[---------------------------------------------------------
-	Returns a random vector
------------------------------------------------------------]]
-function VectorRand()
-	return Vector( math.Rand( -1.0, 1.0 ), math.Rand( -1.0, 1.0 ), math.Rand( -1.0, 1.0 ) )
+function VectorRand( min --[[= -1]], max --[[= 1]] )
+	min = min or -1
+	max = max or 1
+	return Vector( math.Rand( min, max ), math.Rand( min, max ), math.Rand( min, max ) )
 end
 
---[[---------------------------------------------------------
-	Returns a random angle
------------------------------------------------------------]]
-function AngleRand()
-	return Angle( math.Rand( -90, 90 ), math.Rand( -180, 180 ), math.Rand( -180, 180 ) )
+function AngleRand( min --[[-90 pitch, -180 yaw/roll]], max --[[= 90 pitch, 180 yaw/roll]] )
+	return Angle( math.Rand( min or -90, max or 90 ), math.Rand( min or -180, max or 180 ), math.Rand( min or -180, max or 180 ) )
 end
 
 --[[---------------------------------------------------------


### PR DESCRIPTION
```
function VectorRand( min --[[= -1]], max --[[= 1]] )
function AngleRand( min --[[-90 pitch, -180 yaw/roll]], max --[[= 90 pitch, 180 yaw/roll]] )
```

Maintains previous behaviour, but the arguments now give forced mins/maxs into math.Rand. This also directly matches the behaviour of RandomVector and RandomAngle in the mathlib.