### PR TITLE
Fixed entity function type consistency

### DIFF
--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -4,7 +4,13 @@ local meta = FindMetaTable( "Entity" )
 -- Return if there's nothing to add on to
 if ( !meta ) then return end
 
-AccessorFunc( meta, "m_bPlayPickupSound", "ShouldPlayPickupSound" )
+function meta:GetShouldPlayPickupSound()
+	return self.m_bPlayPickupSound || false
+end
+
+function meta:SetShouldPlayPickupSound( bPlaySound )
+	self.m_bPlayPickupSound = tobool( bPlaySound ) || false
+end
 
 --
 -- Entity index accessor. This used to be done in engine, but it's done in Lua now because it's faster
@@ -51,6 +57,10 @@ end
 if ( SERVER ) then
 
 	function meta:SetCreator( ply )
+		if ( !isentity( ply ) ) then
+			error( "bad argument #1 to 'SetCreator' (Entity expected, got " .. type( ply ) .. ")", 2 )
+		end
+
 		self.m_PlayerCreator = ply
 	end
 
@@ -475,7 +485,13 @@ end
 
 if ( SERVER ) then
 
-	AccessorFunc( meta, "m_bUnFreezable", "UnFreezable" )
+	function meta:GetUnFreezable()
+		return self.m_bUnFreezable || false
+	end
+
+	function meta:SetUnFreezable( bFreeze )
+		self.m_bUnFreezable = tobool( bFreeze ) || false
+	end
 
 end
 

--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -56,8 +56,10 @@ end
 
 if ( SERVER ) then
 
-	function meta:SetCreator( ply )
-		if ( !isentity( ply ) ) then
+	function meta:SetCreator( ply --[[= NULL]] )
+		if ( ply == nil ) then
+			ply = NULL
+		elseif ( !isentity( ply ) ) then
 			error( "bad argument #1 to 'SetCreator' (Entity expected, got " .. type( ply ) .. ")", 2 )
 		end
 


### PR DESCRIPTION
Fixes the rest of the functions in https://github.com/Facepunch/garrysmod-issues/issues/3132

RenderOrigin and RenderAngles internally depend on those functions to return nil, so those should probably be moved to engine.

This will not break any addons since these functions return booleans.