### PR TITLE
Fix invalid table.GetWinningKey behavior.

### DIFF
--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -612,7 +612,7 @@ end
 
 function table.GetWinningKey( tab )
 
-	local highest = -10000
+	local highest = -math.huge
 	local winner = nil
 
 	for k, v in pairs( tab ) do


### PR DESCRIPTION
Currently, values less than or equal to `-10000` are not considered. For example, the result of the following call is `nil` when it should be `"a"` .

```lua
table.GetWinningKey({
    a = -10000,
    b = -10001,    
})
```