### PR TITLE
Add HL1 skill cfgs

### DIFF
--- a/garrysmod/cfg/hl1_skill1.cfg
+++ b/garrysmod/cfg/hl1_skill1.cfg
@@ -1,0 +1,130 @@
+// Barney
+sk_barney_health		"35"
+
+// Apache 
+//sk_apache_health	"150"
+
+// Headcrab
+sk_headcrab_health		"10"
+sk_headcrab_dmg_bite		"5"
+
+// Zombie
+sk_zombie_health		"50"
+sk_zombie_dmg_one_slash		"10"
+sk_zombie_dmg_both_slash	"25"
+
+// Vortigaunt
+sk_islave_health		"30"
+sk_islave_dmg_claw      	"8"
+sk_islave_dmg_clawrake		"25"
+sk_islave_dmg_zap		"10"
+
+//Bullsquid
+sk_bullsquid_health		"40"
+sk_bullsquid_dmg_bite   	"15"
+sk_bullsquid_dmg_whip   	"25"
+sk_bullsquid_dmg_spit		"10"
+
+// PLAYER
+//sk_plr_dmg_crowbar		"10"
+//sk_plr_dmg_9mm_bullet		"8"
+//sk_plr_dmg_357_bullet		"40"
+//sk_plr_dmg_buckshot		"5"
+//sk_plr_dmg_mp5_grenade		"100"
+//sk_plr_dmg_rpg			"100"
+//sk_plr_dmg_xbow_bolt_plr	"10"
+//sk_plr_dmg_xbow_bolt_npc	"50"
+//sk_plr_dmg_egon_narrow		"6"
+//sk_plr_dmg_egon_wide		"14"
+//sk_plr_dmg_gauss		"20"
+sk_plr_dmg_grenade		"100"
+//sk_plr_dmg_hornet		"7"
+//sk_plr_dmg_tripmine		"150"
+//sk_plr_dmg_satchel		"150"
+
+//Human Grunts
+sk_hgrunt_health		"50"
+sk_hgrunt_kick			"5"
+sk_hgrunt_pellets		"3"
+sk_hgrunt_gspeed		"400"
+
+//Ichthyosaur
+sk_ichthyosaur_health		"200"
+sk_ichthyosaur_shake		"20"
+
+//Gargantua
+sk_gargantua_health		"800"
+sk_gargantua_dmg_slash		"10"
+sk_gargantua_dmg_fire		"3"
+sk_gargantua_dmg_stomp		"50"
+
+// Snark
+sk_snark_health			"2"
+sk_snark_dmg_bite		"10"
+sk_snark_dmg_pop		"5"
+
+//Nihilanth
+sk_nihilanth_health		"800"
+sk_nihilanth_zap		"30"
+
+// Alien Grunt
+sk_agrunt_health		"60"
+sk_agrunt_dmg_punch		"10"
+
+// Alien Controller
+sk_controller_health	"60"
+sk_controller_dmgzap	"15"
+sk_controller_speedball	"650"
+sk_controller_dmgball	"3"
+
+sk_hassassin_health	"30"
+
+// Turret
+//sk_turret_health	"50"
+
+// MiniTurret
+//sk_miniturret_health	"40"
+
+// Sentry Turret
+//sk_sentry_health	"40"
+
+// Leech
+sk_leech_health	"2"
+sk_leech_dmg_bite "2"
+
+// Big momma
+sk_bigmomma_health_factor 	"1.0"
+sk_bigmomma_dmg_slash 	"50"
+sk_bigmomma_dmg_blast 	"100"
+sk_bigmomma_radius_blast "250"
+
+
+// MONSTER WEAPONS
+//sk_npc_dmg_hornet		"4"
+//sk_npc_dmg_9mm_bullet		"5"
+//sk_npc_dmg_9mmAR_bullet		"3"
+//sk_npc_dmg_12mm_bullet		"8"
+
+// MISC
+//sk_max_9mm_bullet		"250"
+//sk_max_357_bullet		"36"
+//sk_max_buckshot			"125"
+//sk_max_mp5_grenade		"10"
+//sk_mp5_grenade_radius		"100"
+//sk_max_rpg_rocket		"5"
+//sk_max_xbow_bolt		"50"
+//sk_max_uranium			"100"
+sk_max_grenade			"10"
+//sk_max_hornet			"8"
+//sk_max_snark			"15"
+//sk_max_tripmine			"5"
+//sk_max_satchel			"5"
+
+// HEALTH/SUIT CHARGE DISTRIBUTION
+sk_suitcharger			"75"
+sk_battery			"15"
+
+sk_healthcharger		"50"
+sk_healthkit			"15"
+
+sk_scientist_heal		"25"

