### PR TITLE
Remove unused argument from the PhysgunUnfreeze call

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/player.lua
+++ b/garrysmod/gamemodes/base/gamemode/player.lua
@@ -39,7 +39,7 @@ end
 -----------------------------------------------------------]]
 function GM:OnPhysgunReload( weapon, ply )
 
-	ply:PhysgunUnfreeze( weapon )
+	ply:PhysgunUnfreeze()
 
 end
 


### PR DESCRIPTION
[`Player.PhysgunUnfreeze`](https://wiki.garrysmod.com/page/Player/PhysgunUnfreeze) doesn't take any arguments.