### PR TITLE
Add string.Interpolate

### DIFF
--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -351,11 +351,10 @@ end
 
 function string.Interpolate( str, lookuptable )
 
-	return ( string.gsub( str, "{([_%a][_%w]*)}", function ( key )
-		local value = lookuptable[ key ]
-		assert( value != nil, "string.Interpolate: lookup failed for '" .. key .. "'" )
+	return ( string.gsub( str, "{([_%a][_%w]*)}", function( key )
+		local value = lookuptable[ key ] or "{" .. key .. "}"
 
 		return tostring( value )
-	end) )
+	end ) )
 
 end

--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -352,9 +352,9 @@ end
 function string.Interpolate( str, lookuptable )
 
 	return ( string.gsub( str, "{([_%a][_%w]*)}", function( key )
-		local value = lookuptable[ key ] or "{" .. key .. "}"
 
-		return tostring( value )
+		return tostring( lookuptable[ key ] or "{" .. key .. "}" )
+
 	end ) )
 
 end

--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -353,7 +353,7 @@ function string.Interpolate( str, lookuptable )
 
 	return ( string.gsub( str, "{([_%a][_%w]*)}", function ( key )
 		local value = lookuptable[ key ]
-		if (value == nil) then return end
+		assert( value != nil, "string.Interpolate: lookup failed for '" .. key .. "'" )
 
 		return tostring( value )
 	end) )

--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -348,3 +348,14 @@ function string.Comma( number )
 	return number
 
 end
+
+function string.Interpolate( str, lookuptable )
+
+	return ( string.gsub( str, "{([_%a][_%w]*)}", function ( key )
+		local value = lookuptable[ key ]
+		if (value == nil) then return end
+
+		return tostring( value )
+	end) )
+
+end


### PR DESCRIPTION
This is a useful function for having readable format strings as opposed to the normal ones.

Example usage:

```lua
print(string.Interpolate("Hello {name}!", {name = "garry"}))
```
That code would output `Hello garry!`

It only replaces valid lua identifiers between the braces. I figured there isn't really a need to have it work with anything else, considering one of this function's advantages is that it lets you read the format string to more easily understand the intent of the message.

As it stands, the function throws an error if the lookup for a variable fails. I think it's better this way, and it brings it in line with how `string.format` acts.