### PR TITLE
fix for using the CMenu in nonvehicle entities

### DIFF
--- a/garrysmod/lua/includes/modules/properties.lua
+++ b/garrysmod/lua/includes/modules/properties.lua
@@ -111,7 +111,12 @@ end
 function GetHovered( eyepos, eyevec )
 
 	local filter = { LocalPlayer():GetViewEntity() }
-	if ( LocalPlayer():GetViewEntity() == LocalPlayer() && IsValid( LocalPlayer():GetVehicle() ) && !LocalPlayer():GetVehicle():GetThirdPersonMode() ) then table.insert( filter, LocalPlayer():GetVehicle() ) end
+	if ( LocalPlayer():GetViewEntity() == LocalPlayer() ) then
+		local veh=LocalPlayer():GetVehicle()
+		if ( veh:IsVehicle() && !LocalPlayer():GetVehicle():GetThirdPersonMode() || veh:IsValid() && !veh:IsVehicle() ) then
+			table.insert( filter, LocalPlayer():GetVehicle() )
+		end
+	end
 
 	local trace = util.TraceLine( {
 		start = eyepos,

--- a/garrysmod/lua/includes/modules/properties.lua
+++ b/garrysmod/lua/includes/modules/properties.lua
@@ -113,8 +113,8 @@ function GetHovered( eyepos, eyevec )
 	local filter = { LocalPlayer():GetViewEntity() }
 	if ( LocalPlayer():GetViewEntity() == LocalPlayer() ) then
 		local veh=LocalPlayer():GetVehicle()
-		if ( veh:IsVehicle() && !LocalPlayer():GetVehicle():GetThirdPersonMode() || veh:IsValid() && !veh:IsVehicle() ) then
-			table.insert( filter, LocalPlayer():GetVehicle() )
+		if ( veh:IsVehicle() && !veh:GetThirdPersonMode() || veh:IsValid() && !veh:IsVehicle() ) then
+			table.insert( filter, veh )
 		end
 	end
 

--- a/garrysmod/lua/includes/modules/properties.lua
+++ b/garrysmod/lua/includes/modules/properties.lua
@@ -110,11 +110,14 @@ end
 
 function GetHovered( eyepos, eyevec )
 
-	local filter = { LocalPlayer():GetViewEntity() }
-	if ( LocalPlayer():GetViewEntity() == LocalPlayer() ) then
-		local veh=LocalPlayer():GetVehicle()
-		if ( veh:IsVehicle() && !veh:GetThirdPersonMode() || veh:IsValid() && !veh:IsVehicle() ) then
-			table.insert( filter, veh )
+	local ply = LocalPlayer()
+	local filter = ply:GetViewEntity()
+
+	if ( filter == ply ) then
+		local veh = ply:GetVehicle()
+
+		if ( veh:IsValid() && ( !veh:IsVehicle() || !veh:GetThirdPersonMode() ) ) then
+			filter = { filter, veh }
 		end
 	end
 


### PR DESCRIPTION
improved version of my fix.
earlier description:
if you open the context menu while in a prop_vehicle_crane you will get a lua error like this
[ERROR] lua/includes/modules/properties.lua:114: attempt to call method 'GetThirdPersonMode' (a nil value)
  1. GetHovered - lua/includes/modules/properties.lua:114
   2. fn - lua/includes/modules/properties.lua:174
    3. Run - addons/ulib_557962238/lua/ulib/shared/hook.lua:109
     4. fn - lua/includes/modules/halo.lua:149
      5. unknown - addons/ulib_557962238/lua/ulib/shared/hook.lua:109


this is because LocalPlayer():GetVehicle() return the crane you are in, so the IsValid check will return true, but since it's not an actual vehicle, calling a Vehicle function will cause a lua error.