### PR TITLE
[TTT] Remove util.SafeRemoveHook

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -393,7 +393,7 @@ local function CleanUp()
    end
 
    -- a different kind of cleanup
-   util.SafeRemoveHook("PlayerSay", "ULXMeCheck")
+   hook.Remove("PlayerSay", "ULXMeCheck")
 end
 
 local function SpawnEntities()

--- a/garrysmod/gamemodes/terrortown/gamemode/util.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/util.lua
@@ -166,13 +166,6 @@ function util.BasicKeyHandler(pnl, kc)
    end
 end
 
-function util.SafeRemoveHook(event, name)
-   local h = hook.GetTable()
-   if h and h[event] and h[event][name] then
-      hook.Remove(event, name)
-   end
-end
-
 function util.noop() end
 function util.passthrough(x) return x end
 


### PR DESCRIPTION
hook.Remove can be used safely even if the hook doesn't exist.