### PR TITLE
Updating Game & Progress Discussion Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repo consists of all Lua, text, and config extensions for Garry's Mod. Bina
 
 Next Update
 ---
-Current game discussion as well as update progress can be found on [Discord](https://discord.gg/RvD2G6s).
+Current game discussion as well as update progress can be found on [Discord](https://discord.gg/gmod).
 
 You can test [changes for the next update](http://wiki.garrysmod.com/changelist/) on the [Garry's Mod Dev Branch](http://wiki.garrysmod.com/page/Dev_Branch) through Steam.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repo consists of all Lua, text, and config extensions for Garry's Mod. Bina
 
 Next Update
 ---
-Current game discussion as well as update progress can be found on the [Facepunch Forums](https://forum.facepunch.com/f/gmoddev).
+Current game discussion as well as update progress can be found on [Discord](https://discord.gg/RvD2G6s).
 
 You can test [changes for the next update](http://wiki.garrysmod.com/changelist/) on the [Garry's Mod Dev Branch](http://wiki.garrysmod.com/page/Dev_Branch) through Steam.
 


### PR DESCRIPTION
Replaced the link regarding current game discussion and update progress from the now closed Facepunch Forums to the official Garry's Mod Official Discord chat.