### PR TITLE
Fixed table.Copy's global lookup_table declaration

### DIFF
--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -30,7 +30,7 @@ function table.Copy( t, lookup_table )
 		if ( !istable( v ) ) then
 			copy[ i ] = v
 		else
-			lookup_table = lookup_table or {}
+			local lookup_table = lookup_table or {}
 			lookup_table[ t ] = copy
 			if ( lookup_table[ v ] ) then
 				copy[ i ] = lookup_table[ v ] -- we already copied this table. reuse the copy.


### PR DESCRIPTION
As the title says; the missing `local` on the line that declares `lookup_table` makes it be declared globally, thus defeating the entire point of `table.Copy` in scenarios where `lookup_table` is not provided as an argument.

Please let me know if you need any further information, such as example code demonstrating the bug.

Or if this is intended behavior, why that is the case, as it goes against what a developer would expect the function to do.