### PR TITLE
NoDrop NPC spawn fix

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/commands.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/commands.lua
@@ -308,14 +308,14 @@ local function InternalSpawnNPC( Player, Position, Normal, Class, Equipment, Spa
 	--
 	-- This NPC has to be spawned on a ceiling ( Barnacle )
 	--
-	if ( NPCData.OnCeiling && Vector( 0, 0, -1 ):Dot( Normal ) < 0.95 ) then
-		return nil
-	end
-
+	if ( NPCData.OnCeiling ) then
+		if ( Vector( 0, 0, -1 ):Dot( Normal ) < 0.95 ) then
+			return nil
+		end
 	--
 	-- This NPC has to be spawned on a floor ( Turrets )
 	--
-	if ( NPCData.OnFloor && Vector( 0, 0, 1 ):Dot( Normal ) < 0.95 ) then
+	elseif ( NPCData.OnFloor && Vector( 0, 0, 1 ):Dot( Normal ) < 0.95 ) then
 		return nil
 	else
 		bDropToFloor = true
@@ -408,7 +408,7 @@ local function InternalSpawnNPC( Player, Position, Normal, Class, Equipment, Spa
 	NPC:Spawn()
 	NPC:Activate()
 
-	if ( bDropToFloor && !NPCData.OnCeiling ) then
+	if ( bDropToFloor ) then
 		NPC:DropToFloor()
 	end
 
@@ -499,7 +499,7 @@ local function GenericNPCDuplicator( ply, mdl, class, equipment, spawnflags, dat
 
 		duplicator.DoGeneric( ent, data )
 
-		if ( !NPCData.OnCeiling ) then
+		if ( !NPCData.OnCeiling && !NPCData.NoDrop ) then
 			ent:SetPos( pos )
 			ent:DropToFloor()
 		end

--- a/garrysmod/lua/autorun/base_npcs.lua
+++ b/garrysmod/lua/autorun/base_npcs.lua
@@ -6,6 +6,8 @@ local function AddNPC( t, class )
 	list.Set( "NPC", class or t.Class, t )
 end
 
+
+
 local Category = "Humans + Resistance"
 
 AddNPC( {
@@ -97,7 +99,7 @@ AddNPC( {
 	Name = "Medic",
 	Class = "npc_citizen",
 	Category = Category,
-	SpawnFlags = 8 + 131072, --bit.bor( SF_NPC_DROP_HEALTHKIT, SF_CITIZEN_MEDIC ),
+	SpawnFlags = SERVER and bit.bor( SF_NPC_DROP_HEALTHKIT, SF_CITIZEN_MEDIC ) or nil,
 	KeyValues = { citizentype = CT_REBEL, SquadName = "resistance" },
 	Weapons = { "weapon_pistol", "weapon_smg1", "weapon_ar2", "weapon_shotgun" }
 }, "Medic" )
@@ -118,7 +120,6 @@ AddNPC( {
 } )
 
 if ( IsMounted( "ep2" ) ) then
-
 	AddNPC( {
 		Name = "Uriah",
 		Class = "npc_vortigaunt",
@@ -132,7 +133,6 @@ if ( IsMounted( "ep2" ) ) then
 		Class = "npc_magnusson",
 		Category = Category
 	} )
-
 end
 
 if ( IsMounted( "lostcoast" ) ) then
@@ -143,6 +143,8 @@ if ( IsMounted( "lostcoast" ) ) then
 		Weapons = { "weapon_oldmanharpoon" }
 	} ) -- Has no death sequence
 end
+
+
 
 Category = "Zombies + Enemy Aliens"
 
@@ -224,6 +226,15 @@ AddNPC( {
 	KeyValues = { SquadName = "zombies" }
 } )
 
+if ( IsMounted( "episodic" ) ) then
+	AddNPC( {
+		Name = "Zombine",
+		Class = "npc_zombine",
+		Category = Category,
+		KeyValues = { SquadName = "zombies" }
+	} )
+end
+
 if ( IsMounted( "ep2" ) ) then
 	game.AddParticles( "particles/grub_blood.pcf" )
 	game.AddParticles( "particles/antlion_gib_02.pcf" )
@@ -253,14 +264,7 @@ if ( IsMounted( "ep2" ) ) then
 	} )
 end
 
-if ( IsMounted( "episodic" ) ) then
-	AddNPC( {
-		Name = "Zombine",
-		Class = "npc_zombine",
-		Category = Category,
-		KeyValues = { SquadName = "zombies" }
-	} )
-end
+
 
 Category = "Animals"
 
@@ -274,20 +278,24 @@ AddNPC( {
 AddNPC( {
 	Name = "Crow",
 	Class = "npc_crow",
-	Category = Category
+	Category = Category,
+	NoDrop = true
 } )
 
 AddNPC( {
 	Name = "Pigeon",
 	Class = "npc_pigeon",
-	Category = Category
+	Category = Category,
+	NoDrop = true
 } )
 
 AddNPC( {
 	Name = "Seagull",
 	Class = "npc_seagull",
-	Category = Category
+	Category = Category,
+	NoDrop = true
 } )
+
 
 
 Category = "Combine"
@@ -297,7 +305,7 @@ AddNPC( {
 	Class = "npc_metropolice",
 	Category = Category,
 	Weapons = { "weapon_stunstick", "weapon_pistol", "weapon_smg1" },
-	SpawnFlags = 8,
+	SpawnFlags = SF_NPC_DROP_HEALTHKIT,
 	KeyValues = { SquadName = "overwatch" }
 } )
 
@@ -306,7 +314,8 @@ AddNPC( {
 	Class = "npc_rollermine",
 	Category = Category,
 	Offset = 20,
-	KeyValues = { SquadName = "overwatch" }
+	KeyValues = { SquadName = "overwatch" },
+	NoDrop = true
 } )
 
 AddNPC( {
@@ -365,7 +374,7 @@ AddNPC( {
 	Model = "models/combine_super_soldier.mdl",
 	Weapons = { "weapon_ar2" },
 	KeyValues = { Numgrenades = 10, SquadName = "overwatch" },
-	SpawnFlags = 16384
+	SpawnFlags = SF_NPC_NO_PLAYER_PUSHAWAY
 }, "CombineElite" )
 
 AddNPC( {
@@ -373,7 +382,8 @@ AddNPC( {
 	Class = "npc_cscanner",
 	Category = Category,
 	Offset = 20,
-	KeyValues = { SquadName = "overwatch" }
+	KeyValues = { SquadName = "overwatch" },
+	NoDrop = true
 } )
 
 AddNPC( {
@@ -381,7 +391,8 @@ AddNPC( {
 	Class = "npc_clawscanner",
 	Category = Category,
 	Offset = 20,
-	KeyValues = { SquadName = "overwatch" }
+	KeyValues = { SquadName = "overwatch" },
+	NoDrop = true
 } )
 
 AddNPC( {
@@ -389,7 +400,8 @@ AddNPC( {
 	Class = "npc_combinegunship",
 	Category = Category,
 	Offset = 300,
-	KeyValues = { SquadName = "overwatch" }
+	KeyValues = { SquadName = "overwatch" },
+	NoDrop = true
 } )
 
 AddNPC( {
@@ -397,7 +409,8 @@ AddNPC( {
 	Class = "npc_combinedropship",
 	Category = Category,
 	Offset = 300,
-	KeyValues = { SquadName = "overwatch" }
+	KeyValues = { SquadName = "overwatch" },
+	NoDrop = true
 } )
 
 AddNPC( {
@@ -406,7 +419,8 @@ AddNPC( {
 	Category = Category,
 	Offset = 300,
 	Health = 600,
-	KeyValues = { SquadName = "overwatch" }
+	KeyValues = { SquadName = "overwatch" },
+	NoDrop = true
 } )
 
 AddNPC( {
@@ -415,7 +429,8 @@ AddNPC( {
 	Category = Category,
 	OnCeiling = true,
 	Offset = 2,
-	KeyValues = { SquadName = "overwatch" }
+	KeyValues = { SquadName = "overwatch" },
+	NoDrop = true
 } )
 
 AddNPC( {
@@ -448,7 +463,8 @@ AddNPC( {
 	Name = "Manhack",
 	Class = "npc_manhack",
 	Category = Category,
-	KeyValues = { SquadName = "overwatch" }
+	KeyValues = { SquadName = "overwatch" },
+	NoDrop = true
 } )
 
 if ( IsMounted( "ep2" ) ) then
@@ -459,6 +475,8 @@ if ( IsMounted( "ep2" ) ) then
 		KeyValues = { SquadName = "overwatch" }
 	} )
 end
+
+
 
 if ( IsMounted( "hl1" ) ) then
 


### PR DESCRIPTION
- Added NoDrop to multiple NPCs to fix them spawning below platforms/displacements. This is best shown spawning a rollermine or combine camera on this platform in gm_construct:
![](https://i.imgur.com/5pxiD7k.jpg)
DropToFloor's trace starts in the platform and does not hit the displacement below, so it will drop the NPC to the floor underneath the map. The NPCs chosen for this parameter do not rely on starting on the ground and can be spawned anywhere.
- Fixed NoDrop not applying to duped NPCs.
- Changed some raw numbers to SF_ enums.