### PR TITLE
Optimize table.Count comparisons

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/duplicator/icon.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/duplicator/icon.lua
@@ -74,10 +74,6 @@ hook.Add( "PostRender", "RenderDupeIcon", function()
 		i = i + 1
 
 	end
-	-- Rendering icon the way we do is kinda bad and wil crash the game with too many entities in the dupe
-	-- Try to mitigate that to some degree by not rendering the outline when we are above 800 entities
-	-- 1000 was tested without problems, but we want to give it some space as 1000 was tested in "perfect conditions" with nothing else happening on the map
-	local DoDisableOutline = i > 800
 
 	--
 	-- DRAW THE BLUE BACKGROUND
@@ -92,7 +88,10 @@ hook.Add( "PostRender", "RenderDupeIcon", function()
 	--
 	render.SuppressEngineLighting( true )
 
-	if ( !DoDisableOutline ) then
+	-- Rendering icon the way we do is kinda bad and will crash the game with too many entities in the dupe
+	-- Try to mitigate that to some degree by not rendering the outline when we are above 800 entities
+	-- 1000 was tested without problems, but we want to give it some space as 1000 was tested in "perfect conditions" with nothing else happening on the map
+	if ( i < 800 ) then
 		local BorderSize	= CamDist * 0.004
 		local Up			= EyeAng:Up() * BorderSize
 		local Right			= EyeAng:Right() * BorderSize

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/duplicator/icon.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/duplicator/icon.lua
@@ -14,11 +14,6 @@ hook.Add( "PostRender", "RenderDupeIcon", function()
 
 	local FOV = 17
 
-	-- Rendering icon the way we do is kinda bad and wil crash the game with too many entities in the dupe
-	-- Try to mitigate that to some degree by not rendering the outline when we are above 800 entities
-	-- 1000 was tested without problems, but we want to give it some space as 1000 was tested in "perfect conditions" with nothing else happening on the map
-	local DoDisableOutline = table.Count( Dupe.Entities ) > 800
-
 	--
 	-- This is gonna take some cunning to look awesome!
 	--
@@ -48,7 +43,7 @@ hook.Add( "PostRender", "RenderDupeIcon", function()
 	-- Create a bunch of entities we're gonna use to render.
 	--
 	local entities = {}
-
+	local i = 0
 	for k, v in pairs( Dupe.Entities ) do
 
 		if ( v.Class == "prop_ragdoll" ) then
@@ -76,8 +71,13 @@ hook.Add( "PostRender", "RenderDupeIcon", function()
 			entities[ k ] = ClientsideModel( v.Model or "error.mdl", RENDERGROUP_OTHER )
 
 		end
+		i = i + 1
 
 	end
+	-- Rendering icon the way we do is kinda bad and wil crash the game with too many entities in the dupe
+	-- Try to mitigate that to some degree by not rendering the outline when we are above 800 entities
+	-- 1000 was tested without problems, but we want to give it some space as 1000 was tested in "perfect conditions" with nothing else happening on the map
+	local DoDisableOutline = i > 800
 
 	--
 	-- DRAW THE BLUE BACKGROUND

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_awards.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_awards.lua
@@ -145,7 +145,7 @@ local function AllKills(events, scores, players, traitors)
       end
    end
 
-   if table.Count(tr_killers) == 1 then
+   if #tr_killers == 1 then
       local id = tr_killers[1]
       if not table.HasValue(traitors, id) then
          local killer = players[id]
@@ -155,7 +155,7 @@ local function AllKills(events, scores, players, traitors)
       end
    end
 
-   if table.Count(in_killers) == 1 then
+   if #in_killers == 1 then
       local id = in_killers[1]
       if table.HasValue(traitors, id) then
          local killer = players[id]


### PR DESCRIPTION
1) Remove unnecessary use of table.Count in TTT (table is sequential).

2) Remove table.Count from duplicator icon generation and keep count in the already existing loop