### PR TITLE
Remove MarkupObject:Create()

### DIFF
--- a/garrysmod/lua/includes/modules/markup.lua
+++ b/garrysmod/lua/includes/modules/markup.lua
@@ -161,20 +161,7 @@ local function ProcessMatches( p1, p2, p3 )
 end
 
 local MarkupObject = {}
-
---[[---------------------------------------------------------
-	Name: MarkupObject:Create()
-	Desc: Called by Parse. Creates a new table, and setups the
-		  metatable.
-	Usage: ** INTERNAL ** Do not use!
------------------------------------------------------------]]
-function MarkupObject:Create()
-	local o = {}
-	setmetatable( o, self )
-	self.__index = self
-
-	return o
-end
+MarkupObject.__index = MarkupObject
 
 --[[---------------------------------------------------------
 	Name: MarkupObject:GetWidth()
@@ -459,9 +446,9 @@ function Parse( ml, maxwidth )
 		end
 	end
 
-	local newObject = MarkupObject:Create()
-	newObject.totalHeight = totalHeight
-	newObject.totalWidth = xMax
-	newObject.blocks = new_block_list
-	return newObject
+	return setmetatable( {
+		totalHeight = totalHeight,
+		totalWidth = xMax,
+		blocks = new_block_list
+	}, MarkupObject )
 end


### PR DESCRIPTION
This function shouldn't exist - it's a class function of the MarkupObject that... creates a MarkupObject. Calling it on an existing MarkupObject creates an object that now has the metatable of the previous MarkupObject which is improper and inconsistent behaviour for a class function. Even the single use of it calls the function on the MarkupObject metatable as if it were an object. It also updates the __index of the metatable to itself every time needlessly instead of setting it once outright.

This will break no compatibility with previous code since the MarkupObject metatable isn't available outside of a single file, and calling it on an actual MarkupObject results in bad behaviour.