### PR TITLE
Fixed duped effects not having AttachedEntityInfo + minor effect fixes

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/commands.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/commands.lua
@@ -132,6 +132,7 @@ function MakeEffect( ply, model, Data )
 
 	local Prop = ents.Create( "prop_effect" )
 	duplicator.DoGeneric( Prop, Data )
+	Prop.AttachedEntityInfo = table.Copy( Data.AttachedEntityInfo )
 	Prop:Spawn()
 
 	duplicator.DoGenericPhysics( Prop, ply, Data )
@@ -141,7 +142,9 @@ function MakeEffect( ply, model, Data )
 		gamemode.Call( "PlayerSpawnedEffect", ply, model, Prop )
 	end
 
-	DoPropSpawnedEffect( Prop )
+	if IsValid( Prop.AttachedEntity ) then
+		DoPropSpawnedEffect( Prop.AttachedEntity )
+	end
 
 	return Prop
 
@@ -231,7 +234,9 @@ function GMODSpawnEffect( ply, model, iSkin, strBody )
 		gamemode.Call( "PlayerSpawnedEffect", ply, model, e )
 	end
 
-	DoPropSpawnedEffect( e )
+	if ( IsValid( e.AttachedEntity ) ) then
+		DoPropSpawnedEffect( e.AttachedEntity )
+	end
 
 	undo.Create( "Effect" )
 		undo.SetPlayer( ply )
@@ -283,6 +288,10 @@ function DoPlayerEntitySpawn( ply, entity_name, model, iSkin, strBody )
 	ent:SetPos( tr.HitPos )
 	ent:Spawn()
 	ent:Activate()
+
+	if ( entity_name == "prop_effect" and IsValid( ent.AttachedEntity ) ) then
+		ent.AttachedEntity:SetBodyGroups( strBody )
+	end
 
 	-- Attempt to move the object so it sits flush
 	-- We could do a TraceEntity instead of doing all

--- a/garrysmod/gamemodes/sandbox/gamemode/commands.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/commands.lua
@@ -132,7 +132,7 @@ function MakeEffect( ply, model, Data )
 
 	local Prop = ents.Create( "prop_effect" )
 	duplicator.DoGeneric( Prop, Data )
-	Prop.AttachedEntityInfo = table.Copy( Data.AttachedEntityInfo )
+	Prop.AttachedEntityInfo = table.Copy( Data.AttachedEntityInfo ) -- This shouldn't be neccesary
 	Prop:Spawn()
 
 	duplicator.DoGenericPhysics( Prop, ply, Data )
@@ -142,7 +142,7 @@ function MakeEffect( ply, model, Data )
 		gamemode.Call( "PlayerSpawnedEffect", ply, model, Prop )
 	end
 
-	if IsValid( Prop.AttachedEntity ) then
+	if ( IsValid( Prop.AttachedEntity ) ) then
 		DoPropSpawnedEffect( Prop.AttachedEntity )
 	end
 
@@ -288,10 +288,6 @@ function DoPlayerEntitySpawn( ply, entity_name, model, iSkin, strBody )
 	ent:SetPos( tr.HitPos )
 	ent:Spawn()
 	ent:Activate()
-
-	if ( entity_name == "prop_effect" and IsValid( ent.AttachedEntity ) ) then
-		ent.AttachedEntity:SetBodyGroups( strBody )
-	end
 
 	-- Attempt to move the object so it sits flush
 	-- We could do a TraceEntity instead of doing all
@@ -751,24 +747,22 @@ function Spawn_SENT( ply, EntityName, tr )
 
 	end
 
-	if ( IsValid( entity ) ) then
+	if ( !IsValid( entity ) ) then return end
 
-		if ( IsValid( ply ) ) then
-			gamemode.Call( "PlayerSpawnedSENT", ply, entity )
-		end
-
-		undo.Create( "SENT" )
-			undo.SetPlayer( ply )
-			undo.AddEntity( entity )
-			if ( PrintName ) then
-				undo.SetCustomUndoText( "Undone " .. PrintName )
-			end
-		undo.Finish( "Scripted Entity (" .. tostring( EntityName ) .. ")" )
-
-		ply:AddCleanup( "sents", entity )
-		entity:SetVar( "Player", ply )
-
+	if ( IsValid( ply ) ) then
+		gamemode.Call( "PlayerSpawnedSENT", ply, entity )
 	end
+
+	undo.Create( "SENT" )
+		undo.SetPlayer( ply )
+		undo.AddEntity( entity )
+		if ( PrintName ) then
+			undo.SetCustomUndoText( "Undone " .. PrintName )
+		end
+	undo.Finish( "Scripted Entity (" .. tostring( EntityName ) .. ")" )
+
+	ply:AddCleanup( "sents", entity )
+	entity:SetVar( "Player", ply )
 
 end
 concommand.Add( "gm_spawnsent", function( ply, cmd, args ) Spawn_SENT( ply, args[ 1 ] ) end )
@@ -836,14 +830,14 @@ function Spawn_Weapon( ply, wepname, tr )
 
 	local entity = ents.Create( swep.ClassName )
 
-	if ( IsValid( entity ) ) then
+	if ( !IsValid( entity ) ) then return end
 
-		entity:SetPos( tr.HitPos + tr.HitNormal * 32 )
-		entity:Spawn()
+	DoPropSpawnedEffect( entity )
 
-		gamemode.Call( "PlayerSpawnedSWEP", ply, entity )
+	entity:SetPos( tr.HitPos + tr.HitNormal * 32 )
+	entity:Spawn()
 
-	end
+	gamemode.Call( "PlayerSpawnedSWEP", ply, entity )
 
 end
 concommand.Add( "gm_spawnswep", function( ply, cmd, args ) Spawn_Weapon( ply, args[1] ) end )


### PR DESCRIPTION
- Fixed duped prop_effects not having their AttachedEntityInfo table (meaning no entity mods, skin/bodygroup changes, bone manips, etc.) ever since the MakeEffect function was added. This value used to be copied over because duped prop_effects were being spawned with GenericDuplicatorFunction, which dumps the entire dupe data table into the new entity. Now that they have their own spawn function, we have to copy the value over manually.

- Fixed prop_effects spawned from spawnmenu not having any bodygroups other than default because it was trying to apply them to the prop_effect itself instead of its AttachedEntity

- Fixed prop spawn effect not working on prop_effects for the same reason