### PR TITLE
DLabelEditable:GetDTextEntry()

### DIFF
--- a/garrysmod/lua/vgui/dlabeleditable.lua
+++ b/garrysmod/lua/vgui/dlabeleditable.lua
@@ -4,6 +4,10 @@ local PANEL = {}
 function PANEL:Init()
 end
 
+function PANEL:GetDTextEntry()
+	return self.textbox
+end
+
 function PANEL:SizeToContents()
 
 	local w, h = self:GetContentSize()
@@ -39,6 +43,7 @@ function PANEL:DoDoubleClick()
 	TextEdit:OnGetFocus() -- Because the keyboard input might not be enabled yet! (spawnmenu)
 	TextEdit:SelectAllText( true )
 
+	self.textbox = TextEdit
 end
 
 function PANEL:OnLabelTextChanged( text )


### PR DESCRIPTION
With such function, you can easily edit DTextEntry without calling PANEL:GetChildren() on DLabelEditable and without extracting DTextEntry from children table.