### PR TITLE
Added: Support for reversing a integer indexed table including holes

### DIFF
--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -702,10 +702,11 @@ end
 --[[---------------------------------------------------------
 	Name: ReverseHole( t )
 	Desc: Reverses the table even if there are holes in it
+	      You can also provide a second argument as forced table length
 -----------------------------------------------------------]]
 function table.ReverseHole( t )
 	
-	local nN = table.maxn( t ) 
+	local nN = tonumber( n ) or table.maxn( t ) 
 	
 	for iD = 1, math.floor( nN / 2 ) do
 		local iK = ( nN + 1 - iD )

--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -699,7 +699,6 @@ function table.GetKeys( tab )
 
 end
 
-
 --[[---------------------------------------------------------
 	Name: ReverseHole( t )
 	Desc: Reverses the table even if there are holes in it

--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -698,3 +698,21 @@ function table.GetKeys( tab )
 	return keys
 
 end
+
+
+--[[---------------------------------------------------------
+	Name: ReverseHole( t )
+	Desc: Reverses the table even if there are holes in it
+-----------------------------------------------------------]]
+function table.ReverseHole( t )
+	
+	local nN = table.maxn( t ) 
+	
+	for iD = 1, math.floor( nN / 2 ) do
+		local iK = ( nN + 1 - iD )
+		t[ iD ], t[ iK ] = t[ iK ], t[ iD ]
+	end
+	
+	return nN
+	
+end


### PR DESCRIPTION
This will reverse a table if there are holes inside. It is not designed to replace `table.Reverse` in any way, but to add support for tables with vacant slots. Considering the following example:
```lua
BEFORE = {}
BEFORE[1] = 1
BEFORE[2] = 2
BEFORE[3] = 3
BEFORE[10] = 10
AFTER = {}
AFTER[1] = 10
AFTER[8] = 3
AFTER[9] = 2
AFTER[10] = 1
```