### PR TITLE
TTT: Add TTTNameChangeKick hook

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -335,7 +335,7 @@ local function NameChangeKick()
    if GetRoundState() == ROUND_ACTIVE then
       for _, ply in pairs(player.GetHumans()) do
          if ply.spawn_nick then
-            if ply.has_spawned and ply.spawn_nick != ply:Nick() and not hook.Call("TTTNameChangeKick", GAMEMODE) then
+            if ply.has_spawned and ply.spawn_nick != ply:Nick() and not hook.Call("TTTNameChangeKick", GAMEMODE, ply) then
                local t = GetConVar("ttt_namechange_bantime"):GetInt()
                local msg = "Changed name during a round"
                if t > 0 then

--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -335,7 +335,7 @@ local function NameChangeKick()
    if GetRoundState() == ROUND_ACTIVE then
       for _, ply in pairs(player.GetHumans()) do
          if ply.spawn_nick then
-            if ply.has_spawned and ply.spawn_nick != ply:Nick() then
+            if ply.has_spawned and ply.spawn_nick != ply:Nick() and not hook.Call("TTTNameChangeKick", GAMEMODE) then
                local t = GetConVar("ttt_namechange_bantime"):GetInt()
                local msg = "Changed name during a round"
                if t > 0 then


### PR DESCRIPTION
I propose adding a `TTTNameChangeKick` hook that would let developers prevent players from being kicked/banned when they change their name during a round.

That'd allow more customization of this system than just changing the `ttt_namechange_bantime` cvar without having to rewrite it from scratch.

For example, this change would allow for these things to be easily implemented:
* Prevent admins from being auto-kicked
* Alter the penalty for changing nickname during a round
* Do something (add a record to a database, save some data, etc.) before the player gets kicked

Let me know what you think about this, I really thing something like this should be implemented 😄