### PR TITLE
Fixed paint tool not clearing entity mods on reload

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/paint.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/paint.lua
@@ -48,6 +48,13 @@ function TOOL:Reload( trace )
 
 	trace.Entity:RemoveAllDecals()
 
+	if ( SERVER ) then
+		for i = 1, 32 do
+			duplicator.ClearEntityModifier( trace.Entity, "decal" .. i )
+		end
+		trace.Entity.DecalCount = nil
+	end
+
 	return true
 end
 


### PR DESCRIPTION
Previously, these entity mods weren't being cleared, so if you removed the decals from an entity and then duped/saved it, the copy would still have the decals applied.