### PR TITLE
Added custom PANEL:SetPos(x,y) function

### DIFF
--- a/garrysmod/lua/vgui/dframe.lua
+++ b/garrysmod/lua/vgui/dframe.lua
@@ -194,6 +194,16 @@ function PANEL:Think()
 
 end
 
+function PANEL:SetPos(x,y)
+	if (x > ScrW()-1 or x < -self:GetWide()) or ( y > ScrH()-1 or y < -self:GetTall()) then -- if the screen position happens to be out of bounds when using PANEL:SetPos(x,y) function...
+		self:Close() -- ... close the DFrame ...
+		error("DFrame's position is out of bounds! X:"..x.." Y: "..y, 2) -- ... and throw an error message ...
+	else -- ... otherwise ...
+		self.x = x; -- .. set the x and y position as normal ...
+		self.y = y;
+	end
+end
+
 function PANEL:Paint( w, h )
 
 	if ( self.m_bBackgroundBlur ) then


### PR DESCRIPTION
The PANEL:SetPos(x,y) doesn't check if the DFrame is within screen boundaries by normal means. That was allowing setting position of the DFrame way out of bounds of the screen, making the player unable to close/move the modal window since its title bar was completely unreachable. My version of the function will actually check if the DFrame will be within screen boundaries when using SetPos function. If it isn't, it will close the DFrame, which would be otherwise out of bounds and throw the error showing the destination position of the DFrame in the error message.