### PR TITLE
Change gmod_tool's holdtype to pistol

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/shared.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/shared.lua
@@ -69,7 +69,7 @@ end
 
 function SWEP:Initialize()
 
-	self:SetHoldType( "revolver" )
+	self:SetHoldType( "pistol" )
 
 	self:InitializeTools()
 


### PR DESCRIPTION
IMO this been like this since GMod 13 and it looks way better and stylish than pre-GM13 holdtypes, changing this to revolver was unnecessary.