### PR TITLE
Optimize mouth animation

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/animations.lua
+++ b/garrysmod/gamemodes/base/gamemode/animations.lua
@@ -266,20 +266,22 @@ end
 --
 function GM:MouthMoveAnimation( ply )
 
-	local flexes = {
-		ply:GetFlexIDByName( "jaw_drop" ),
-		ply:GetFlexIDByName( "left_part" ),
-		ply:GetFlexIDByName( "right_part" ),
-		ply:GetFlexIDByName( "left_mouth_drop" ),
-		ply:GetFlexIDByName( "right_mouth_drop" )
-	}
+	if ply:IsSpeaking() then
+		local flexes = {
+			ply:GetFlexIDByName( "jaw_drop" ),
+			ply:GetFlexIDByName( "left_part" ),
+			ply:GetFlexIDByName( "right_part" ),
+			ply:GetFlexIDByName( "left_mouth_drop" ),
+			ply:GetFlexIDByName( "right_mouth_drop" )
+		}
 
-	local weight = ply:IsSpeaking() && math.Clamp( ply:VoiceVolume() * 2, 0, 2 ) || 0
+		local weight = math.Clamp( ply:VoiceVolume() * 2, 0, 2 )
 
-	for k, v in pairs( flexes ) do
+		for k, v in pairs( flexes ) do
 
-		ply:SetFlexWeight( v, weight )
+			ply:SetFlexWeight( v, weight )
 
+		end
 	end
 
 end


### PR DESCRIPTION
The flex weights will return to normal without SetFlexWeight being called so it's unnecessary to SetFlexWeight all the time which is expensive and conflicts with other addons.