### PR TITLE
Nice Ammo Reduction

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/entities/base_ammo_ttt.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/base_ammo_ttt.lua
@@ -86,7 +86,7 @@ function ENT:CheckForWeapon(ply)
 end
 
 function ENT:Touch(ent)
-  if (SERVER amd self.tickRemoval ~= true) and ent:IsValid() and ent:IsPlayer() and self:CheckForWeapon(ent) and self:PlayerCanPickup(ent) then
+  if (SERVER and self.tickRemoval ~= true) and ent:IsValid() and ent:IsPlayer() and self:CheckForWeapon(ent) and self:PlayerCanPickup(ent) then
     local ammo = ent:GetAmmoCount(self.AmmoType)
     -- need clipmax info and room for at least 1/4th
     if self.AmmoMax >= (ammo + math.ceil(self.AmmoAmount * 0.25)) then

--- a/garrysmod/gamemodes/terrortown/entities/entities/base_ammo_ttt.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/base_ammo_ttt.lua
@@ -31,7 +31,7 @@ function ENT:Initialize()
       self:SetTrigger(true)
    end
 
-   self.taken = false
+   self.tickRemoval = false
 
    -- this made the ammo get physics'd too early, meaning it would fall
    -- through physics surfaces it was lying on on the client, leading to

--- a/garrysmod/gamemodes/terrortown/entities/entities/base_ammo_ttt.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/base_ammo_ttt.lua
@@ -86,7 +86,7 @@ function ENT:CheckForWeapon(ply)
 end
 
 function ENT:Touch(ent)
-  if SERVER and ent:IsValid() and ent:IsPlayer() and self:CheckForWeapon(ent) and self:PlayerCanPickup(ent) then
+  if (SERVER amd self.tickRemoval ~= true) and ent:IsValid() and ent:IsPlayer() and self:CheckForWeapon(ent) and self:PlayerCanPickup(ent) then
     local ammo = ent:GetAmmoCount(self.AmmoType)
     -- need clipmax info and room for at least 1/4th
     if self.AmmoMax >= (ammo + math.ceil(self.AmmoAmount * 0.25)) then
@@ -98,6 +98,7 @@ function ENT:Touch(ent)
       self.AmmoAmount = newEntAmount
 
       if self.AmmoAmount <= 0 then
+        self.tickRemoval = true
         self:Remove()
       end
     end

--- a/garrysmod/gamemodes/terrortown/entities/entities/base_ammo_ttt.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/base_ammo_ttt.lua
@@ -86,23 +86,22 @@ function ENT:CheckForWeapon(ply)
 end
 
 function ENT:Touch(ent)
-   if SERVER and self.taken != true then
-      if (ent:IsValid() and ent:IsPlayer() and self:CheckForWeapon(ent) and self:PlayerCanPickup(ent)) then
+  if SERVER and ent:IsValid() and ent:IsPlayer() and self:CheckForWeapon(ent) and self:PlayerCanPickup(ent) then
+    local ammo = ent:GetAmmoCount(self.AmmoType)
+    -- need clipmax info and room for at least 1/4th
+    if self.AmmoMax >= (ammo + math.ceil(self.AmmoAmount * 0.25)) then
+      local given = self.AmmoAmount
+      given = math.min(given, self.AmmoMax - ammo)
+      ent:GiveAmmo(given, self.AmmoType)
 
-         local ammo = ent:GetAmmoCount(self.AmmoType)
-         -- need clipmax info and room for at least 1/4th
-         if self.AmmoMax >= (ammo + math.ceil(self.AmmoAmount * 0.25)) then
-            local given = self.AmmoAmount
-            given = math.min(given, self.AmmoMax - ammo)
-            ent:GiveAmmo( given, self.AmmoType)
+      local newEntAmount = self.AmmoAmount - given
+      self.AmmoAmount = newEntAmount
 
-            self:Remove()
-
-            -- just in case remove does not happen soon enough
-            self.taken = true
-         end
+      if self.AmmoAmount <= 0 then
+        self:Remove()
       end
-   end
+    end
+  end
 end
 
 -- Hack to force ammo to physwake
@@ -118,4 +117,3 @@ if SERVER then
       end
    end
 end
-

--- a/garrysmod/gamemodes/terrortown/entities/entities/base_ammo_ttt.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/base_ammo_ttt.lua
@@ -88,23 +88,25 @@ function ENT:CheckForWeapon(ply)
 end
 
 function ENT:Touch(ent)
