### PR TITLE
DColorButton: Added ability to choose Tooltip

### DIFF
--- a/garrysmod/lua/vgui/dcolorbutton.lua
+++ b/garrysmod/lua/vgui/dcolorbutton.lua
@@ -27,7 +27,7 @@ function PANEL:IsDown()
 
 end
 
-function PANEL:SetColor( color, displayTooltip = false )
+function PANEL:SetColor( color, displayTooltip )
 
 	if ( displayTooltip == true ) then
 		

--- a/garrysmod/lua/vgui/dcolorbutton.lua
+++ b/garrysmod/lua/vgui/dcolorbutton.lua
@@ -27,9 +27,9 @@ function PANEL:IsDown()
 
 end
 
-function PANEL:SetColor( color, displayTooltip )
+function PANEL:SetColor( color, hideTooltip )
 
-	if ( displayTooltip == true or displayTooltip == nil ) then
+	if ( hideTooltip == false or hideTooltip == nil ) then
 		
 		local colorStr = "R: " .. color.r .. "\nG: " .. color.g .. "\nB: " .. color.b .. "\nA: " .. color.a
 		self:SetTooltip( colorStr )

--- a/garrysmod/lua/vgui/dcolorbutton.lua
+++ b/garrysmod/lua/vgui/dcolorbutton.lua
@@ -29,7 +29,7 @@ end
 
 function PANEL:SetColor( color, hideTooltip )
 
-	if ( hideTooltip == false or hideTooltip == nil ) then
+	if ( !hideTooltip ) then
 		
 		local colorStr = "R: " .. color.r .. "\nG: " .. color.g .. "\nB: " .. color.b .. "\nA: " .. color.a
 		self:SetTooltip( colorStr )

--- a/garrysmod/lua/vgui/dcolorbutton.lua
+++ b/garrysmod/lua/vgui/dcolorbutton.lua
@@ -27,11 +27,15 @@ function PANEL:IsDown()
 
 end
 
-function PANEL:SetColor( color )
+function PANEL:SetColor( color, displayTooltip = false )
 
-	local colorStr = "R: " .. color.r .. "\nG: " .. color.g .. "\nB: " .. color.b .. "\nA: " .. color.a
-
-	self:SetTooltip( colorStr )
+	if ( displayTooltip == true ) then
+		
+		local colorStr = "R: " .. color.r .. "\nG: " .. color.g .. "\nB: " .. color.b .. "\nA: " .. color.a
+		self:SetTooltip( colorStr )
+		
+	end
+	
 	self.m_Color = color
 
 end

--- a/garrysmod/lua/vgui/dcolorbutton.lua
+++ b/garrysmod/lua/vgui/dcolorbutton.lua
@@ -29,7 +29,7 @@ end
 
 function PANEL:SetColor( color, displayTooltip )
 
-	if ( displayTooltip == true ) then
+	if ( displayTooltip == true or displayTooltip == nil ) then
 		
 		local colorStr = "R: " .. color.r .. "\nG: " .. color.g .. "\nB: " .. color.b .. "\nA: " .. color.a
 		self:SetTooltip( colorStr )


### PR DESCRIPTION
Added a boolean value to SetColor() for the DColorButton so you are able to choose to show the color string tooltip. The default value is false. 

Now the tooltip won't be reset every time the color is changed but you are still able to view it if you want to.

Fixes #Facepunch/garrysmod-issues#3836