### PR TITLE
Replace dead link about line endings

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Pull Requests
 ---
 Pull requests are welcome. 
 
-Please make sure your [line endings are correct](https://github.com/sugarcrm/sugarcrm_dev/wiki/Line-Ending-issues-on-Windows-with-git).
+Please make sure your [line endings are correct](https://help.github.com/articles/dealing-with-line-endings/).
 
 Also try to condense multiple commits down to easily see the changes made, either through [resetting the head](http://stackoverflow.com/a/5201642) or [rebasing the branch](http://stackoverflow.com/a/5189600).
 


### PR DESCRIPTION
Let it point to the github documentation instead.
The old one redirected to an info page about the project being abandoned.