-  if (SERVER and self.tickRemoval ~= true) and ent:IsValid() and ent:IsPlayer() and self:CheckForWeapon(ent) and self:PlayerCanPickup(ent) then
-    local ammo = ent:GetAmmoCount(self.AmmoType)
-    -- need clipmax info and room for at least 1/4th
-    if self.AmmoMax >= (ammo + math.ceil(self.AmmoAmount * 0.25)) then
-      local given = self.AmmoAmount
-      given = math.min(given, self.AmmoMax - ammo)
-      ent:GiveAmmo(given, self.AmmoType)
+   if (SERVER and self.tickRemoval ~= true) and ent:IsValid() and ent:IsPlayer() and self:CheckForWeapon(ent) and self:PlayerCanPickup(ent) then
+     local ammo = ent:GetAmmoCount(self.AmmoType)
+     
+     -- need clipmax info and room for at least 1/4th
+     if self.AmmoMax >= (ammo + math.ceil(self.AmmoAmount * 0.25)) then
+       local given = self.AmmoAmount
+       given = math.min(given, self.AmmoMax - ammo)
+       ent:GiveAmmo(given, self.AmmoType)
 
-      local newEntAmount = self.AmmoAmount - given
-      self.AmmoAmount = newEntAmount
-
-      if self.AmmoAmount <= 0 or  math.ceil(self.AmmoEntMax * 0.15) > self.AmmoAmount then
-        self.tickRemoval = true
-        self:Remove()
-      end
-    end
-  end
+       local newEntAmount = self.AmmoAmount - given
+       self.AmmoAmount = newEntAmount
+       print(self.AmmoEntMax, math.ceil(self.AmmoEntMax * 0.25), self.AmmoAmount)
+       
+       if self.AmmoAmount <= 0 or math.ceil(self.AmmoEntMax * 0.25) > self.AmmoAmount then
+         self.tickRemoval = true
+         self:Remove()
+       end
+     end
+   end
 end
 
 -- Hack to force ammo to physwake

--- a/garrysmod/gamemodes/terrortown/entities/entities/base_ammo_ttt.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/base_ammo_ttt.lua
@@ -8,6 +8,7 @@ ENT.Type = "anim"
 ENT.AmmoType = "Pistol"
 ENT.AmmoAmount = 1
 ENT.AmmoMax = 10
+ENT.AmmoEntMax = 1
 ENT.Model = Model( "models/items/boxsrounds.mdl" )
 
 
@@ -40,6 +41,7 @@ function ENT:Initialize()
    --	if (phys:IsValid()) then
    --		phys:Wake()
    --	end
+   self.AmmoEntMax = self.AmmoAmount
 end
 
 -- Pseudo-clone of SDK's UTIL_ItemCanBeTouchedByPlayer
@@ -97,7 +99,7 @@ function ENT:Touch(ent)
       local newEntAmount = self.AmmoAmount - given
       self.AmmoAmount = newEntAmount
 
-      if self.AmmoAmount <= 0 then
+      if self.AmmoAmount <= 0 or self.AmmoEntMax < math.Ceil(self.AmmoAmount * 0.15) then
         self.tickRemoval = true
         self:Remove()
       end

--- a/garrysmod/gamemodes/terrortown/entities/entities/base_ammo_ttt.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/base_ammo_ttt.lua
@@ -99,7 +99,7 @@ function ENT:Touch(ent)
       local newEntAmount = self.AmmoAmount - given
       self.AmmoAmount = newEntAmount
 
-      if self.AmmoAmount <= 0 or self.AmmoEntMax < math.Ceil(self.AmmoAmount * 0.15) then
+      if self.AmmoAmount <= 0 or  math.ceil(self.AmmoEntMax * 0.15) > self.AmmoAmount then
         self.tickRemoval = true
         self:Remove()
       end

--- a/garrysmod/gamemodes/terrortown/entities/entities/base_ammo_ttt.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/base_ammo_ttt.lua
@@ -99,7 +99,6 @@ function ENT:Touch(ent)
 
        local newEntAmount = self.AmmoAmount - given
        self.AmmoAmount = newEntAmount
-       print(self.AmmoEntMax, math.ceil(self.AmmoEntMax * 0.25), self.AmmoAmount)
        
        if self.AmmoAmount <= 0 or math.ceil(self.AmmoEntMax * 0.25) > self.AmmoAmount then
          self.tickRemoval = true


### PR DESCRIPTION
A much-needed feature. Stop removing the whole ammo box when someone only needs 5 ammo.

Ex.
- Pistol ammo box. Player can come up and only need 5 ammo, reduce the ammo count to 15. The other player needs 20 ammo. Player comes up and gives them 15 ammo, and then removes the ammo box.