### PR TITLE
Outline system for entities (not halo)

### DIFF
--- a/garrysmod/lua/includes/init.lua
+++ b/garrysmod/lua/includes/init.lua
@@ -63,6 +63,7 @@ if ( CLIENT ) then
 	require ( "markup" )		-- Text markup library
 	require ( "effects" )
 	require ( "halo" )
+	require ( "outline" )
 	require ( "killicon" )
 	require ( "spawnmenu" )
 	require ( "controlpanel" )

--- a/garrysmod/lua/includes/modules/outline.lua
+++ b/garrysmod/lua/includes/modules/outline.lua
@@ -1,0 +1,117 @@
+
+module("outline",package.seeall)
+
+local List = {}
+local RenderEnt = NULL
+
+local CopyMat		= Material("pp/copy")
+local OutlineMat	= CreateMaterial("OutlineMat","UnlitGeneric",{["$ignorez"] = 1,["$alphatest"] = 1})
+local StoreTexture	= render.GetScreenEffectTexture(0)
+local DrawTexture	= render.GetScreenEffectTexture(1)
+
+--[[-------------------------------
+	Modes:
+	0 - Always draw
+	1 - Draw if not visible
+	2 - Draw if visible
+--]]-------------------------------
+
+function Add(ents,color,mode)
+	if !istable(ents) then ents = {ents} end	--Support for passing Entity as first argument
+	if table.IsEmpty(ents) then return end		--Do not pass empty tables
+	if #List>=255 then return end				--Maximum 255 reference values
+	
+	table.insert(List,{
+		Ents = ents,
+		Color = color,
+		Mode = mode
+	})
+end
+
+function RenderedEntity()
+	return RenderEnt
+end
+
+local function Render()
+	local scene = render.GetRenderTarget()
+	render.CopyRenderTargetToTexture(StoreTexture)
+	
+	render.Clear(0,0,0,0,true,true)
+
+	render.SetStencilEnable(true)
+		cam.IgnoreZ(true)
+		render.SuppressEngineLighting(true)
+	
+		render.SetStencilWriteMask(255)
+		render.SetStencilTestMask(255)
+		
+		render.SetStencilCompareFunction(STENCIL_ALWAYS)
+		render.SetStencilFailOperation(STENCIL_KEEP)
+		render.SetStencilZFailOperation(STENCIL_REPLACE)
+		render.SetStencilPassOperation(STENCIL_REPLACE)
+		
+		cam.Start3D()
+			for k,v in ipairs(List) do
+				render.SetStencilReferenceValue(k)
+				
+				for k2,v2 in ipairs(v.Ents) do
+					if !IsValid(v2) then continue end
+					
+					local visible = LocalPlayer():IsLineOfSightClear(v2)
+					if v.Mode==1 and visible or v.Mode==2 and !visible then continue end
+					
+					RenderEnt = v2
+					v2:DrawModel()
+					RenderEnt = NULL
+				end
+			end
+		cam.End3D()
+		
+		render.SetStencilCompareFunction(STENCIL_EQUAL)
+		
+		cam.Start2D()
+			for k,v in ipairs(List) do
+				render.SetStencilReferenceValue(k)
+				
+				surface.SetDrawColor(v.Color)
+				surface.DrawRect(0,0,ScrW(),ScrH())
+			end
+		cam.End2D()
+		
+		render.SuppressEngineLighting(false)
+		cam.IgnoreZ(false)
+	render.SetStencilEnable(false)
+	
+	render.CopyRenderTargetToTexture(DrawTexture)
+	
+	render.SetRenderTarget(scene)
+	CopyMat:SetTexture("$basetexture",StoreTexture)
+	render.SetMaterial(CopyMat)
+	render.DrawScreenQuad()
+	
+	render.SetStencilEnable(true)
+		render.SetStencilReferenceValue(0)
+		render.SetStencilCompareFunction(STENCIL_EQUAL)
+		
+		OutlineMat:SetTexture("$basetexture",DrawTexture)
+		render.SetMaterial(OutlineMat)
+		
+		for x=-1,1 do
+			for y=-1,1 do
+				if x==0 and x==0 then continue end
+				
+				render.DrawScreenQuadEx(x,y,ScrW(),ScrH())
+			end
+		end
+	render.SetStencilEnable(false)
+end
+
+hook.Add("PostDrawEffects","RenderOutlines",function()
+	hook.Run("PreDrawOutlines")
+	
+	if #List==0 then return end
+	
+	Render()
+	
+	List = {}
+end)

--- a/garrysmod/lua/includes/modules/outline.lua
+++ b/garrysmod/lua/includes/modules/outline.lua
@@ -114,7 +114,7 @@ local function Render()
 	
 	local w, h = ScrW(), ScrH()
 	
