### PR TITLE
Fixed: Attempt to index local 'vars' (a nil value)

### DIFF
--- a/garrysmod/lua/vgui/prop_float.lua
+++ b/garrysmod/lua/vgui/prop_float.lua
@@ -23,8 +23,8 @@ function PANEL:Setup( vars )
 	ctrl:SetDecimals( self:GetDecimals() )
 
 	-- Apply vars
-	ctrl:SetMin( vars.min || 0 )
-	ctrl:SetMax( vars.max || 1 )
+	ctrl:SetMin( tonumber(vars && vars.min) || 0 )
+	ctrl:SetMax( tonumber(vars && vars.max) || 1 )
 
 	-- The label needs mouse input so we can scratch
 	self:GetRow().Label:SetMouseInputEnabled( true )


### PR DESCRIPTION
When the "vars" limit table is mandatory and not given, the user receives the following error:
[ERROR] lua/vgui/prop_float.lua:26: attempt to index local 'vars' (a nil value)
  1. Setup - lua/vgui/prop_float.lua:26
   2. Setup - lua/vgui/dproperties.lua:38