### PR TITLE
Removed a similar condition

### DIFF
--- a/garrysmod/lua/vgui/dcheckbox.lua
+++ b/garrysmod/lua/vgui/dcheckbox.lua
@@ -43,7 +43,7 @@ end
 
 function PANEL:Toggle()
 
-	if ( self:GetChecked() == nil || !self:GetChecked() ) then
+	if ( !self:GetChecked() ) then
 		self:SetValue( true )
 	else
 		self:SetValue( false )


### PR DESCRIPTION
I think this is an unnecessary condition, and I not understand what it was for. since !nil = true and !false = true. Also I could not find a comment for what it might be. If I'm wrong, please announce this decision)