-	render.Clear( 0, 0, 0, 0, false, true )
+	render.ClearStencil()
 	
 	render.SetStencilEnable( true )
 		render.SuppressEngineLighting( true )
@@ -126,7 +126,7 @@ local function Render()
 		render.SetStencilFailOperation( STENCIL_KEEP )
 		
 		cam.Start3D()
-			render.SetBlend(0)
+			render.SetBlend(1)
 			
 			for i = 1, ListSize do
 				
@@ -205,6 +205,8 @@ local function Render()
 		render.SetStencilCompareFunction( STENCIL_EQUAL )
 		render.SetStencilZFailOperation( STENCIL_KEEP )
 		render.SetStencilPassOperation( STENCIL_KEEP )
+		
+		render.Clear( 0, 0, 0, 0, false, false )
 		
 		cam.Start2D()
 			

--- a/garrysmod/lua/includes/modules/outline.lua
+++ b/garrysmod/lua/includes/modules/outline.lua
@@ -95,7 +95,7 @@ end
 function SetDoubleThickness( thickness )
 
 	local old_thickness = OutlineThickness == 2
-	OutlineThickness = thickness and 2 or 1
+	OutlineThickness = thickness && 2 || 1
 	
 	return old_thickness
 	
@@ -140,7 +140,7 @@ local function Render()
 				
 				if ( mode == OUTLINE_MODE_BOTH || mode == OUTLINE_MODE_VISIBLE ) then
 					
-					render.SetStencilZFailOperation( mode == OUTLINE_MODE_BOTH and STENCIL_REPLACE or STENCIL_KEEP )
+					render.SetStencilZFailOperation( mode == OUTLINE_MODE_BOTH && STENCIL_REPLACE || STENCIL_KEEP )
 					render.SetStencilPassOperation( STENCIL_REPLACE )
 					
 					for j = 1, #ents do

--- a/garrysmod/lua/includes/modules/outline.lua
+++ b/garrysmod/lua/includes/modules/outline.lua
@@ -1,128 +1,227 @@
-
-OUTLINE_MODE_BOTH	= 0
+OUTLINE_MODE_BOTH		= 0		-- Render always
 OUTLINE_MODE_NOTVISIBLE	= 1
 OUTLINE_MODE_VISIBLE	= 2
 
-local istable		= istable
-local render		= render
-local LocalPlayer	= LocalPlayer
-local Material		= Material
+OUTLINE_RENDERTYPE_BEFORE_VM	= 0		-- Render before drawing the view model
+OUTLINE_RENDERTYPE_BEFORE_EF	= 1		-- Render before drawing all effects (after drawing the viewmodel)
+OUTLINE_RENDERTYPE_AFTER_EF		= 2		-- Render after drawing all effects
+
+local istable			= istable
+local render			= render
+local Material			= Material
 local CreateMaterial	= CreateMaterial
-local hook		= hook
-local cam		= cam
-local ScrW		= ScrW
-local ScrH		= ScrH
-local IsValid		= IsValid
-local surface		= surface
+local hook				= hook
+local cam				= cam
+local ScrW				= ScrW
+local ScrH				= ScrH
+local IsValid			= IsValid
+local surface			= surface
 
 module( "outline", package.seeall )
 
-local List, ListSize = {}, 0
-local RenderEnt = NULL
+local List, ListSize		= {}, 0
+local RenderEnt				= NULL
+local RenderType			= OUTLINE_RENDERTYPE_AFTER_EF
+local OutlineThickness		= 1
 
