### PR TITLE
Fixed GetEyeTraceNoCursor incorrect serverside caching

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/obj_player_extend.lua
+++ b/garrysmod/gamemodes/base/gamemode/obj_player_extend.lua
@@ -174,16 +174,22 @@ end
 -----------------------------------------------------------]]
 function meta:GetEyeTrace()
 
-	-- Cache the trace results for the current frame, unless we're serverside
-	-- in which case it wouldn't play well with lag compensation at all
-	if ( CLIENT and self.LastPlayerTrace == CurTime() ) then
-		return self.PlayerTrace
+	if ( CLIENT ) then
+		local curtime = CurTime()
+
+		-- Cache the trace results for the current frame, unless we're serverside
+		-- in which case it wouldn't play well with lag compensation at all
+		if ( self.LastPlayerTrace == curtime ) then
+			return self.PlayerTrace
+		end
+
+		self.LastPlayerTrace = curtime
 	end
 
-	self.PlayerTrace = util.TraceLine( util.GetPlayerTrace( self ) )
-	self.LastPlayerTrace = CurTime()
-	
-	return self.PlayerTrace
+	local tr = util.TraceLine( util.GetPlayerTrace( self ) )
+	self.PlayerTrace = tr
+
+	return tr
 
 end
 
@@ -193,16 +199,19 @@ end
 -----------------------------------------------------------]]
 function meta:GetEyeTraceNoCursor()
 
-	if ( self:GetTable().LastPlayerAimTrace == CurTime() ) then
-		return self:GetTable().PlayerAimTrace
+	if ( CLIENT ) then
+		local curtime = CurTime()
+
+		if ( self.LastPlayerAimTrace == curtime ) then
+			return self.PlayerAimTrace
+		end
+
+		self.LastPlayertAimTrace = curtime
 	end
 
-	-- Use the players eye angles rather than their aim vector..
-	local fwd = self:EyeAngles():Forward()
+	local tr = util.TraceLine( util.GetPlayerTrace( self, self:EyeAngles():Forward() ) )
+	self.PlayerAimTrace = tr
 
-	self:GetTable().PlayerAimTrace = util.TraceLine( util.GetPlayerTrace( self, fwd ) )
-	self:GetTable().LastPlayertAimTrace = CurTime()
-	
-	return self:GetTable().PlayerAimTrace
+	return tr
 
 end


### PR DESCRIPTION
Fixes https://github.com/Facepunch/garrysmod-issues/issues/3586.

- Removed trace caching serverside with GetEyeTraceNoCursor to do a new trace during lag compensation
- Removed unnecessary GetTable usage
- Saved on player __index calls by localising the trace

There should also be some better cache checking done in these functions - the player's eyepos and other entity positions can change in a tick.