### PR TITLE
[TTT] Loadout Bugfix

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
@@ -132,8 +132,8 @@ end
 -- calling this function is used to get them the weapons anyway as soon as
 -- possible.
 local function LateLoadout(id)
-   local ply = player.GetByID(id)
-   if not IsValid(ply) then
+   local ply = Entity(id)
+   if not IsValid(ply) or not ply:IsPlayer() then
       timer.Remove("lateloadout" .. id)
       return
    end


### PR DESCRIPTION
Here, the ID is a return of ply:EntIndex(). This should use Entity(id) (http://wiki.garrysmod.com/page/Global/Entity) instead of player.GetByID(id) (http://wiki.garrysmod.com/page/player/GetByID)