### PR TITLE
TTT: Fix always playing zoom-out animation

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -445,10 +445,12 @@ function SWEP:WasBought(buyer)
 end
 
 function SWEP:SetIronsights(b)
-   self:SetIronsightsPredicted(b)
-   self:SetIronsightsTime(CurTime())
-   if CLIENT then
-      self:CalcViewModel()
+   if (b ~= self:GetIronsights()) then
+      self:SetIronsightsPredicted(b)
+      self:SetIronsightsTime(CurTime())
+      if CLIENT then
+         self:CalcViewModel()
+      end
    end
 end
 function SWEP:GetIronsights()


### PR DESCRIPTION
Since #1387 all weapons in TTT play their zoom-out animation for a split second when reloading regardless whether it's needed (when in zoom before reloading) or not.
This looks weird as you can see here:
[before.mp4](https://1fichier.com/?57at2pusal)

Adding a `if (b ~= self:GetIronsights()) then` check prevents from setting the 'new' state and playing the reload animation when the state doesn't change. See here:
[after.mp4](https://1fichier.com/?jjlcvwrb95)