### PR TITLE
Add utility functions for using the Hammer IO system

### DIFF
--- a/garrysmod/gamemodes/base/entities/entities/base_entity/outputs.lua
+++ b/garrysmod/gamemodes/base/entities/entities/base_entity/outputs.lua
@@ -23,6 +23,49 @@ function ENT:StoreOutput( name, info )
 	table.insert( self.m_tOutputs[ name ], Output )
 end
 
+-- This works like SetNetworkKeyValue, call it from ENT:KeyValue and it'll
+-- return true if it successfully added an output from the passed KV pair.
+function ENT:AddOutputFromKeyValue( key, value )
+
+	if ( key:sub( 1, 2 ) == "On" ) then
+
+		self:StoreOutput( key, value )
+		return true
+
+	end
+
+	return false
+
+end
+
+-- Call from ENT:AcceptInput and it'll return true if the input was AddOutput
+-- and if it successfully added an output.
+-- Note that to be strictly compatible with Source entities, AddOutput should
+-- allow setting arbitrary keyvalues, but this implementation does not.
+function ENT:AddOutputFromAcceptInput( name, value )
+
+	if ( name ~= "AddOutput" ) then
+
+		return false
+
+	end
+
+	local pos = string.find(value, " ", 1, true )
+	if ( pos == nil ) then
+
+		return false
+
+	end
+
+	name, value = value:sub(1, pos - 1), value:sub(pos + 1)
+
+	-- This is literally KeyValue but as an input and with ,s as :s.
+	value = value:gsub( ":", "," )
+
+	return self:AddOutputFromKeyValue( name, value )
+
+end
+
 -- Nice helper function, this does all the work. Returns false if the
 -- output should be removed from the list.
 


### PR DESCRIPTION
Usage:

```lua
function ENT:KeyValue( key, value )
	if ( BaseClass.KeyValue ) then BaseClass.KeyValue( self, key, value ) end

	if ( self:SetNetworkKeyValue( key, value ) ) then
		return
	elseif ( self:AddOutputFromKeyValue( key, value ) ) then
		return
	end

	-- Your entity's logic goes here

end

function ENT:AcceptInput( name, activator, called, value )
	if ( BaseClass.AcceptInput and BaseClass.AcceptInput( self, name, activator, called, value ) ) then
		return true
	end

	if ( self:AddOutputFromAcceptInput( name, value ) ) then
		return true
	end

	-- Your entity's logic goes here

	return false

end
```

Ideally I'd like to make the base_entity functions do this for you automatically so most people won't even need to think about doing this, what do you think?