### PR TITLE
workaround for Player:GetVehicle() returning a non vehicle entities

### DIFF
--- a/garrysmod/lua/includes/modules/properties.lua
+++ b/garrysmod/lua/includes/modules/properties.lua
@@ -111,7 +111,7 @@ end
 function GetHovered( eyepos, eyevec )
 
 	local filter = { LocalPlayer():GetViewEntity() }
-	if ( LocalPlayer():GetViewEntity() == LocalPlayer() && IsValid( LocalPlayer():GetVehicle() ) && !LocalPlayer():GetVehicle():GetThirdPersonMode() ) then table.insert( filter, LocalPlayer():GetVehicle() ) end
+	if ( LocalPlayer():GetViewEntity() == LocalPlayer() && IsValid( LocalPlayer():GetVehicle() ) && LocalPlayer():GetVehicle():IsVehicle() && !LocalPlayer():GetVehicle():GetThirdPersonMode() ) then table.insert( filter, LocalPlayer():GetVehicle() ) end
 
 	local trace = util.TraceLine( {
 		start = eyepos,


### PR DESCRIPTION
if you open the context menu while in a prop_vehicle_crane you will get a lua error like this
[ERROR] lua/includes/modules/properties.lua:114: attempt to call method 'GetThirdPersonMode' (a nil value)
  1. GetHovered - lua/includes/modules/properties.lua:114
   2. fn - lua/includes/modules/properties.lua:174
    3. Run - addons/ulib_557962238/lua/ulib/shared/hook.lua:109
     4. fn - lua/includes/modules/halo.lua:149
      5. unknown - addons/ulib_557962238/lua/ulib/shared/hook.lua:109


this is because LocalPlayer():GetVehicle() return the crane you are in, so the IsValid check will return true, but since it's not an actual vehicle, calling a Vehicle function will cause a lua error.