### PR TITLE
Refactor net messaging for PlayerDeath (in base gamemode)

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/cl_deathnotice.lua
+++ b/garrysmod/gamemodes/base/gamemode/cl_deathnotice.lua
@@ -39,38 +39,46 @@ local function PlayerIDOrNameToString( var )
 
 end
 
+local RecvPlayerDeath = {
+	-- PlayerKilled
+	[0] = function()
 
-local function RecvPlayerKilledByPlayer()
+		local victim	= net.ReadEntity()
+		if ( !IsValid( victim ) ) then return end
+		local inflictor	= net.ReadString()
+		local attacker	= "#" .. net.ReadString()
 
-	local victim	= net.ReadEntity()
-	local inflictor	= net.ReadString()
-	local attacker	= net.ReadEntity()
+		GAMEMODE:AddDeathNotice( attacker, -1, inflictor, victim:Name(), victim:Team() )
 
-	if ( !IsValid( attacker ) ) then return end
-	if ( !IsValid( victim ) ) then return end
+	end,
 
-	GAMEMODE:AddDeathNotice( attacker:Name(), attacker:Team(), inflictor, victim:Name(), victim:Team() )
+	-- PlayerKilledSelf
+	[1] = function()
 
-end
-net.Receive( "PlayerKilledByPlayer", RecvPlayerKilledByPlayer )
+		local victim = net.ReadEntity()
+		if ( !IsValid( victim ) ) then return end
+		GAMEMODE:AddDeathNotice( nil, 0, "suicide", victim:Name(), victim:Team() )
 
-local function RecvPlayerKilledSelf()
+	end,
 
-	local victim = net.ReadEntity()
-	if ( !IsValid( victim ) ) then return end
-	GAMEMODE:AddDeathNotice( nil, 0, "suicide", victim:Name(), victim:Team() )
+	-- PlayerKilledByPlayer
+	[2] = function()
 
-end
-net.Receive( "PlayerKilledSelf", RecvPlayerKilledSelf )
+		local victim	= net.ReadEntity()
+		local inflictor	= net.ReadString()
+		local attacker	= net.ReadEntity()
 
+		if ( !IsValid( attacker ) ) then return end
+		if ( !IsValid( victim ) ) then return end
+
+		GAMEMODE:AddDeathNotice( attacker:Name(), attacker:Team(), inflictor, victim:Name(), victim:Team() )
+
+	end
+}
 local function RecvPlayerKilled()
 
-	local victim	= net.ReadEntity()
-	if ( !IsValid( victim ) ) then return end
-	local inflictor	= net.ReadString()
-	local attacker	= "#" .. net.ReadString()
-
-	GAMEMODE:AddDeathNotice( attacker, -1, inflictor, victim:Name(), victim:Team() )
+	local deathType = net.ReadUInt( 2 )
+	RecvPlayerDeath[deathType]()
 
 end
 net.Receive( "PlayerKilled", RecvPlayerKilled )

--- a/garrysmod/gamemodes/base/gamemode/player.lua
+++ b/garrysmod/gamemodes/base/gamemode/player.lua
@@ -140,10 +140,8 @@ function GM:PlayerSilentDeath( Victim )
 
 end
 
--- Pool network strings used for PlayerDeaths.
+-- Pool network string used for PlayerDeath.
 util.AddNetworkString( "PlayerKilled" )
-util.AddNetworkString( "PlayerKilledSelf" )
-util.AddNetworkString( "PlayerKilledByPlayer" )
 
 --[[---------------------------------------------------------
 	Name: gamemode:PlayerDeath()
@@ -177,7 +175,8 @@ function GM:PlayerDeath( ply, inflictor, attacker )
 
 	if ( attacker == ply ) then
 
-		net.Start( "PlayerKilledSelf" )
+		net.Start( "PlayerKilled" )
+			net.WriteUInt( 1, 2 )
 			net.WriteEntity( ply )
 		net.Broadcast()
 
@@ -187,8 +186,9 @@ function GM:PlayerDeath( ply, inflictor, attacker )
 
 	if ( attacker:IsPlayer() ) then
 
-		net.Start( "PlayerKilledByPlayer" )
+		net.Start( "PlayerKilled" )
 
+			net.WriteUInt( 2, 2 )
 			net.WriteEntity( ply )
 			net.WriteString( inflictor:GetClass() )
 			net.WriteEntity( attacker )
@@ -201,6 +201,7 @@ function GM:PlayerDeath( ply, inflictor, attacker )
 
 	net.Start( "PlayerKilled" )
 
+		net.WriteUInt( 0, 2 )
 		net.WriteEntity( ply )
 		net.WriteString( inflictor:GetClass() )
 		net.WriteString( attacker:GetClass() )


### PR DESCRIPTION
Fixes [1407](https://github.com/Facepunch/garrysmod-requests/issues/1407)

Note: This change has a potential of breaking client-side scripts (which rely on these specific net messages; `PlayerKilledSelf` and `PlayerKilledByPlayer`).