### PR TITLE
Hook library rewrite (prioritization and performance enhancements)

### DIFF
--- a/garrysmod/lua/includes/modules/hook.lua
+++ b/garrysmod/lua/includes/modules/hook.lua
@@ -1,125 +1,289 @@
-local gmod                        = gmod
-local pairs                        = pairs
-local isfunction        = isfunction
-local isstring                = isstring
-local IsValid                = IsValid
+local hook_func = 1
+local hook_name = 2
+local next_hook = 3
+local real_hook_func = 4
+local last_hook = 5
+local hook_priority = 6
 
-module( "hook" )
+local event_table = {}
 
-local Hooks = {}
+-- keeps the record of how many hooks are in an event metatable to always
+-- return a value so you don't need to do checks everywhere
+local event_count = setmetatable({}, {
+	__index = function(self, k)
+		self[k] = 0
+		return 0
+	end
+})
+local gmod = gmod
+local type = type
+local math = math
+local pairs = pairs
+local assert = assert
+local IsValid = IsValid
 
---[[---------------------------------------------------------
-    Name: GetTable
-    Desc: Returns a table of all hooks.
------------------------------------------------------------]]
-function GetTable() return Hooks end
+local noop_hook = {
+	-- hook_func
+	function() return false end,
+	-- hook_name
+	nil,
+	-- next_hook
+	nil,
+	-- real_hook_func
+	nil,
+	-- last_hook
+	nil,
+	-- hook_priority
+	-math.huge
+}
 
+module "hook"
 
---[[---------------------------------------------------------
-    Name: Add
-    Args: string hookName, any identifier, function func
-    Desc: Add a hook to listen to the specified event.
------------------------------------------------------------]]
-function Add( event_name, name, func )
+-- This is not modifiable like in the past. Other hook libraries that were
+-- implemented and overrode the library in the past also did this, so I
+-- doubt many addons will break because of this.
 
-	if ( !isfunction( func ) ) then return end
-	if ( !isstring( event_name ) ) then return end
+local function _GetTable()
+	local out = {}
+	for event, hooklist in pairs( event_table ) do
+		out[ event ] = {}
 
-	if (Hooks[ event_name ] == nil) then
-			Hooks[ event_name ] = {}
+		for i = 1, event_count[ event ] do
+			out[ event ][ hooklist[ hook_name ] ] = hooklist[ real_hook_func ]
+			hooklist = hooklist[ next_hook ]
+		end
+	end
+	return out
+end
+
+local function _GetPriority( event, name )
+	assert( type( event ) ~= "nil", "bad argument #1 to 'Remove' (value expected)" )
+	assert( type( name ) ~= "nil",  "bad argument #2 to 'Remove' (value expected)" )
+
+	local iterator = event_table[ event ]
+	if ( not iterator ) then
+		return
 	end
 
-	Hooks[ event_name ][ name ] = func
-
+	for i = 1, event_count[ event ] do
+		if ( iterator[ hook_name ] == name ) then
+			return iterator[ hook_priority ]
+		end
+		iterator = iterator[ next_hook ]
+	end
 end
 
 
---[[---------------------------------------------------------
-    Name: Remove
-    Args: string hookName, identifier
-    Desc: Removes the hook with the given indentifier.
------------------------------------------------------------]]
-function Remove( event_name, name )
+local function _Remove( event, name )
+	assert( type( event ) ~= "nil", "bad argument #1 to 'Remove' (value expected)" )
+	assert( type( name ) ~= "nil",  "bad argument #2 to 'Remove' (value expected)" )
 
-	if ( !isstring( event_name ) ) then return end
-	if ( !Hooks[ event_name ] ) then return end
+	local iterator = event_table[ event ]
+	if ( not iterator ) then
+		return
+	end
 
-	Hooks[ event_name ][ name ] = nil
+	local first_hook = iterator
 