--- a/garrysmod/cfg/hl1_skill2.cfg
+++ b/garrysmod/cfg/hl1_skill2.cfg
@@ -1,0 +1,129 @@
+// Barney
+sk_barney_health		"35"
+
+// Apache 
+//sk_apache_health	"250"
+
+// Headcrab
+sk_headcrab_health		"10"
+sk_headcrab_dmg_bite		"10"
+
+// Zombie
+sk_zombie_health		"50"
+sk_zombie_dmg_one_slash		"20"
+sk_zombie_dmg_both_slash	"40"
+
+// Vortigaunt
+sk_islave_health		"30"
+sk_islave_dmg_claw      	"10"
+sk_islave_dmg_clawrake		"25"
+sk_islave_dmg_zap		"10"
+
+//Bullsquid
+sk_bullsquid_health		"40"
+sk_bullsquid_dmg_bite   	"25"
+sk_bullsquid_dmg_whip   	"35"
+sk_bullsquid_dmg_spit		"10"
+
+//Human Grunts
+sk_hgrunt_health		"50"
+sk_hgrunt_kick			"10"
+sk_hgrunt_pellets		"5"
+sk_hgrunt_gspeed		"600"
+
+//Ichthyosaur
+sk_ichthyosaur_health		"200"
+sk_ichthyosaur_shake		"35"
+
+//Gargantua
+sk_gargantua_health		"800"
+sk_gargantua_dmg_slash		"30"
+sk_gargantua_dmg_fire		"5"
+sk_gargantua_dmg_stomp		"100"
+
+// Snark
+sk_snark_health			"2"
+sk_snark_dmg_bite		"10"
+sk_snark_dmg_pop		"5"
+
+// Alien Grunt
+sk_agrunt_health		"90"
+sk_agrunt_dmg_punch		"20"
+
+// Alien Controller
+sk_controller_health	"60"
+sk_controller_dmgzap	"25"
+sk_controller_speedball	"800"
+sk_controller_dmgball	"4"
+
+sk_hassassin_health	"50"
+
+// Turret
+//sk_turret_health	"50"
+
+// MiniTurret
+//sk_miniturret_health	"40"
+
+// Sentry Turret
+//sk_sentry_health	"40"
+
+// Leech
+sk_leech_health	"2"
+sk_leech_dmg_bite "2"
+
+// Big momma
+sk_bigmomma_health_factor 	"1.5"
+sk_bigmomma_dmg_slash	"60"
+sk_bigmomma_dmg_blast 	"120"
+sk_bigmomma_radius_blast "250"
+
+//Nihilanth
+sk_nihilanth_health		"800"
+sk_nihilanth_zap		"30"
+
+// PLAYER
+//sk_plr_dmg_crowbar		"10"
+//sk_plr_dmg_9mm_bullet		"8"
+//sk_plr_dmg_357_bullet		"40"
+//sk_plr_dmg_buckshot		"5"
+//sk_plr_dmg_mp5_grenade		"100"
+//sk_plr_dmg_rpg			"100"
+//sk_plr_dmg_xbow_bolt_plr	"10"
+//sk_plr_dmg_xbow_bolt_npc	"50"
+//sk_plr_dmg_egon_narrow		"6"
+//sk_plr_dmg_egon_wide		"14"
+//sk_plr_dmg_gauss		"20"
+sk_plr_dmg_grenade		"100"
+//sk_plr_dmg_hornet		"7"
+//sk_plr_dmg_tripmine		"150"
+//sk_plr_dmg_satchel		"150"
+
+// MONSTER WEAPONS
+//sk_npc_dmg_hornet		"5"
+//sk_npc_dmg_9mm_bullet		"5"
+//sk_npc_dmg_9mmAR_bullet		"4"
+//sk_npc_dmg_12mm_bullet		"10"
+
+// MISC
+//sk_max_9mm_bullet		"250"
+//sk_max_357_bullet		"36"
+//sk_max_buckshot			"125"
+//sk_max_mp5_grenade		"10"
+//sk_mp5_grenade_radius		"100"
+//sk_max_rpg_rocket		"5"
+//sk_max_xbow_bolt		"50"
+//sk_max_uranium			"100"
+sk_max_grenade			"10"
+//sk_max_hornet			"8"
+//sk_max_snark			"15"
+//sk_max_tripmine			"5"
+//sk_max_satchel			"5"
+
+// HEALTH/SUIT CHARGE DISTRIBUTION
+sk_suitcharger			"50"
+sk_battery			"15"
+
+sk_healthcharger		"40"
+sk_healthkit			"15"
+
+sk_scientist_heal		"25"

