### PR TITLE
Fix error when gamemode has no valid settings

### DIFF
--- a/garrysmod/lua/menu/mainmenu.lua
+++ b/garrysmod/lua/menu/mainmenu.lua
@@ -178,7 +178,7 @@ function UpdateServerSettings()
 
 		local Settings = util.KeyValuesToTable( settings_file )
 
-		if ( Settings.settings ) then
+		if ( istable( Settings.settings ) ) then
 
 			array.settings = Settings.settings
 


### PR DESCRIPTION
Some gamemodes simply do not have a configuration and leave a blank string, and when you have it set and try to enter in any server, the following error is thrown:

> [MENU ERROR] lua/menu/mainmenu.lua:185: bad argument # 1 to 'pairs' (table expected, got string)

An example gamemode is [The Hidden](https://steamcommunity.com/sharedfiles/filedetails/?id=443458575).