+	for i = 1, event_count[ event ] do
+		if ( iterator[ hook_name ] == name ) then
+			local last, next = iterator[ last_hook ], iterator[ next_hook ]
+
+			if ( last ) then
+				last[ next_hook ] = iterator[ next_hook ]
+			end
+
+			if ( next ~= noop_hook ) then
+				next[ last_hook ] = iterator[ last_hook ]
+			end
+
+			-- If this is the start of the list, update it to the correct value
+			-- don't ever let the first value be noop_hook since it will just
+			-- waste time
+			if ( iterator == first_hook ) then
+				event_table[ event ] = next ~= noop_hook and next or nil
+			end
+
+			-- Removed, decrement the event hook count
+			event_count[ event ] = event_count[ event ] - 1
+
+			break
+		end
+
+		iterator = iterator[ next_hook ]
+	end
 end
 
+local function _Add( event, name, real_fn, priority )
+	assert( event ~= nil, "bad argument #1 to 'Add' (value expected)" )
+	assert( type( real_fn ) == "function", "bad argument #3 to 'Add' (function expected)" )
+	assert( type( priority ) == "number" or type( priority ) == "nil", "bad argument #4 to 'Add' (number or nil expected)" )
+	assert( priority == priority, "bad argument #4 to 'Add' (number cannot be nan)" )
 
---[[---------------------------------------------------------
-    Name: Run
-    Args: string hookName, vararg args
-    Desc: Calls hooks associated with the hook name.
------------------------------------------------------------]]
-function Run( name, ... )
-	return Call( name, gmod and gmod.GetGamemode() or nil, ... )
-end
+	if ( not name ) then
+		return
+	end
 
+	priority = priority or 0
 
---[[---------------------------------------------------------
-    Name: Run
-    Args: string hookName, table gamemodeTable, vararg args
-    Desc: Calls hooks associated with the hook name.
------------------------------------------------------------]]
-function Call( name, gm, ... )
+	-- To remove loops in hook.Call we replace every function with another
+	-- that calls the next or returns its values
 
-	--
-	-- Run hooks
-	--
-	local HookTable = Hooks[ name ]
-	if ( HookTable != nil ) then
-	
-		local a, b, c, d, e, f;
+	local fn
 
-		for k, v in pairs( HookTable ) do 
-			
-			if ( isstring( k ) ) then
-				
-				--
-				-- If it's a string, it's cool
-				--
-				a, b, c, d, e, f = v( ... )
-
+	if ( type( name ) ~= "string" ) then
+		-- IsValid checks are required
+		fn = function( myentry, ... )
+			if ( not IsValid( name ) ) then
+				_Remove( event, name )
 			else
-
-				--
-				-- If the key isn't a string - we assume it to be an entity
-				-- Or panel, or something else that IsValid works on.
-				--
-				if ( IsValid( k ) ) then
-					--
-					-- If the object is valid - pass it as the first argument (self)
-					--
-					a, b, c, d, e, f = v( k, ... )
-				else
-					--
-					-- If the object has become invalid - remove it
-					--
-					HookTable[ k ] = nil
+				local a, b, c, d, e, f = myentry[ real_hook_func ]( name, ... )
+				if (a ~= nil) then
+					return true, a, b, c, d, e, f
 				end
 			end
 
-			--
-			-- Hook returned a value - it overrides the gamemode function
-			--
-			if ( a != nil ) then
-				return a, b, c, d, e, f
+			local next = myentry[ next_hook ]
+			return next[ hook_func ]( next, ... )
+		end
+	else
+		fn = function( myentry, ... )
+			local a, b, c, d, e, f = real_fn( ... )
+			if (a == nil) then
+				local next = myentry[ next_hook ]
+				return next[ hook_func ]( next, ... )
 			end
-				
+			return true, a, b, c, d, e, f
 		end
 	end
