### PR TITLE
Toolgun Think fixes

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/shared.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/shared.lua
@@ -142,38 +142,48 @@ end
 
 -- Think does stuff every frame
 function SWEP:Think()
+	local owner = self:GetOwner()
+	if ( !owner:IsPlayer() ) then return end
 
-	self.Mode = self.Owner:GetInfo( "gmod_toolmode" )
+	local curmode = owner:GetInfo( "gmod_toolmode" )
+	self.Mode = curmode
 
-	local tool = self:GetToolObject()
+	local tool = self:GetToolObject( curmode )
 	if ( !tool ) then return end
 
 	tool:CheckObjects()
 
-	self.last_mode = self.current_mode
-	self.current_mode = self.Mode
+	local lastmode = self.current_mode
+	self.last_mode = lastmode
+	self.current_mode = curmode
 
 	-- Release ghost entities if we're not allowed to use this new mode?
 	if ( !tool:Allowed() ) then
-		self:GetToolObject( self.last_mode ):ReleaseGhostEntity()
+		if ( lastmode ) then
+			local lastmode_obj = self:GetToolObject( lastmode )
+
+			if ( lastmode_obj ) then
+				lastmode_obj:ReleaseGhostEntity()
+			end
+		end
+
 		return
 	end
 
-	if ( self.last_mode != self.current_mode ) then
+	if ( lastmode && lastmode != curmode ) then
+		local lastmode_obj = self:GetToolObject( lastmode )
 
-		if ( !self:GetToolObject( self.last_mode ) ) then return end
-
-		-- We want to release the ghost entity just in case
-		self:GetToolObject( self.last_mode ):Holster()
-
+		if ( lastmode_obj ) then
+			-- We want to release the ghost entity just in case
+			lastmode_obj:Holster()
+		end
 	end
 
-	self.Primary.Automatic = tool.LeftClickAutomatic or false
-	self.Secondary.Automatic = tool.RightClickAutomatic or false
-	self.RequiresTraceHit = tool.RequiresTraceHit or true
+	self.Primary.Automatic = tool.LeftClickAutomatic || false
+	self.Secondary.Automatic = tool.RightClickAutomatic || false
+	self.RequiresTraceHit = tool.RequiresTraceHit || true
 
 	tool:Think()
-
 end
 
 -- The shoot effect


### PR DESCRIPTION
- Check owner validity - fixes rare edge case of the owner being invalid when Think is called and cases where the owner is an NPC
- Check last tool object validity before releasing its entity - fixes error when switching from invalid mode to another invalid mode
- Remove a return when a mode switch occurs and the last mode was invalid, causing the first Think after a mode switch to be skipped - fixes https://github.com/Facepunch/garrysmod-issues/issues/3682