### PR TITLE
Add DButton:SetColorIcon()

### DIFF
--- a/garrysmod/lua/vgui/dbutton.lua
+++ b/garrysmod/lua/vgui/dbutton.lua
@@ -51,6 +51,42 @@ function PANEL:SetImage( img )
 end
 PANEL.SetIcon = PANEL.SetImage
 
+local function ColorIconPaint( self, w, h )
+
+	surface.SetDrawColor( self.m_ColorIcon )
+	surface.DrawRect( 0, 0, w, h )
+
+end
+
+function PANEL:SetColorIcon( color )
+
+	if ( !color ) then
+
+		self.m_ColorIcon = nil
+
+		self:SetImage()
+
+	else
+
+		assert( IsColor( color ), "Expected a color but " .. type(color) .. " was passed" )
+
+		self:SetImage( "icon16/box.png" )
+
+		self.m_Image.m_ColorIcon = self.m_ColorIcon
+		self.m_ColorIcon = self.m_Image.m_ColorIcon
+		
+		self.m_Image.Paint = ColorIconPaint
+
+	end
+
+end
+
+function PANEL:GetColorIcon()
+
+	return self.m_ColorIcon
+
+end
+
 function PANEL:Paint( w, h )
 
 	derma.SkinHook( "Paint", "Button", self, w, h )


### PR DESCRIPTION
This is hacky as fuck and I hate it, but it should mean that it's quite smoothly backwards compatible (as it just kind of piggybacks off the behaviour of `DButton:SetImage()`)

Here's the cool thing you can do with it:

![image](https://user-images.githubusercontent.com/14863743/75385860-85408600-58d8-11ea-82d0-d72c881414de.png)