### PR TITLE
Remove wepswitch command

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
@@ -175,24 +175,6 @@ function GM:UpdatePlayerLoadouts()
    end
 end
 
----- Weapon switching
-local function ForceWeaponSwitch(ply, cmd, args)
-   if not ply:IsPlayer() or not args[1] then return end
-   -- Turns out even SelectWeapon refuses to switch to empty guns, gah.
-   -- Worked around it by giving every weapon a single Clip2 round.
-   -- Works because no weapon uses those.
-   local wepname = args[1]
-   local wep = ply:GetWeapon(wepname)
-   if IsValid(wep) then
-      -- Weapons apparently not guaranteed to have this
-      if wep.SetClip2 then
-         wep:SetClip2(1)
-      end
-      ply:SelectWeapon(wepname)
-   end
-end
-concommand.Add("wepswitch", ForceWeaponSwitch)
-
 ---- Weapon dropping
 
 function WEPS.DropNotifiedWeapon(ply, wep, death_drop)


### PR DESCRIPTION
"+attack;wepswtich weapon_ttt_deagle;-attack" will let you shoot but wont play the sound of the original weapon or consume ammo, there's no need for this command since its not been used after #1388