-	
-	--
-	-- Call the gamemode function
-	--
-	if ( !gm ) then return end
-	
-	local GamemodeFunction = gm[ name ]
-	if ( GamemodeFunction == nil ) then return end
-			
-	return GamemodeFunction( gm, ... )        
-	
+
+	local iterator = event_table[ event ]
+
+	local new_hook
+
+	-- Check if a hook with the given name already exists
+	for i = 1, event_count[ event ] do
+		if ( iterator[ hook_name ] == name ) then
+			new_hook = iterator
+			break
+		end
+		iterator = iterator[ next_hook ]
+	end
+
+	-- If it does, update
+	if ( new_hook ) then
+		new_hook[ hook_func ]      = fn
+		new_hook[ real_hook_func ] = real_fn
+
+		-- If the old hook existed and had the same priority, no need to 
+		-- reposition the hook, so just stop here
+		if ( new_hook[ hook_priority ] == priority ) then
+			return
+		end
+
+		-- WARNING: UNDEFINED BEHAVIOR WARNING doing this inside another hook
+		-- with earlier priority than the hook running could run the hook again
+		_Remove( event, name )
+		new_hook[ hook_priority ] = priority
+		new_hook[ next_hook ]	   = noop_hook
+		new_hook[ last_hook ]	   = nil
+	else
+		-- Hook didn't exist, create it
+		new_hook = {
+			-- hook_func
+			fn,
+			-- hook_name
+			name,
+			-- next_hook
+			noop_hook,
+			-- real_hook_func
+			real_fn,
+			-- last_hook
+			nil,
+			-- hook_priority
+			priority
+		}
+	end
+
+	-- increment hook count here
+	event_count[ event ] = event_count[ event ] + 1
+
+	-- find link in hook list to add to
+	iterator = event_table[ event ]
+	local first_hook = iterator
+
+	if ( iterator ) then
+		local lasthook
+
+		for i = 1, event_count[ event ] do
+			-- Check priority to see if we can fit
+			-- This will ALWAYS happen since we have noop_hook at -infinity
+			-- priority and filter out NaN as priority
+			if ( iterator[ hook_priority ] <= priority ) then
+				-- insert between last and next hook
+				if ( lasthook ) then
+					lasthook[ next_hook ] = new_hook
+				end
+
+				iterator[ last_hook ] = new_hook
+				new_hook[ next_hook ] = iterator
+				new_hook[ last_hook ] = lasthook
+
+				-- If this hook is not at the start of the array we don't need
+				-- to update anything further
+				if ( first_hook ~= iterator ) then
+					return
+				end
+
+				break
+			end
+
+			-- not suitable here, check next hook in list
+			lasthook = iterator
+			iterator = iterator[ next_hook ]
+		end
+	end
+
+	-- List was empty or was inserted at the beginning
+	event_table[ event ] = new_hook
+end
+
+local function _Call( event, gm, ... )
+	local hook = event_table[ event ]
+
+	if ( hook ) then
+		-- this single call will tail recurse until it finds a hook that
+		-- returns or at the end of the list
+		local found, a, b, c, d, e, f = hook[ hook_func ]( hook, ... )
+		if ( found ) then
+			return a, b, c, d, e, f
+		end
+	end
+
+	if ( gm ) then
+		local fn = gm[ event ]
+		if ( fn ) then
+			return fn( gm, ... )
+		end
+	end
+end
+
+local function _Run( event, ... )
+	return _Call( event, gmod and gmod.GetGamemode() or nil, ... )
+end
+
+Remove = _Remove
+GetTable = _GetTable
+Add = _Add
+Call = _Call
+Run = _Run
+GetPriority = _GetPriority
+Priority = {
+	NO_RETURN = math.huge -- not enforced, just should be followed
+}
+
+-- Leave this for people to not mess with the library and have people who need
+-- to stil able to, just don't document it
+GetInternal = function()
+	return event_table, event_count
 end


### PR DESCRIPTION
This is based on my rewrite from https://gist.github.com/meepen/5566c9598e0e610e5885d12fad2ec3a8

Notes: 
- This maintains almost 100% backwards compatibility with the current hook system, the only exception is that `hook.GetTable()` modifications won't add or remove hooks to run. I believe this will be fine because ULX does the same, so developers have come to expect it won't work on a majority of servers.
- Adds priority to the hook.Add function (higher number = higher priority)
- Adds `hook.Priority` (a table) with a single member `NO_RETURN`
- `NO_RETURN` is NOT enforced in code but should be followed as a standard. It will always be ran first in the priority list.
- Adds `hook.GetPriority(event, name)`
- Adds `hook.GetInternal()` so people who want to irritate the hook library can do so if they want without rewriting it or replacing it with a whole new library. Please don't document this on the wiki, or make it say it is internal and should not be used.
- Adds some type checking to arguments for sanity's sake

credits:
@ThatLing for reviewing my code to ensure everything is tip top shape and can be read