### PR TITLE
[TTT] Make first-person spectating not draw the label of the spectated player

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
@@ -579,7 +579,7 @@ if CLIENT then
    function SWEP:DrawHUD()
       self.BaseClass.DrawHUD(self)
 
-      if self.dt.can_rag_pin and IsValid(self.dt.carried_rag) and LocalPlayer():IsTraitor() then
+      if LocalPlayer():IsSpec() or self.dt.can_rag_pin and IsValid(self.dt.carried_rag) and LocalPlayer():IsTraitor() then
          local client = LocalPlayer()
 
          local tr = util.TraceLine({start  = client:EyePos(),

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
@@ -579,16 +579,18 @@ if CLIENT then
    function SWEP:DrawHUD()
       self.BaseClass.DrawHUD(self)
 
-      if LocalPlayer():IsSpec() or self.dt.can_rag_pin and IsValid(self.dt.carried_rag) and LocalPlayer():IsTraitor() then
+      if self.dt.can_rag_pin and IsValid(self.dt.carried_rag) then
          local client = LocalPlayer()
 
-         local tr = util.TraceLine({start  = client:EyePos(),
-                                    endpos = client:EyePos() + (client:GetAimVector() * PIN_RAG_RANGE),
-                                    filter = {client, self, self.dt.carried_rag},
-                                    mask   = MASK_SOLID})
+         if not client:IsSpec() and client:IsTraitor() then
+            local tr = util.TraceLine({start  = client:EyePos(),
+               endpos = client:EyePos() + (client:GetAimVector() * PIN_RAG_RANGE),
+               filter = {client, self, self.dt.carried_rag},
+               mask   = MASK_SOLID})
 
-         if tr.HitWorld and (not tr.HitSky) then
-            draw.SimpleText(PT("magnet_help", key_params), "TabLarge", ScrW() / 2, ScrH() / 2 - 50, COLOR_RED, TEXT_ALIGN_CENTER)
+            if tr.HitWorld and (not tr.HitSky) then
+               draw.SimpleText(PT("magnet_help", key_params), "TabLarge", ScrW() / 2, ScrH() / 2 - 50, COLOR_RED, TEXT_ALIGN_CENTER)
+            end
          end
       end
    end

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -140,6 +140,8 @@ local rag_color = Color(200,200,200,255)
 
 local GetLang = LANG.GetUnsafeLanguageTable
 
+local MAX_TRACE_LENGTH = math.sqrt(3) * 2 * 16384
+
 function GM:HUDDrawTargetID()
    local client = LocalPlayer()
 
@@ -149,7 +151,17 @@ function GM:HUDDrawTargetID()
       DrawPropSpecLabels(client)
    end
 
-   local trace = client:GetEyeTrace(MASK_SHOT)
+   local startpos = client:EyePos()
+   local endpos = client:GetAimVector()
+   endpos:Mul(MAX_TRACE_LENGTH)
+   endpos:Add(startpos)
+
+   local trace = util.TraceLine({
+      start = startpos,
+      endpos = endpos,
+      mask = MASK_SHOT,
+      filter = client:GetObserverMode() == OBS_MODE_IN_EYE and {client, client:GetObserverTarget()} or client
+   })
    local ent = trace.Entity
    if (not IsValid(ent)) or ent.NoTarget then return end
 


### PR DESCRIPTION
It now will show the label of whoever the spectated player is looking at. This also stops drawing the "MOUSE 1 to hang bodies" magneto label for spectators.