### PR TITLE
Fix sorting of bodygroups and skins in spawn icon editor

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/gui/iconeditor.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/gui/iconeditor.lua
@@ -467,6 +467,7 @@ function PANEL:FillAnimations( ent )
 
 		local combo = self.BodyList:Add( "DComboBox" )
 		combo:Dock( TOP )
+		combo:SetSortItems( false )
 		combo:DockMargin( 0, 0, 0, 3 )
 		newItems = newItems + 1
 
@@ -499,6 +500,7 @@ function PANEL:FillAnimations( ent )
 
 		local combo = self.BodyList:Add( "DComboBox" )
 		combo:Dock( TOP )
+		combo:SetSortItems( false )
 		combo:DockMargin( 0, 0, 0, 3 )
 		newItems = newItems + 1
 


### PR DESCRIPTION
Previously the DComboBox in this GUI would sort the items alphabetically, despite the items already being in order, resulting in an order like this:

```
Skin 0, Skin 1, Skin 10, Skin 11, ...
```

 `DComboBox:SetSortItems(false)` fixes this.