### PR TITLE
chore: optimize primary global lookups

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/base/gamemode/cl_init.lua
@@ -8,6 +8,11 @@ include( "cl_deathnotice.lua" )
 include( "cl_pickteam.lua" )
 include( "cl_voice.lua" )
 
+local IsValid = IsValid
+local LocalPlayer = LocalPlayer
+local player_manager = player_manager
+local drive = drive
+
 --[[---------------------------------------------------------
 	Name: gamemode:Initialize()
 	Desc: Called immediately after starting the gamemode

--- a/garrysmod/lua/derma/derma_gwen.lua
+++ b/garrysmod/lua/derma/derma_gwen.lua
@@ -1,4 +1,4 @@
-
+local surface = surface
 local meta = FindMetaTable( "Panel" )
 
 GWEN = {}

--- a/garrysmod/lua/matproxy/player_weapon_color.lua
+++ b/garrysmod/lua/matproxy/player_weapon_color.lua
@@ -1,3 +1,7 @@
+local CurTime = CurTime
+local IsValid = IsValid
+local isvector = isvector
+local math = math
 
 matproxy.Add( {
 	name = "PlayerWeaponColor",

--- a/garrysmod/lua/matproxy/sky_paint.lua
+++ b/garrysmod/lua/matproxy/sky_paint.lua
@@ -1,4 +1,7 @@
 
+local RealTime = RealTime
+local IsValid = IsValid
+
 matproxy.Add( {
 	name = "SkyPaint",
 
@@ -6,27 +9,27 @@ matproxy.Add( {
 	end,
 
 	bind = function( self, mat, ent )
+		local skyPaint = g_SkyPaint
+		if ( !IsValid( skyPaint ) ) then return end
 
-		if ( !IsValid( g_SkyPaint ) ) then return end
+		mat:SetVector( "$TOPCOLOR",		skyPaint:GetTopColor() )
+		mat:SetVector( "$BOTTOMCOLOR",	skyPaint:GetBottomColor() )
+		mat:SetVector( "$SUNNORMAL",	skyPaint:GetSunNormal() )
+		mat:SetVector( "$SUNCOLOR",		skyPaint:GetSunColor() )
+		mat:SetVector( "$DUSKCOLOR",	skyPaint:GetDuskColor() )
+		mat:SetFloat( "$FADEBIAS",		skyPaint:GetFadeBias() )
+		mat:SetFloat( "$HDRSCALE",		skyPaint:GetHDRScale() )
+		mat:SetFloat( "$DUSKSCALE",		skyPaint:GetDuskScale() )
+		mat:SetFloat( "$DUSKINTENSITY",	skyPaint:GetDuskIntensity() )
+		mat:SetFloat( "$SUNSIZE",		skyPaint:GetSunSize() )
 
-		mat:SetVector( "$TOPCOLOR",		g_SkyPaint:GetTopColor() )
-		mat:SetVector( "$BOTTOMCOLOR",	g_SkyPaint:GetBottomColor() )
-		mat:SetVector( "$SUNNORMAL",	g_SkyPaint:GetSunNormal() )
-		mat:SetVector( "$SUNCOLOR",		g_SkyPaint:GetSunColor() )
-		mat:SetVector( "$DUSKCOLOR",	g_SkyPaint:GetDuskColor() )
-		mat:SetFloat( "$FADEBIAS",		g_SkyPaint:GetFadeBias() )
-		mat:SetFloat( "$HDRSCALE",		g_SkyPaint:GetHDRScale() )
-		mat:SetFloat( "$DUSKSCALE",		g_SkyPaint:GetDuskScale() )
-		mat:SetFloat( "$DUSKINTENSITY",	g_SkyPaint:GetDuskIntensity() )
-		mat:SetFloat( "$SUNSIZE",		g_SkyPaint:GetSunSize() )
+		if ( skyPaint:GetDrawStars() ) then
 
-		if ( g_SkyPaint:GetDrawStars() ) then
-
-			mat:SetInt( "$STARLAYERS",		g_SkyPaint:GetStarLayers() )
-			mat:SetFloat( "$STARSCALE",		g_SkyPaint:GetStarScale() )
-			mat:SetFloat( "$STARFADE",		g_SkyPaint:GetStarFade() )
-			mat:SetFloat( "$STARPOS",		RealTime() * g_SkyPaint:GetStarSpeed() )
-			mat:SetTexture( "$STARTEXTURE",	g_SkyPaint:GetStarTexture() )
+			mat:SetInt( "$STARLAYERS",		skyPaint:GetStarLayers() )
+			mat:SetFloat( "$STARSCALE",		skyPaint:GetStarScale() )
+			mat:SetFloat( "$STARFADE",		skyPaint:GetStarFade() )
+			mat:SetFloat( "$STARPOS",		RealTime() * skyPaint:GetStarSpeed() )
+			mat:SetTexture( "$STARTEXTURE",	skyPaint:GetStarTexture() )
 
 		else
 


### PR DESCRIPTION
I wrote a [tool](https://gist.github.com/SimonSchick/b5d93c622e3c4dced85e2275367bc89a) that was meant to help us find global accesses in our code base and report excessive use.

I ran it against gmod and identified the most common lookups (in sandbox, idle):

```
fnName@file                                         count  count/s   impact
g_SkyPaint@lua/matproxy/sky_paint.lua               18462   6084.3    41.85%
IsValid@gamemodes/base/gamemode/cl_init.lua          7494   2469.7    16.99%
LocalPlayer@gamemodes/base/gamemode/cl_init.lua      3588   1182.5     8.13%
player_manager@gamemodes/base/gamemode/cl_init.lua   1108    365.1     2.51%
IsValid@lua/matproxy/player_weapon_color.lua         1086    357.9     2.46%
RealTime@lua/matproxy/sky_paint.lua                  1086    357.9     2.46%
IsValid@lua/matproxy/sky_paint.lua                   1086    357.9     2.46%
...truncated
```

These changes should effectively reduce global lookups by ~75% in the described scenario.
The overall performance impact is hard to measure so but it should safe amount 0.1-0.5ms per second or so.

In the end this is more of a micro optimisation but I had fun doing it 😄 