### PR TITLE
Add spacers to DComboBox's DMenu

### DIFF
--- a/garrysmod/lua/vgui/dcombobox.lua
+++ b/garrysmod/lua/vgui/dcombobox.lua
@@ -30,6 +30,7 @@ function PANEL:Clear()
 	self.Choices = {}
 	self.Data = {}
 	self.ChoiceIcons = {}
+	self.Spacers = {}
 	self.selected = nil
 
 	if ( self.Menu ) then
@@ -123,6 +124,12 @@ function PANEL:OnSelect( index, value, data )
 
 end
 
+function PANEL:AddSpacer()
+
+	self.Spacers[ #self.Choices ] = true
+
+end
+
 function PANEL:AddChoice( value, data, select, icon )
 
 	local i = table.insert( self.Choices, value )
@@ -181,12 +188,18 @@ function PANEL:OpenMenu( pControlOpener )
 			if ( self.ChoiceIcons[ v.id ] ) then
 				option:SetIcon( self.ChoiceIcons[ v.id ] )
 			end
+			if ( self.Spacers[ v.id ] ) then
+				self.Menu:AddSpacer()
+			end
 		end
 	else
 		for k, v in pairs( self.Choices ) do
 			local option = self.Menu:AddOption( v, function() self:ChooseOption( v, k ) end )
 			if ( self.ChoiceIcons[ k ] ) then
 				option:SetIcon( self.ChoiceIcons[ k ] )
+			end
+			if ( self.Spacers[ k ] ) then
+				self.Menu:AddSpacer()
 			end
 		end
 	end


### PR DESCRIPTION
Adds simple DMenu spacers to DComboBox. Supports both sorted and unsorted DComboBoxes.

![Screenshot](http://i.venner.io/hl2_2018-12-02_16-25-41.png)