-local OutlineMatSettings = {
-	[ "$ignorez" ] = 1,
-	[ "$alphatest" ] = 1
+local StoreTexture			= render.GetScreenEffectTexture( 0 )
+local DrawTexture			= render.GetScreenEffectTexture( 1 )
+
+local OutlineMatSettings	= {
+	[ "$basetexture" ]	= DrawTexture:GetName(),
+	[ "$ignorez" ]		= 1,
+	[ "$alphatest" ]	= 1
 }
 
-local CopyMat		= Material( "pp/copy" )
-local OutlineMat	= CreateMaterial( "OutlineMat", "UnlitGeneric", OutlineMatSettings )
-local StoreTexture	= render.GetScreenEffectTexture( 0 )
-local DrawTexture	= render.GetScreenEffectTexture( 1 )
+local CopyMat				= Material( "pp/copy" )
+local OutlineMat			= CreateMaterial( "outline", "UnlitGeneric", OutlineMatSettings )
 
-local ENTS	= 1
-local COLOR	= 2
-local MODE	= 3
+local ENTS, COLOR, MODE		= 1, 2, 3
 
 function Add( ents, color, mode )
-
-	if ( ListSize >= 255 ) then return end			--Maximum 255 reference values
-	if ( !istable( ents ) ) then ents = { ents } end	--Support for passing Entity as first argument
-	if ( ents[ 1 ] == nil ) then return end			--Do not pass empty tables
 	
-	local t = {
+	if ( ListSize >= 255 ) then return end				--Maximum 255 reference values
+	if ( !istable( ents ) ) then ents = { ents } end	--Support for passing Entity as first argument
+	if ( ents[ 1 ] == nil ) then return end				--Do not pass empty tables
+	
+	if (
+		mode != OUTLINE_MODE_BOTH &&
+		mode != OUTLINE_MODE_NOTVISIBLE &&
+		mode != OUTLINE_MODE_VISIBLE
+	) then
+		mode = OUTLINE_MODE_BOTH
+	end
+	
+	local data = {
 		[ ENTS ] = ents,
 		[ COLOR ] = color,
-		[ MODE ] = mode or OUTLINE_MODE_BOTH
+		[ MODE ] = mode
 	}
 	
 	ListSize = ListSize + 1
-	List[ ListSize ] = t
+	List[ ListSize ] = data
+	
 end
 
 function RenderedEntity()
-
+	
 	return RenderEnt
 	
 end
 
-local function Render()
-	local ply = LocalPlayer()
-	local IsLineOfSightClear = ply.IsLineOfSightClear
+function SetRenderType( render_type )
+	
+	if (
+		render_type != OUTLINE_RENDERTYPE_BEFORE_VM &&
+		render_type != OUTLINE_RENDERTYPE_BEFORE_EF &&
+		render_type != OUTLINE_RENDERTYPE_AFTER_EF
+	) then
+		return
+	end
 
+	local old_type = RenderType
+	RenderType = render_type
+	
+	return old_type
+	
+end
+
+function GetRenderType()
+	
+	return RenderType
+	
+end
+
+function SetDoubleThickness( thickness )
+
+	local old_thickness = OutlineThickness == 2
+	OutlineThickness = thickness and 2 or 1
+	
+	return old_thickness
+	
+end
+
+function IsDoubleThickness()
+	
+	return OutlineThickness == 2
+	
+end
+
+local function Render()
+	
 	local scene = render.GetRenderTarget()
 	render.CopyRenderTargetToTexture( StoreTexture )
 	
-	local w = ScrW()
-	local h = ScrH()
+	local w, h = ScrW(), ScrH()
 	
-	render.Clear( 0, 0, 0, 0, true, true )
-
+	render.Clear( 0, 0, 0, 0, false, true )
+	
 	render.SetStencilEnable( true )
-		cam.IgnoreZ( true )
 		render.SuppressEngineLighting( true )
-	
+		
 		render.SetStencilWriteMask( 0xFF )
 		render.SetStencilTestMask( 0xFF )
 		
-		render.SetStencilCompareFunction( STENCIL_ALWAYS )
+		render.SetStencilCompareFunction( STENCIL_GREATER )
 		render.SetStencilFailOperation( STENCIL_KEEP )
-		render.SetStencilZFailOperation( STENCIL_REPLACE )
-		render.SetStencilPassOperation( STENCIL_REPLACE )
 		
 		cam.Start3D()
-		
+			render.SetBlend(0)
+			
 			for i = 1, ListSize do
-				local v = List[ i ]
-				local mode = v[ MODE ]
-				local ents = v[ ENTS ]
 				
-				render.SetStencilReferenceValue( i )
-		
-				for j = 1, #ents do
-					local ent = ents[ j ]
+				local reference = 0xFF - ( i - 1 )
+				
+				local data = List[ i ]
+				local mode = data[ MODE ]
+				local ents = data[ ENTS ]
+				
+				render.SetStencilReferenceValue( reference )
+				
+				if ( mode == OUTLINE_MODE_BOTH || mode == OUTLINE_MODE_VISIBLE ) then
 					
-					if ( !IsValid( ent ) ) then continue end
+					render.SetStencilZFailOperation( mode == OUTLINE_MODE_BOTH and STENCIL_REPLACE or STENCIL_KEEP )
+					render.SetStencilPassOperation( STENCIL_REPLACE )
 					
-					if ( ( mode == OUTLINE_MODE_NOTVISIBLE && IsLineOfSightClear( ply, ent ) ) || ( mode == OUTLINE_MODE_VISIBLE && !IsLineOfSightClear( ply, ent ) ) ) then
-						continue
+					for j = 1, #ents do
+						
+						local ent = ents[ j ]
+						
+						if ( IsValid( ent ) ) then
+							
+							RenderEnt = ent
+							ent:DrawModel()
+							
+						end
+						
 					end
 					
-					RenderEnt = ent
+				elseif ( mode == OUTLINE_MODE_NOTVISIBLE ) then
 					
-					ent:DrawModel()
+					render.SetStencilZFailOperation( STENCIL_REPLACE )
+					render.SetStencilPassOperation( STENCIL_KEEP )
+					
+					for j = 1, #ents do
+						
+						local ent = ents[ j ]
+						
+						if ( IsValid( ent ) ) then
+							
+							RenderEnt = ent
+							ent:DrawModel()
+							
+						end
+						
+					end
+					
+					render.SetStencilCompareFunction( STENCIL_EQUAL )
+					render.SetStencilZFailOperation( STENCIL_KEEP )
+					render.SetStencilPassOperation( STENCIL_ZERO )
+					
+					for j = 1, #ents do
+						
+						local ent = ents[ j ]
+						
+						if ( IsValid( ent ) ) then
+							
+							RenderEnt = ent
+							ent:DrawModel()
+							
+						end
+						
+					end
+					
+					render.SetStencilCompareFunction( STENCIL_GREATER )
+					
 				end
+				
 			end
 			
 			RenderEnt = NULL
 			
+			render.SetBlend(1)
 		cam.End3D()
 		
 		render.SetStencilCompareFunction( STENCIL_EQUAL )
+		render.SetStencilZFailOperation( STENCIL_KEEP )
+		render.SetStencilPassOperation( STENCIL_KEEP )
 		
 		cam.Start2D()
-		
+			
 			for i = 1, ListSize do
-				render.SetStencilReferenceValue( i )
+				
+				local reference = 0xFF - ( i - 1 )
+				
+				render.SetStencilReferenceValue( reference )
 				
 				surface.SetDrawColor( List[ i ][ COLOR ] )
 				surface.DrawRect( 0, 0, w, h )
+				
 			end
 			
 		cam.End2D()
 		
 		render.SuppressEngineLighting( false )
-		cam.IgnoreZ( false )
 	render.SetStencilEnable( false )
 	
 	render.CopyRenderTargetToTexture( DrawTexture )
@@ -133,33 +232,66 @@ local function Render()
 	render.DrawScreenQuad()
 	
 	render.SetStencilEnable( true )
+	
 		render.SetStencilReferenceValue( 0 )
+		
 		render.SetStencilCompareFunction( STENCIL_EQUAL )
 		
 		OutlineMat:SetTexture( "$basetexture", DrawTexture )
 		render.SetMaterial( OutlineMat )
 		
-		render.DrawScreenQuadEx( -1, -1, w ,h )
-		render.DrawScreenQuadEx( -1, 0, w, h )
-		render.DrawScreenQuadEx( -1, 1, w, h )
-		render.DrawScreenQuadEx( 0, -1, w, h )
-		render.DrawScreenQuadEx( 0, 1, w, h )
-		render.DrawScreenQuadEx( 1, 1, w, h )
-		render.DrawScreenQuadEx( 1, 0, w, h )
-		render.DrawScreenQuadEx( 1, 1, w, h )
-	
+		render.DrawScreenQuadEx( -OutlineThickness, -OutlineThickness, w ,h )
+		render.DrawScreenQuadEx( -OutlineThickness, 0, w, h )
+		render.DrawScreenQuadEx( -OutlineThickness, OutlineThickness, w, h )
+		render.DrawScreenQuadEx( 0, -OutlineThickness, w, h )
+		render.DrawScreenQuadEx( 0, OutlineThickness, w, h )
+		render.DrawScreenQuadEx( OutlineThickness, -OutlineThickness, w, h )
+		render.DrawScreenQuadEx( OutlineThickness, 0, w, h )
+		render.DrawScreenQuadEx( OutlineThickness, OutlineThickness, w, h )
+		
 	render.SetStencilEnable( false )
 	
+	render.ClearDepth()		-- Allows to render view model and other stuff in front of outline
 end
 
-hook.Add( "PostDrawEffects", "RenderOutlines", function()
-
-	hook.Run( "PreDrawOutlines" )
+local function RenderOutlines()
+	
+	hook.Run( "SetupOutlines", Add )
 	
 	if ( ListSize == 0 ) then return end
 	
 	Render()
 	
 	List, ListSize = {}, 0
+	
+end
+
+hook.Add( "PreDrawViewModels", "RenderOutlines", function()
+	
+	if ( RenderType == OUTLINE_RENDERTYPE_BEFORE_VM ) then
+		
+		RenderOutlines()
+		
+	end
+	
+end )
+
+hook.Add( "PreDrawEffects", "RenderOutlines", function()
+	
+	if ( RenderType == OUTLINE_RENDERTYPE_BEFORE_EF ) then
+		
+		RenderOutlines()
+		
+	end
+	
+end )
+
+hook.Add( "PostDrawEffects", "RenderOutlines", function()
+	
+	if ( RenderType == OUTLINE_RENDERTYPE_AFTER_EF ) then
+		
+		RenderOutlines()
+		
+	end
 	
 end )

--- a/garrysmod/lua/includes/modules/outline.lua
+++ b/garrysmod/lua/includes/modules/outline.lua
@@ -3,6 +3,18 @@ OUTLINE_MODE_BOTH	= 0
 OUTLINE_MODE_NOTVISIBLE	= 1
 OUTLINE_MODE_VISIBLE	= 2
 
+local istable		= istable
+local render		= render
+local LocalPlayer	= LocalPlayer
+local Material		= Material
+local CreateMaterial	= CreateMaterial
+local hook		= hook
+local cam		= cam
+local ScrW		= ScrW
+local ScrH		= ScrH
+local IsValid		= IsValid
+local surface		= surface
+
 module( "outline", package.seeall )
 
 local List, ListSize = {}, 0

--- a/garrysmod/lua/includes/modules/outline.lua
+++ b/garrysmod/lua/includes/modules/outline.lua
@@ -81,7 +81,7 @@ local function Render()
 					
 					if ( !IsValid( ent ) ) then continue end
 					
-					if ( ( mode == OUTLINE_MODE_NOTVISIBLE && LocalPlayer():IsLineOfSightClear( ent ) ) || ( mode==OUTLINE_MODE_VISIBLE && !LocalPlayer():IsLineOfSightClear( ent ) ) ) then continue end
+					if ( ( mode == OUTLINE_MODE_NOTVISIBLE && LocalPlayer():IsLineOfSightClear( ent ) ) || ( mode == OUTLINE_MODE_VISIBLE && !LocalPlayer():IsLineOfSightClear( ent ) ) ) then continue end
 					
 					RenderEnt = ent
 					

--- a/garrysmod/lua/includes/modules/outline.lua
+++ b/garrysmod/lua/includes/modules/outline.lua
@@ -1,125 +1,150 @@
-OUTLINE_MODE_BOTH,OUTLINE_MODE_NOTVISIBLE,OUTLINE_MODE_VISIBLE = 0,1,2
 
-module("outline",package.seeall)
+OUTLINE_MODE_BOTH	= 0
+OUTLINE_MODE_NOTVISIBLE	= 1
+OUTLINE_MODE_VISIBLE	= 2
 
-local List,ListSize = {},0
+module( "outline", package.seeall )
+
+local List, ListSize = {}, 0
 local RenderEnt = NULL
 
-local CopyMat		= Material("pp/copy")
-local OutlineMat	= CreateMaterial("OutlineMat","UnlitGeneric",{["$ignorez"] = 1,["$alphatest"] = 1})
-local StoreTexture	= render.GetScreenEffectTexture(0)
-local DrawTexture	= render.GetScreenEffectTexture(1)
+local OutlineMatSettings = {
+	[ "$ignorez" ] = 1,
+	[ "$alphatest" ] = 1
+}
 
-local ENTS,COLOR,MODE = 1,2,3
+local CopyMat		= Material( "pp/copy" )
+local OutlineMat	= CreateMaterial( "OutlineMat", "UnlitGeneric", OutlineMatSettings )
+local StoreTexture	= render.GetScreenEffectTexture( 0 )
+local DrawTexture	= render.GetScreenEffectTexture( 1 )
 
-function Add(ents,color,mode)
-	if ListSize>=255 then return end		--Maximum 255 reference values
-	if !istable(ents) then ents = {ents} end	--Support for passing Entity as first argument
-	if ents[1]==nil then return end			--Do not pass empty tables
+local ENTS	= 1
+local COLOR	= 2
+local MODE	= 3
+
+function Add( ents, color, mode )
+
+	if ( ListSize >= 255 ) then return end				--Maximum 255 reference values
+	if ( !istable( ents ) ) then ents = { ents } end	--Support for passing Entity as first argument
+	if ( ents[ 1 ] == nil ) then return end				--Do not pass empty tables
 	
-	table.insert(List,{
-		[ENTS] = ents,
-		[COLOR] = color,
-		[MODE] = mode or OUTLINE_MODE_BOTH
-	})
+	local t = {
+		[ ENTS ] = ents,
+		[ COLOR ] = color,
+		[ MODE ] = mode or OUTLINE_MODE_BOTH
+	}
+	table.insert( List, t )
 	
-	ListSize = ListSize+1
+	ListSize = ListSize + 1
+	
 end
 
 function RenderedEntity()
+
 	return RenderEnt
+	
 end
 
 local function Render()
-	local scene = render.GetRenderTarget()
-	render.CopyRenderTargetToTexture(StoreTexture)
-	
-	local w,h = ScrW(),ScrH()
-	
-	render.Clear(0,0,0,0,true,true)
 
-	render.SetStencilEnable(true)
-		cam.IgnoreZ(true)
-		render.SuppressEngineLighting(true)
+	local scene = render.GetRenderTarget()
+	render.CopyRenderTargetToTexture( StoreTexture )
 	
-		render.SetStencilWriteMask(255)
-		render.SetStencilTestMask(255)
+	local w = ScrW()
+	local h = ScrH()
+	
+	render.Clear( 0, 0, 0, 0, true, true )
+
+	render.SetStencilEnable( true )
+		cam.IgnoreZ( true )
+		render.SuppressEngineLighting( true )
+	
+		render.SetStencilWriteMask( 0xFF )
+		render.SetStencilTestMask( 0xFF )
 		
-		render.SetStencilCompareFunction(STENCIL_ALWAYS)
-		render.SetStencilFailOperation(STENCIL_KEEP)
-		render.SetStencilZFailOperation(STENCIL_REPLACE)
-		render.SetStencilPassOperation(STENCIL_REPLACE)
+		render.SetStencilCompareFunction( STENCIL_ALWAYS )
+		render.SetStencilFailOperation( STENCIL_KEEP )
+		render.SetStencilZFailOperation( STENCIL_REPLACE )
+		render.SetStencilPassOperation( STENCIL_REPLACE )
 		
 		cam.Start3D()
-			for k=1,ListSize do
-				local v = List[k]
-				local mode = v[MODE]
-				
-				render.SetStencilReferenceValue(k)
-				
-				local ents = v[ENTS]
-				local entssize = #ents		
 		
-				for k2=1,entssize do
-					local v2 = ents[k2]
+			for i = 1, ListSize do
+				local v = List[ i ]
+				local mode = v[ MODE ]
+				local ents = v[ ENTS ]
+				
+				render.SetStencilReferenceValue( i )
+		
+				for j = 1, #ents do
+					local ent = ents[ j ]
 					
-					if !IsValid(v2) then continue end
-					if mode==OUTLINE_MODE_NOTVISIBLE and LocalPlayer():IsLineOfSightClear(v2) or mode==OUTLINE_MODE_VISIBLE and !LocalPlayer():IsLineOfSightClear(v2) then continue end
+					if ( !IsValid( ent ) ) then continue end
 					
-					RenderEnt = v2
-					v2:DrawModel()
-					RenderEnt = NULL
+					if ( ( mode == OUTLINE_MODE_NOTVISIBLE && LocalPlayer():IsLineOfSightClear( ent ) ) || ( mode==OUTLINE_MODE_VISIBLE && !LocalPlayer():IsLineOfSightClear( ent ) ) ) then continue end
+					
+					RenderEnt = ent
+					
+					ent:DrawModel()
 				end
 			end
+			
+			RenderEnt = NULL
+			
 		cam.End3D()
 		
-		render.SetStencilCompareFunction(STENCIL_EQUAL)
+		render.SetStencilCompareFunction( STENCIL_EQUAL )
 		
 		cam.Start2D()
-			for i=1,ListSize do
-				render.SetStencilReferenceValue(i)
+		
+			for i = 1, ListSize do
+				render.SetStencilReferenceValue( i )
 				
-				surface.SetDrawColor(List[i][COLOR])
-				surface.DrawRect(0,0,w,h)
+				surface.SetDrawColor( List[ i ][ COLOR ] )
+				surface.DrawRect( 0, 0, w, h )
 			end
+			
 		cam.End2D()
 		
-		render.SuppressEngineLighting(false)
-		cam.IgnoreZ(false)
-	render.SetStencilEnable(false)
+		render.SuppressEngineLighting( false )
+		cam.IgnoreZ( false )
+	render.SetStencilEnable( false )
 	
-	render.CopyRenderTargetToTexture(DrawTexture)
+	render.CopyRenderTargetToTexture( DrawTexture )
 	
-	render.SetRenderTarget(scene)
-	CopyMat:SetTexture("$basetexture",StoreTexture)
-	render.SetMaterial(CopyMat)
+	render.SetRenderTarget( scene )
+	CopyMat:SetTexture( "$basetexture", StoreTexture )
+	render.SetMaterial( CopyMat )
 	render.DrawScreenQuad()
 	
-	render.SetStencilEnable(true)
-		render.SetStencilReferenceValue(0)
-		render.SetStencilCompareFunction(STENCIL_EQUAL)
+	render.SetStencilEnable( true )
+		render.SetStencilReferenceValue( 0 )
+		render.SetStencilCompareFunction( STENCIL_EQUAL )
 		
-		OutlineMat:SetTexture("$basetexture",DrawTexture)
-		render.SetMaterial(OutlineMat)
+		OutlineMat:SetTexture( "$basetexture", DrawTexture )
+		render.SetMaterial( OutlineMat )
 		
-		render.DrawScreenQuadEx(-1,-1,w,h)
-		render.DrawScreenQuadEx(-1,0,w,h)
-		render.DrawScreenQuadEx(-1,1,w,h)
-		render.DrawScreenQuadEx(0,-1,w,h)
-		render.DrawScreenQuadEx(0,1,w,h)
-		render.DrawScreenQuadEx(1,1,w,h)
-		render.DrawScreenQuadEx(1,0,w,h)
-		render.DrawScreenQuadEx(1,1,w,h)
+		render.DrawScreenQuadEx( -1, -1, w ,h )
+		render.DrawScreenQuadEx( -1, 0, w, h )
+		render.DrawScreenQuadEx( -1, 1, w, h )
+		render.DrawScreenQuadEx( 0, -1, w, h )
+		render.DrawScreenQuadEx( 0, 1, w, h )
+		render.DrawScreenQuadEx( 1, 1, w, h )
+		render.DrawScreenQuadEx( 1, 0, w, h )
+		render.DrawScreenQuadEx( 1, 1, w, h )
 	
-	render.SetStencilEnable(false)
+	render.SetStencilEnable( false )
+	
 end
 
-hook.Add("PostDrawEffects","RenderOutlines",function()
-	hook.Run("PreDrawOutlines")
+hook.Add( "PostDrawEffects", "RenderOutlines", function()
+
+	hook.Run( "PreDrawOutlines" )
 	
-	if ListSize==0 then return end
+	if ( ListSize == 0 ) then return end
 	
 	Render()
 	
-	List,ListSize = {},0
-end)
+	List, ListSize = {}, 0
+	
+end )

--- a/garrysmod/lua/includes/modules/outline.lua
+++ b/garrysmod/lua/includes/modules/outline.lua
@@ -1,3 +1,5 @@
+OUTLINE_MODE_BOTH,OUTLINE_MODE_NOTVISIBLE,OUTLINE_MODE_VISIBLE = 0,1,2
+
 module("outline",package.seeall)
 
 local List,ListSize = {},0
@@ -9,7 +11,6 @@ local StoreTexture	= render.GetScreenEffectTexture(0)
 local DrawTexture	= render.GetScreenEffectTexture(1)
 
 local ENTS,COLOR,MODE = 1,2,3
-local MODE_NOTVISIBLE,MODE_VISIBLE = 1,2
 
 function Add(ents,color,mode)
 	if ListSize>=255 then return end		--Maximum 255 reference values
@@ -19,7 +20,7 @@ function Add(ents,color,mode)
 	table.insert(List,{
 		[ENTS] = ents,
 		[COLOR] = color,
-		[MODE] = mode
+		[MODE] = mode or OUTLINE_MODE_BOTH
 	})
 	
 	ListSize = ListSize+1
@@ -62,7 +63,7 @@ local function Render()
 					if !IsValid(v2) then continue end
 					
 					local visible = LocalPlayer():IsLineOfSightClear(v2)
-					if mode==MODE_NOTVISIBLE and visible or mode==MODE_VISIBLE and !visible then continue end
+					if mode==OUTLINE_MODE_NOTVISIBLE and visible or mode==OUTLINE_MODE_VISIBLE and !visible then continue end
 					
 					RenderEnt = v2
 					v2:DrawModel()

--- a/garrysmod/lua/includes/modules/outline.lua
+++ b/garrysmod/lua/includes/modules/outline.lua
@@ -50,12 +50,15 @@ local function Render()
 		render.SetStencilPassOperation(STENCIL_REPLACE)
 		
 		cam.Start3D()
-			for k,v in ipairs(List) do
-				render.SetStencilReferenceValue(k)
-				
+			for k=1,ListSize do
+				local v = List[k]
 				local mode = v[MODE]
 				
-				for k2,v2 in ipairs(v[ENTS]) do
+				render.SetStencilReferenceValue(k)
+				
+				for k2=1,#v[ENTS] do
+					local v2 = v[ENTS][k2]
+					
 					if !IsValid(v2) then continue end
 					
 					local visible = LocalPlayer():IsLineOfSightClear(v2)
@@ -71,10 +74,10 @@ local function Render()
 		render.SetStencilCompareFunction(STENCIL_EQUAL)
 		
 		cam.Start2D()
-			for k,v in ipairs(List) do
-				render.SetStencilReferenceValue(k)
+			for i=1,ListSize do
+				render.SetStencilReferenceValue(i)
 				
-				surface.SetDrawColor(v[COLOR])
+				surface.SetDrawColor(List[i][COLOR])
 				surface.DrawRect(0,0,w,h)
 			end
 		cam.End2D()

--- a/garrysmod/lua/includes/modules/outline.lua
+++ b/garrysmod/lua/includes/modules/outline.lua
@@ -24,19 +24,18 @@ local MODE	= 3
 
 function Add( ents, color, mode )
 
-	if ( ListSize >= 255 ) then return end				--Maximum 255 reference values
+	if ( ListSize >= 255 ) then return end			--Maximum 255 reference values
 	if ( !istable( ents ) ) then ents = { ents } end	--Support for passing Entity as first argument
-	if ( ents[ 1 ] == nil ) then return end				--Do not pass empty tables
+	if ( ents[ 1 ] == nil ) then return end			--Do not pass empty tables
 	
 	local t = {
 		[ ENTS ] = ents,
 		[ COLOR ] = color,
 		[ MODE ] = mode or OUTLINE_MODE_BOTH
 	}
-	table.insert( List, t )
 	
 	ListSize = ListSize + 1
-	
+	List[ ListSize ] = t
 end
 
 function RenderedEntity()
@@ -46,6 +45,8 @@ function RenderedEntity()
 end
 
 local function Render()
+	local ply = LocalPlayer()
+	local IsLineOfSightClear = ply.IsLineOfSightClear
 
 	local scene = render.GetRenderTarget()
 	render.CopyRenderTargetToTexture( StoreTexture )
@@ -81,7 +82,9 @@ local function Render()
 					
 					if ( !IsValid( ent ) ) then continue end
 					
-					if ( ( mode == OUTLINE_MODE_NOTVISIBLE && LocalPlayer():IsLineOfSightClear( ent ) ) || ( mode == OUTLINE_MODE_VISIBLE && !LocalPlayer():IsLineOfSightClear( ent ) ) ) then continue end
+					if ( ( mode == OUTLINE_MODE_NOTVISIBLE && IsLineOfSightClear( ply, ent ) ) || ( mode == OUTLINE_MODE_VISIBLE && !IsLineOfSightClear( ply, ent ) ) ) then
+						continue
+					end
 					
 					RenderEnt = ent
 					

--- a/garrysmod/lua/includes/modules/outline.lua
+++ b/garrysmod/lua/includes/modules/outline.lua
@@ -98,7 +98,7 @@ local function Render()
 		
 		for x=-1,1 do
 			for y=-1,1 do
-				if x==0 and x==0 then continue end
+				if x==0 and y==0 then continue end
 				
 				render.DrawScreenQuadEx(x,y,ScrW(),ScrH())
 			end

--- a/garrysmod/lua/includes/modules/outline.lua
+++ b/garrysmod/lua/includes/modules/outline.lua
@@ -57,8 +57,11 @@ local function Render()
 				
 				render.SetStencilReferenceValue(k)
 				
-				for k2=1,#v[ENTS] do
-					local v2 = v[ENTS][k2]
+				local ents = v[ENTS]
+				local entssize = #ents		
+		
+				for k2=1,entssize do
+					local v2 = ents[k2]
 					
 					if !IsValid(v2) then continue end
 					

--- a/garrysmod/lua/includes/modules/outline.lua
+++ b/garrysmod/lua/includes/modules/outline.lua
@@ -64,9 +64,7 @@ local function Render()
 					local v2 = ents[k2]
 					
 					if !IsValid(v2) then continue end
-					
-					local visible = LocalPlayer():IsLineOfSightClear(v2)
-					if mode==OUTLINE_MODE_NOTVISIBLE and visible or mode==OUTLINE_MODE_VISIBLE and !visible then continue end
+					if mode==OUTLINE_MODE_NOTVISIBLE and LocalPlayer():IsLineOfSightClear(v2) or mode==OUTLINE_MODE_VISIBLE and !LocalPlayer():IsLineOfSightClear(v2) then continue end
 					
 					RenderEnt = v2
 					v2:DrawModel()

--- a/garrysmod/lua/send.txt
+++ b/garrysmod/lua/send.txt
@@ -136,6 +136,7 @@ lua\includes\modules\presets.lua
 lua\includes\modules\cookie.lua
 lua\includes\modules\notification.lua
 lua\includes\modules\halo.lua
+lua\includes\modules\outline.lua
 lua\includes\gmsave.lua
 lua\includes\util\model_database.lua
 lua\includes\util\vgui_showlayout.lua


### PR DESCRIPTION
Maybe you know that standard halo system greatly reduces FPS if called many times for example for other colors on entities, because of blur. And halo looks like glow. I make other system with better performance and looks like outline, not like glow (and still greatly visible on big distance).

Some screenshots:
![image](https://user-images.githubusercontent.com/49488893/59933474-da72f080-9449-11e9-8131-19cf74138e5e.png)
![image](https://user-images.githubusercontent.com/49488893/59933491-e1016800-9449-11e9-8017-d8adc73255f7.png)
![image](https://user-images.githubusercontent.com/49488893/59933514-eb236680-9449-11e9-892b-383ab8af723d.png)

I believe 28 fps is gone when drawing models to fill stencil buffer.