--- a/garrysmod/cfg/hl1_skill3.cfg
+++ b/garrysmod/cfg/hl1_skill3.cfg
@@ -1,0 +1,130 @@
+// Barney
+sk_barney_health		"35"
+
+// Apache 
+//sk_apache_health	"400"
+
+// Headcrab
+sk_headcrab_health		"20"
+sk_headcrab_dmg_bite		"10"
+
+// Zombie
+sk_zombie_health		"100"
+sk_zombie_dmg_one_slash		"20"
+sk_zombie_dmg_both_slash	"40"
+
+// Vortigaunt
+sk_islave_health		"60"
+sk_islave_dmg_claw      	"10"
+sk_islave_dmg_clawrake		"25"
+sk_islave_dmg_zap		"15"
+
+//Bullsquid
+sk_bullsquid_health		"120"
+sk_bullsquid_dmg_bite   	"25"
+sk_bullsquid_dmg_whip   	"35"
+sk_bullsquid_dmg_spit		"15"
+
+//Human Grunts
+sk_hgrunt_health		"80"
+sk_hgrunt_kick			"10"
+sk_hgrunt_pellets		"6"
+sk_hgrunt_gspeed		"800"
+
+//Ichthyosaur
+sk_ichthyosaur_health		"400"
+sk_ichthyosaur_shake		"50"
+
+//Gargantua
+sk_gargantua_health		"1000"
+sk_gargantua_dmg_slash		"30"
+sk_gargantua_dmg_fire		"5"
+sk_gargantua_dmg_stomp		"100"
+
+// Snark
+sk_snark_health			"2"
+sk_snark_dmg_bite		"10"
+sk_snark_dmg_pop		"5"
+
+// Alien Grunt
+sk_agrunt_health		"120"
+sk_agrunt_dmg_punch		"20"
+
+// Alien Controller
+sk_controller_health	"100"
+sk_controller_dmgzap	"35"
+sk_controller_speedball	"1000"
+sk_controller_dmgball	"5"
+
+sk_hassassin_health	"50"
+
+// Turret
+//sk_turret_health	"60"
+
+// MiniTurret
+//sk_miniturret_health	"50"
+
+// Sentry Turret
+//sk_sentry_health	"50"
+
+// Leech
+sk_leech_health	"2"
+sk_leech_dmg_bite "2"
+
+// Big momma
+sk_bigmomma_health_factor 	"2"
+sk_bigmomma_dmg_slash 	"70"
+sk_bigmomma_dmg_blast 	"160"
+sk_bigmomma_radius_blast "275"
+
+//Nihilanth
+sk_nihilanth_health		"1000"
+sk_nihilanth_zap		"50"
+
+// PLAYER
+//sk_plr_dmg_crowbar		"10"
+//sk_plr_dmg_9mm_bullet		"8"
+//sk_plr_dmg_357_bullet		"40"
+//sk_plr_dmg_buckshot		"5"
+//sk_plr_dmg_mp5_grenade		"100"
+//sk_plr_dmg_rpg			"100"
+//sk_plr_dmg_xbow_bolt_plr	"10"
+//sk_plr_dmg_xbow_bolt_npc	"50"
+//sk_plr_dmg_egon_narrow		"6"
+//sk_plr_dmg_egon_wide		"14"
+//sk_plr_dmg_gauss		"20"
+sk_plr_dmg_grenade		"100"
+//sk_plr_dmg_hornet		"7"
+//sk_plr_dmg_tripmine		"150"
+//sk_plr_dmg_rpg			"100"
+//sk_plr_dmg_satchel		"150"
+
+// MONSTER WEAPONS
+//sk_npc_dmg_hornet		"8"
+//sk_npc_dmg_9mm_bullet		"8"
+//sk_npc_dmg_9mmAR_bullet		"5"
+//sk_npc_dmg_12mm_bullet		"10"
+
+// MISC
+//sk_max_9mm_bullet		"250"
+//sk_max_357_bullet		"36"
+//sk_max_buckshot			"125"
+//sk_max_mp5_grenade		"10"
+//sk_mp5_grenade_radius		"100"
+//sk_max_rpg_rocket		"5"
+//sk_max_xbow_bolt		"50"
+//sk_max_uranium			"100"
+sk_max_grenade			"10"
+//sk_max_hornet			"8"
+//sk_max_snark			"15"
+//sk_max_tripmine			"5"
+//sk_max_satchel			"5"
+
+// HEALTH/SUIT CHARGE DISTRIBUTION
+sk_suitcharger			"35"
+sk_battery			"10"
+
+sk_healthcharger		"25"
+sk_healthkit			"10"
+
+sk_scientist_heal		"25"

