### PR TITLE
Optimized player.GetBy* functions in player.lua

### DIFF
--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -44,7 +44,7 @@ end
 -- These are totally in the wrong place.
 function player.GetByAccountID(ID)
 	local players = player.GetAll()
-	for i = 1, player.GetCount() do
+	for i = 1, #players do
 		if players[i]:AccountID() == ID then
 			return players[i]
 		end
@@ -54,7 +54,7 @@ end
 
 function player.GetByUniqueID(ID)
 	local players = player.GetAll()
-	for i = 1, player.GetCount() do
+	for i = 1, #players do
 		if players[i]:UniqueID() == ID then
 			return players[i]
 		end
@@ -65,7 +65,7 @@ end
 function player.GetBySteamID(ID)
 	ID = string.upper(ID)
 	local players = player.GetAll()
-	for i = 1, player.GetCount() do
+	for i = 1, #players do
 		if players[i]:SteamID() == ID then
 			return players[i]
 		end
@@ -76,7 +76,7 @@ end
 function player.GetBySteamID64(ID)
 	ID = tostring(ID)
 	local players = player.GetAll()
-	for i = 1, player.GetCount() do
+	for i = 1, #players do
 		if players[i]:SteamID64() == ID then
 			return players[i]
 		end

--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -42,45 +42,49 @@ if ( !sql.TableExists( "playerpdata" ) ) then
 end
 
 -- These are totally in the wrong place.
-function player.GetByAccountID(ID)
+function player.GetByAccountID( ID )
 	local players = player.GetAll()
 	for i = 1, #players do
-		if players[i]:AccountID() == ID then
+		if ( players[i]:AccountID() == ID ) then
 			return players[i]
 		end
 	end
+	
 	return false
 end
 
-function player.GetByUniqueID(ID)
+function player.GetByUniqueID( ID )
 	local players = player.GetAll()
 	for i = 1, #players do
-		if players[i]:UniqueID() == ID then
+		if ( players[i]:UniqueID() == ID ) then
 			return players[i]
 		end
 	end
+	
 	return false
 end
 
-function player.GetBySteamID(ID)
-	ID = string.upper(ID)
+function player.GetBySteamID( ID )
+	ID = string.upper( ID )
 	local players = player.GetAll()
 	for i = 1, #players do
-		if players[i]:SteamID() == ID then
+		if ( players[i]:SteamID() == ID ) then
 			return players[i]
 		end
 	end
+	
 	return false
 end
 
-function player.GetBySteamID64(ID)
-	ID = tostring(ID)
+function player.GetBySteamID64( ID )
+	ID = tostring( ID )
 	local players = player.GetAll()
 	for i = 1, #players do
-		if players[i]:SteamID64() == ID then
+		if ( players[i]:SteamID64() == ID ) then
 			return players[i]
 		end
 	end
+	
 	return false
 end
 

--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -42,64 +42,46 @@ if ( !sql.TableExists( "playerpdata" ) ) then
 end
 
 -- These are totally in the wrong place.
-function player.GetByAccountID( ID )
-
-	for _, pl in pairs( player.GetAll() ) do
-
-		if ( pl:AccountID() == ID ) then
-			return pl
+function player.GetByAccountID(ID)
+	local players = player.GetAll()
+	for i = 1, player.GetCount() do
+		if players[i]:AccountID() == ID then
+			return players[i]
 		end
-
 	end
-
 	return false
-
 end
 
-function player.GetByUniqueID( ID )
-
-	for _, pl in pairs( player.GetAll() ) do
-
-		if ( pl:UniqueID() == ID ) then
-			return pl
+function player.GetByUniqueID(ID)
+	local players = player.GetAll()
+	for i = 1, player.GetCount() do
+		if players[i]:UniqueID() == ID then
+			return players[i]
 		end
-
 	end
-
 	return false
-
 end
 
-function player.GetBySteamID( ID )
-
-	ID = string.upper( ID )
-
-	for _, pl in pairs( player.GetAll() ) do
-
-		if ( pl:SteamID() == ID ) then
-			return pl
+function player.GetBySteamID(ID)
+	ID = string.upper(ID)
+	local players = player.GetAll()
+	for i = 1, player.GetCount() do
+		if players[i]:SteamID() == ID then
+			return players[i]
 		end
-
 	end
-
 	return false
-
 end
 
-function player.GetBySteamID64( ID )
-
-	ID = tostring( ID )
-
-	for _, pl in pairs( player.GetAll() ) do
-
-		if ( pl:SteamID64() == ID ) then
-			return pl
+function player.GetBySteamID64(ID)
+	ID = tostring(ID)
+	local players = player.GetAll()
+	for i = 1, player.GetCount() do
+		if players[i]:SteamID64() == ID then
+			return players[i]
 		end
-
 	end
-
 	return false
-
 end
 
 --[[---------------------------------------------------------


### PR DESCRIPTION
Optimized player.GetBy* functions. Replaced _pairs_ with numerical _for_ loop, because using _pairs_ to iterate over a numerically indexed table is inefficient.