### PR TITLE
Catch NaN for OnDown

### DIFF
--- a/garrysmod/lua/includes/modules/numpad.lua
+++ b/garrysmod/lua/includes/modules/numpad.lua
@@ -173,6 +173,7 @@ end
 function OnDown( ply, key, name, ... )
 
 	if ( !key ) then ErrorNoHalt( "ERROR: numpad.OnDown key is nil!\n" ) return end
+	if ( key ~= key ) then ErrorNoHalt( "ERROR: numpad.OnDown key is NaN!\n" ) return end
 	keys_in[ key ] = keys_in[ key ] or {}
 
 	local impulse = {}


### PR DESCRIPTION
People can spawn cameras that can't be undone by doing a console command.
```
[ERROR] lua/includes/modules/numpad.lua:180: table index is NaN
           1. OnDown - lua/includes/modules/numpad.lua:180
            2. MakeCamera - gamemodes/sandbox/entities/weapons/gmod_tool/stools/camera.lua:67
             3. LeftClick - gamemodes/sandbox/entities/weapons/gmod_tool/stools/camera.lua:96
              4. unknown - gamemodes/sandbox/entities/weapons/gmod_tool/shared.lua:227
```