### PR TITLE
Allow numerical indexing of colors

### DIFF
--- a/garrysmod/lua/includes/util/color.lua
+++ b/garrysmod/lua/includes/util/color.lua
@@ -40,9 +40,9 @@ debug.getregistry().Color = COLOR
 -----------------------------------------------------------]]
 function Color( r, g, b, a )
 	return setmetatable( {
-		r = math.max( math.min( tonumber(r), 255 ), 0 ),
-		g = math.max( math.min( tonumber(g), 255 ), 0 ),
-		b = math.max( math.min( tonumber(b), 255 ), 0 ),
+		r = r == nil && 255 || math.max( math.min( tonumber(r), 255 ), 0 ),
+		g = g == nil && 255 || math.max( math.min( tonumber(g), 255 ), 0 ),
+		b = b == nil && 255 || math.max( math.min( tonumber(b), 255 ), 0 ),
 		a = a == nil && 255 || math.max( math.min( tonumber(a), 255 ), 0 )
 	}, COLOR )
 end

--- a/garrysmod/lua/includes/util/color.lua
+++ b/garrysmod/lua/includes/util/color.lua
@@ -1,5 +1,33 @@
 local COLOR = {}
-COLOR.__index = COLOR
+
+local numerical_keys = { [1] = "r", [2] = "g", [3] = "b", [4] = "a" }
+local allowed_keys = { r = true, g = true, b = true, a = true }
+
+COLOR.__index = function( col, k )
+	local comp = numerical_keys[ k ]
+
+	if ( comp ) then
+		return rawget( col, comp )
+	end
+
+	-- If these somehow become unset, don't index the Color metatable
+	if ( allowed_keys[ k ] ) then return nil end
+
+	return COLOR[ k ]
+end
+
+COLOR.__newindex = function( col, k, v )
+	if ( allowed_keys[ k ] ) then
+		-- If a valid component was set to nil, allow setting it back to a number
+		if ( isnumber( v ) ) then
+			rawset( col, k, v )
+		else
+			ErrorNoHaltStack( "attempted to set key \"" .. k .. "\" on Color to " .. type( v ) .. ", number expected", 2 )
+		end
+	else
+		ErrorNoHaltStack( "attempted to alter invalid key \"" .. k .. "\" on Color", 2 )
+	end
+end
 
 --[[---------------------------------------------------------
 	Register our metatable to make it accessible using FindMetaTable
@@ -11,10 +39,12 @@ debug.getregistry().Color = COLOR
 	To easily create a color table
 -----------------------------------------------------------]]
 function Color( r, g, b, a )
-
-	a = a or 255
-	return setmetatable( { r = math.min( tonumber(r), 255 ), g =  math.min( tonumber(g), 255 ), b =  math.min( tonumber(b), 255 ), a =  math.min( tonumber(a), 255 ) }, COLOR )
-	
+	return setmetatable( {
+		r = math.max( math.min( tonumber(r), 255 ), 0 ),
+		g = math.max( math.min( tonumber(g), 255 ), 0 ),
+		b = math.max( math.min( tonumber(b), 255 ), 0 ),
+		a = a == nil && 255 || math.max( math.min( tonumber(a), 255 ), 0 )
+	}, COLOR )
 end
 
 --[[---------------------------------------------------------


### PR DESCRIPTION
- Allows color[i] for indexing elements
- Prevents any keys other than r, g, b, and a from being modified on the color object
- Prevents setting color components to non-numerical types if the key was set to nil prior. This is the best that can be done with type safety in Lua without aliasing the Color object since __newindex isn't called for keys that already exist in the table, and the object can't be aliased without breaking scripts calling ``rawget``/``rawset`` on colors.
- Don't allow negative color components, clamp between [0, 255]
- Make 255 the default for every argument of ``Color``

Relies on https://github.com/Facepunch/garrysmod/pull/1587.