### PR TITLE
Do not discipline a weapon's new table type values when inheriting the BaseClass table

### DIFF
--- a/garrysmod/lua/includes/modules/weapons.lua
+++ b/garrysmod/lua/includes/modules/weapons.lua
@@ -13,7 +13,7 @@ local function TableInherit( t, base )
 
 		if ( t[ k ] == nil ) then
 			t[ k ] = v
-		elseif ( k != "BaseClass" && istable( t[ k ] ) ) then
+		elseif ( k != "BaseClass" && istable( t[ k ] ) && istable( v ) ) then
 			TableInherit( t[ k ], v )
 		end
 


### PR DESCRIPTION
Allow a weapon's BaseClass to have non-table values by using the defining weapon's new table type value instead of erroring and breaking weapons.