### PR TITLE
Create table.IsEmpty

### DIFF
--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -53,6 +53,17 @@ function table.Empty( tab )
 end
 
 --[[---------------------------------------------------------
+	Name: IsEmpty( tab )
+	Desc: Returns whether a table has iterable items in it, useful for non-sequential tables
+-----------------------------------------------------------]]
+function table.IsEmpty( tab )
+	for k, v in pairs( tab ) do
+		return false
+	end
+	return true
+end
+
+--[[---------------------------------------------------------
 	Name: CopyFromTo( FROM, TO )
 	Desc: Make TO exactly the same as FROM - but still the same table.
 -----------------------------------------------------------]]

--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -57,10 +57,7 @@ end
 	Desc: Returns whether a table has iterable items in it, useful for non-sequential tables
 -----------------------------------------------------------]]
 function table.IsEmpty( tab )
-	for k, v in pairs( tab ) do
-		return false
-	end
-	return true
+	return next( tab ) == nil
 end
 
 --[[---------------------------------------------------------


### PR DESCRIPTION
Quickly returns whether a table has iterable items in it - useful for checking whether non-sequential tables are empty.