### PR TITLE
ENT:BeingLookedAtByLocalPlayer optimisation

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/entities/base_gmodentity.lua
+++ b/garrysmod/gamemodes/sandbox/entities/entities/base_gmodentity.lua
@@ -5,22 +5,16 @@ DEFINE_BASECLASS( "base_anim" )
 ENT.Spawnable = false
 
 if ( CLIENT ) then
-	ENT.ViewDistance = 256
+	ENT.MaxWorldTipDistance = 256
 
 	function ENT:BeingLookedAtByLocalPlayer()
 		local ply = LocalPlayer()
 		if ( not IsValid( ply ) ) then return false end
 
 		local view = ply:GetViewEntity()
-		local dist = self.ViewDistance
+		local dist = self.MaxWorldtipDistance
 		dist = dist * dist
-		local pos
-
-		if ( view:IsPlayer() ) then
-			pos = view:GetShootPos()
-		else
-			pos = view:GetPos()
-		end
+		local pos = view:IsPlayer() && view:GetShootPos() || view:GetPos()
 
 		return pos:DistToSqr( self:GetPos() ) <= dist && ply:GetEyeTrace().Entity == self
 	end

--- a/garrysmod/gamemodes/sandbox/entities/entities/base_gmodentity.lua
+++ b/garrysmod/gamemodes/sandbox/entities/entities/base_gmodentity.lua
@@ -5,29 +5,35 @@ DEFINE_BASECLASS( "base_anim" )
 ENT.Spawnable = false
 
 if ( CLIENT ) then
+	ENT.ViewDistance = 256
 
 	function ENT:BeingLookedAtByLocalPlayer()
+		local ply = LocalPlayer()
+		if ( not IsValid( ply ) ) then return false end
 
-		if ( LocalPlayer():GetEyeTrace().Entity != self ) then return false end
-		if ( LocalPlayer():GetViewEntity() == LocalPlayer() && LocalPlayer():GetShootPos():Distance( self:GetPos() ) > 256 ) then return false end
-		if ( LocalPlayer():GetViewEntity() != LocalPlayer() && LocalPlayer():GetViewEntity():GetPos():Distance( self:GetPos() ) > 256 ) then return false end
+		local view = ply:GetViewEntity()
+		local dist = self.ViewDistance
+		dist = dist * dist
+		local pos
 
-		return true
+		if ( view:IsPlayer() ) then
+			pos = view:GetShootPos()
+		else
+			pos = view:GetPos()
+		end
 
+		return pos:DistToSqr( self:GetPos() ) <= dist && ply:GetEyeTrace().Entity == self
 	end
 
-end
+	function ENT:Think()
+		local text = self:GetOverlayText()
 
-function ENT:Think()
+		if ( text != "" && self:BeingLookedAtByLocalPlayer() ) then
+			AddWorldTip( self:EntIndex(), text, 0.5, self:GetPos(), self )
 
-	if ( CLIENT && self:BeingLookedAtByLocalPlayer() && self:GetOverlayText() != "" ) then
-
-		AddWorldTip( self:EntIndex(), self:GetOverlayText(), 0.5, self:GetPos(), self.Entity )
-
-		halo.Add( { self }, Color( 255, 255, 255, 255 ), 1, 1, 1, true, true )
-
+			halo.Add( { self }, color_white, 1, 1, 1, true, true )
+		end
 	end
-
 end
 
 function ENT:SetOverlayText( text )


### PR DESCRIPTION
- ``ENT.MaxWorldTipDistance`` can now set the maximum distance the worldtip is displayed at when looking at an entity.
- The distance check now uses the view entity's ShootPos if it's a player, just like the local player does. This makes the result consistent between a player and spectators.
- Dist->DistToSqr
- Order of operations changed in ENT:Think and ENT:BeingLookedAtByLocalPlayer to do traces last - optimises entities too far from the player from doing an unnecessary eyetrace.