### PR TITLE
Fix DFrame not taking parent offset into account when dragging/sizing

### DIFF
--- a/garrysmod/lua/vgui/dframe.lua
+++ b/garrysmod/lua/vgui/dframe.lua
@@ -171,14 +171,16 @@ function PANEL:Think()
 
 	end
 
-	if ( self.Hovered && self.m_bSizable && mousex > ( self.x + self:GetWide() - 20 ) && mousey > ( self.y + self:GetTall() - 20 ) ) then
+	local screenX, screenY = self:LocalToScreen(0, 0)
+
+	if ( self.Hovered && self.m_bSizable && mousex > ( screenX + self:GetWide() - 20 ) && mousey > ( screenY + self:GetTall() - 20 ) ) then
 
 		self:SetCursor( "sizenwse" )
 		return
 
 	end
 
-	if ( self.Hovered && self:GetDraggable() && mousey < ( self.y + 24 ) ) then
+	if ( self.Hovered && self:GetDraggable() && mousey < ( screenY + 24 ) ) then
 		self:SetCursor( "sizeall" )
 		return
 	end
@@ -205,13 +207,15 @@ end
 
 function PANEL:OnMousePressed()
 
-	if ( self.m_bSizable && gui.MouseX() > ( self.x + self:GetWide() - 20 ) && gui.MouseY() > ( self.y + self:GetTall() - 20 ) ) then
+	local screenX, screenY = self:LocalToScreen(0, 0)
+
+	if ( self.m_bSizable && gui.MouseX() > ( screenX + self:GetWide() - 20 ) && gui.MouseY() > ( screenY + self:GetTall() - 20 ) ) then
 		self.Sizing = { gui.MouseX() - self:GetWide(), gui.MouseY() - self:GetTall() }
 		self:MouseCapture( true )
 		return
 	end
 
-	if ( self:GetDraggable() && gui.MouseY() < (self.y + 24) ) then
+	if ( self:GetDraggable() && gui.MouseY() < (screenY + 24) ) then
 		self.Dragging = { gui.MouseX() - self.x, gui.MouseY() - self.y }
 		self:MouseCapture( true )
 		return

--- a/garrysmod/lua/vgui/dframe.lua
+++ b/garrysmod/lua/vgui/dframe.lua
@@ -171,7 +171,7 @@ function PANEL:Think()
 
 	end
 
-	local screenX, screenY = self:LocalToScreen(0, 0)
+	local screenX, screenY = self:LocalToScreen( 0, 0 )
 
 	if ( self.Hovered && self.m_bSizable && mousex > ( screenX + self:GetWide() - 20 ) && mousey > ( screenY + self:GetTall() - 20 ) ) then
 
@@ -207,7 +207,7 @@ end
 
 function PANEL:OnMousePressed()
 
-	local screenX, screenY = self:LocalToScreen(0, 0)
+	local screenX, screenY = self:LocalToScreen( 0, 0 )
 
 	if ( self.m_bSizable && gui.MouseX() > ( screenX + self:GetWide() - 20 ) && gui.MouseY() > ( screenY + self:GetTall() - 20 ) ) then
 		self.Sizing = { gui.MouseX() - self:GetWide(), gui.MouseY() - self:GetTall() }
@@ -215,7 +215,7 @@ function PANEL:OnMousePressed()
 		return
 	end
 
-	if ( self:GetDraggable() && gui.MouseY() < (screenY + 24) ) then
+	if ( self:GetDraggable() && gui.MouseY() < ( screenY + 24 ) ) then
 		self.Dragging = { gui.MouseX() - self.x, gui.MouseY() - self.y }
 		self:MouseCapture( true )
 		return


### PR DESCRIPTION
When creating a DFrame inside of a container panel (i.e `container:Add("DFrame")` rather than `vgui.Create("DFrame")`), the dragging and sizing operations do not take into account the new offset of the DFrame, resulting in non-functional/wonky operation.

This change allows you to drag and size DFrames inside of panels like you would expect.