### PR TITLE
Add table.Pack

### DIFF
--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -1,4 +1,8 @@
 
+function table.Pack( ... )
+	return { ... }, select( "#", ... )
+end
+
 --[[---------------------------------------------------------
 	Name: Inherit( t, base )
 	Desc: Copies any missing data from base to t


### PR DESCRIPTION
Since https://github.com/Facepunch/garrysmod-requests/issues/585 isn't going to be done anytime soon, this is the 5.1 alternative. This packs varargs in a table and returns the proper length including nils, which is unreliable with the ``#`` operator.