### PR TITLE
Fix string.Comma with large numbers

### DIFF
--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -334,7 +334,7 @@ end
 function string.Comma( number )
 
 	local number, k = string.format( "%f", number ), nil
-	number = string.match( number, "^(.-)%.?0+$" ) -- Remove trailing zeros
+	number = string.match( number, "^(.-)%.?0*$" ) -- Remove trailing zeros
 	
 	while true do
 		number, k = string.gsub( number, "^(-?%d+)(%d%d%d)", "%1,%2" )

--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -333,8 +333,9 @@ end
 
 function string.Comma( number )
 
-	local number, k = tostring( number ), nil
-
+	local number, k = string.format( "%f", number ), nil
+	number = string.match( number, "^(.-)%.?0+$" ) -- Remove trailing zeros
+	
 	while true do
 		number, k = string.gsub( number, "^(-?%d+)(%d%d%d)", "%1,%2" )
 		if ( k == 0 ) then break end

--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -333,9 +333,13 @@ end
 
 function string.Comma( number )
 
-	local number, k = string.format( "%f", number ), nil
-	number = string.match( number, "^(.-)%.?0*$" ) -- Remove trailing zeros
-	
+	if isnumber( number ) then
+		number = string.format( "%f", number )
+		number = string.match( number, "^(.-)%.?0*$" ) -- Remove trailing zeros
+	end
+
+	local k
+
 	while true do
 		number, k = string.gsub( number, "^(-?%d+)(%d%d%d)", "%1,%2" )
 		if ( k == 0 ) then break end


### PR DESCRIPTION
```
print(string.Comma( 2^53 ))
```
Will print `9,007,199,254,740,992` instead of `9.007199254741e+15`