### PR TITLE
Make slider constraint not save its gmod_anchor and made gmod_anchor not duplicatable.

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/entities/gmod_anchor.lua
+++ b/garrysmod/gamemodes/sandbox/entities/entities/gmod_anchor.lua
@@ -3,6 +3,7 @@ AddCSLuaFile()
 
 ENT.Type = "anim"
 ENT.PrintName = "World Anchor"
+ENT.DoNotDuplicate = true
 
 if ( CLIENT ) then return end
 

--- a/garrysmod/lua/includes/modules/constraint.lua
+++ b/garrysmod/lua/includes/modules/constraint.lua
@@ -718,6 +718,18 @@ function Slider( Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, width, material )
 		Subdiv = 1,
 	}
 
+	local ctable = {
+		Type = "Slider",
+		Ent1 = Ent1,
+		Ent2 = Ent2,
+		Bone1 = Bone1,
+		Bone2 = Bone2,
+		LPos1 = LPos1,
+		LPos2 = LPos2,
+		width = width,
+		material = material
+	}
+
 	-- Start World Hack.
 	-- Attaching a slider to the world makes it really sucks so we make
 	-- a prop and attach to that.
@@ -758,18 +770,6 @@ function Slider( Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, width, material )
 		Constraint:DeleteOnRemove( StaticAnchor )
 
 	end
-
-	local ctable = {
-		Type = "Slider",
-		Ent1 = Ent1,
-		Ent2 = Ent2,
-		Bone1 = Bone1,
-		Bone2 = Bone2,
-		LPos1 = LPos1,
-		LPos2 = LPos2,
-		width = width,
-		material = material
-	}
 
 	Constraint:SetTable( ctable )
 


### PR DESCRIPTION
'fixed' constraints (constraints that add a slider) don't save their gmod_anchor to their constraint table so any slider they make always creates a new gmod_anchor. This modifies the slider constraint to mimic this behavior and makes gmod_anchor unduplicatable to avoid it getting copied by duplicators with 'area copy' ability.