### PR TITLE
dtextentry: pass the current value through OnEnter

### DIFF
--- a/garrysmod/lua/vgui/dtextentry.lua
+++ b/garrysmod/lua/vgui/dtextentry.lua
@@ -76,7 +76,7 @@ function PANEL:OnKeyCodeTyped( code )
 		end
 
 		self:FocusNext()
-		self:OnEnter()
+		self:OnEnter(self:GetValue())
 		self.HistoryPos = 0
 
 	end
@@ -237,7 +237,7 @@ function PANEL:Think()
 
 end
 
-function PANEL:OnEnter()
+function PANEL:OnEnter( val )
 
 	-- For override
 	self:UpdateConvarValue()


### PR DESCRIPTION
idk why this wasn't a thing before