### PR TITLE
Call PreReloadToolsMenu

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/spawnmenu.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/spawnmenu.lua
@@ -173,6 +173,8 @@ vgui.Register( "SpawnMenu", PANEL, "EditablePanel" )
 -----------------------------------------------------------]]
 local function CreateSpawnMenu()
 
+	hook.Run( "PreReloadToolsMenu" )
+
 	-- If we have an old spawn menu remove it.
 	if ( IsValid( g_SpawnMenu ) ) then
 


### PR DESCRIPTION
Actually made the hook get called. This has always been documented on the wiki.