### PR TITLE
Remove CanProperty from the base gamemode

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/shared.lua
+++ b/garrysmod/gamemodes/base/gamemode/shared.lua
@@ -264,10 +264,3 @@ function GM:OnViewModelChanged( vm, old, new )
 	end
 
 end
-
---[[---------------------------------------------------------
-	Disable properties serverside for all non-sandbox derived gamemodes.
------------------------------------------------------------]]
-function GM:CanProperty( pl, property, ent )
-	return false
-end


### PR DESCRIPTION
I don't think it belongs there. Why is it there anyways?