--- a/garrysmod/cfg/skill.cfg
+++ b/garrysmod/cfg/skill.cfg
@@ -226,7 +226,7 @@ sk_combineball_seek_angle	"15"
 sk_combineball_guidefactor	"1.0"
 
 // NPC damage adjusters
-sk_npc_head		"3"
+sk_npc_head		"5"
 sk_npc_chest	"1"
 sk_npc_stomach	"1"
 sk_npc_arm		"1"
@@ -270,4 +270,4 @@ sk_vortigaunt_dmg_zap			"25"
 sk_headcrab_poison_npc_damage "20.0"
 
 // advisor
-sk_advisor_health "1000" 
+//sk_advisor_health "1000" 

--- a/garrysmod/cfg/skill.cfg
+++ b/garrysmod/cfg/skill.cfg
@@ -103,7 +103,6 @@ sk_antlionguard_dmg_shove	"10"
 //Ichthyosaur
 sk_ichthyosaur_health		"200"
 sk_ichthyosaur_melee_dmg	"8"
-sk_ichthyosaur_shake		"20"
 
 // Combine Gunship
 sk_gunship_burst_size		"15"
@@ -227,7 +226,7 @@ sk_combineball_seek_angle	"15"
 sk_combineball_guidefactor	"1.0"
 
 // NPC damage adjusters
-sk_npc_head		"5"
+sk_npc_head		"3"
 sk_npc_chest	"1"
 sk_npc_stomach	"1"
 sk_npc_arm		"1"
@@ -271,4 +270,4 @@ sk_vortigaunt_dmg_zap			"25"
 sk_headcrab_poison_npc_damage "20.0"
 
 // advisor
-//sk_advisor_health "1000" 
+sk_advisor_health "1000" 

--- a/garrysmod/cfg/skill1.cfg
+++ b/garrysmod/cfg/skill1.cfg
@@ -1,0 +1,2 @@
+exec hl1_skill1.cfg
+exec skill.cfg

--- a/garrysmod/cfg/skill2.cfg
+++ b/garrysmod/cfg/skill2.cfg
@@ -1,0 +1,2 @@
+exec hl1_skill2.cfg
+exec skill.cfg

--- a/garrysmod/cfg/skill3.cfg
+++ b/garrysmod/cfg/skill3.cfg
@@ -1,0 +1,2 @@
+exec hl1_skill3.cfg
+exec skill.cfg


### PR DESCRIPTION
This PR is reliant on https://github.com/Facepunch/garrysmod-requests/issues/1148 and https://github.com/Facepunch/garrysmod-requests/issues/1151 for functionality.

Setting these convars fixes a number of HL1 NPC issues with having incorrect health or doing no damage.

skill#.cfg will first exec hl1_skill#.cfg to set HL1 skill values, then run skill.cfg to set HL2 skill values, giving precedent to HL2 while still setting necessary HL1-specific convars. skill_manifest.cfg is no longer used with this new setup but is still called by the engine. Convars for non-existing NPCs and weapons have been commented out.

https://github.com/Facepunch/garrysmod-requests/issues/1149 can allow hl1_skill#.cfg to be exec'd again at the very end of a skill level change, giving priority to HL1 values for HL1 campaign addons.