### PR TITLE
Kill nonexistent console variable assignments.

### DIFF
--- a/garrysmod/cfg/skill.cfg
+++ b/garrysmod/cfg/skill.cfg
@@ -184,12 +184,6 @@ sk_plr_dmg_grenade			"150"
 sk_npc_dmg_grenade			"75"
 sk_max_grenade				"5"
 
-sk_plr_dmg_crowbar			"10"
-sk_npc_dmg_crowbar			"5"
-
-sk_plr_dmg_stunstick		"10"
-sk_npc_dmg_stunstick		"40"	// Kill a citizen in one hit
-
 //sk_plr_dmg_satchel			"150"
 //sk_npc_dmg_satchel			"75"
 //sk_satchel_radius			"150"


### PR DESCRIPTION
Those appear to not exist in Garry's Mod, neither in the client not in a server.