### PR TITLE
Pre/Post Init Scripts

### DIFF
--- a/garrysmod/lua/includes/init.lua
+++ b/garrysmod/lua/includes/init.lua
@@ -1,3 +1,10 @@
+--[[---------------------------------------------------------
+	Include init_pre scripts
+-----------------------------------------------------------]]
+
+for k, v in ipairs( file.Find("init_pre/*.lua", "LUA") ) do
+	include("init_pre/"..v)
+end
 
 --[[---------------------------------------------------------
 	Non-Module includes
@@ -123,3 +130,10 @@ if ( CLIENT ) then
 
 end
 
+--[[---------------------------------------------------------
+	Include init_post scripts
+-----------------------------------------------------------]]
+
+for k, v in ipairs( file.Find("init_post/*.lua", "LUA") ) do
+	include("init_post/"..v)
+end


### PR DESCRIPTION
Probably it would be better to implement this on C side, but this is needed.  This would be useful for overriding functions, with a guarantee that the function hasn't been called before by different addons.  Before gmod13, we used to have `lua/includes/enum/` folder that did that exact thing, that is, execute scripts in `includes/enum/` before `autorun/` scripts. Right now, multiple anti cheats are using `init.lua` and other developers can't use that file, for any other purposes, without breaking anticheats.