### PR TITLE
Remove unused PlayerSpawnTime table from base gamemode

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/init.lua
+++ b/garrysmod/gamemodes/base/gamemode/init.lua
@@ -4,8 +4,6 @@ include( 'player.lua' )
 include( 'npc.lua' )
 include( 'variable_edit.lua' )
 
-GM.PlayerSpawnTime = {}
-
 --[[---------------------------------------------------------
    Name: gamemode:Initialize()
    Desc: Called immediately after starting the gamemode


### PR DESCRIPTION
I couldn't find any references to the `PlayerSpawnTime`. Neither in Base, Sandbox nor TTT.
Also, [GitHub search revealed nothing either](https://github.com/search?l=Lua&q=GM+PlayerSpawnTime&type=Code).