### PR TITLE
Replace UniqueID() with SteamID()

### DIFF
--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -176,7 +176,7 @@ end
 -----------------------------------------------------------]]
 function meta:GetPData( name, default )
 
-	name = Format( "%s[%s]", self:UniqueID(), name )
+	name = Format( "%s[%s]", self:SteamID(), name )
 	local val = sql.QueryValue( "SELECT value FROM playerpdata WHERE infoid = " .. SQLStr( name ) .. " LIMIT 1" )
 	if ( val == nil ) then return default end
 
@@ -190,7 +190,7 @@ end
 -----------------------------------------------------------]]
 function meta:SetPData( name, value )
 
-	name = Format( "%s[%s]", self:UniqueID(), name )
+	name = Format( "%s[%s]", self:SteamID(), name )
 	return sql.Query( "REPLACE INTO playerpdata ( infoid, value ) VALUES ( " .. SQLStr( name ) .. ", " .. SQLStr( value ) .. " )" ) ~= false
 
 end
@@ -201,7 +201,7 @@ end
 -----------------------------------------------------------]]
 function meta:RemovePData( name )
 
-	name = Format( "%s[%s]", self:UniqueID(), name )
+	name = Format( "%s[%s]", self:SteamID(), name )
 	return sql.Query( "DELETE FROM playerpdata WHERE infoid = " .. SQLStr( name ) ) ~= false
 
 end


### PR DESCRIPTION
Makes it so the PData section wont have any collisions like UniqueID() caused.