### PR TITLE
Remove impact of playercounts on server sorting

### DIFF
--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -237,11 +237,6 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 	if ( data.players == data.maxplayers ) data.recommended += 75; // Server is full
 	if ( data.pass ) data.recommended += 300; // If we can't join it, don't put it to the top
 
-	// The first few bunches of players reduce the impact of the server's ping on the ranking a little
-	if ( data.players >= 16 ) data.recommended -= 40;
-	if ( data.players >= 32 ) data.recommended -= 20;
-	if ( data.players >= 64 ) data.recommended -= 10;
-
 	data.listen = data.desc.indexOf('[L]') >= 0;
 	if ( data.listen ) data.desc = data.desc.substr( 4 );
 


### PR DESCRIPTION
I think that basing the server rating off of playercounts is a bad idea.
These fixed numbers don't represent what people are most likely looking for when picking a server.
Personally, I wouldn't say that a 15-player server is "hardcoded" to be any worse than a 16-player server, but that's how it is right now.

Let's pretent that I'm running a Trouble in Terrorist Town server. In my opinion, TTT with 16 people is a complete mess, let alone even more.
But these few lines of code are making server owners set their servers to >20 slots, because they know that once they get 16 players, the rest of the slots is going to fill up regardless of how many there are.

I realize of course that this is not the optimal solution and that servers with really low playercounts should be lower down the list. But the numbers need to be relative to the amount of players on other servers, not arbitrary fixed numbers.

I'm looking for thoughts on this.