### PR TITLE
Fix GetEyeTraceNoCursor caching

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/obj_player_extend.lua
+++ b/garrysmod/gamemodes/base/gamemode/obj_player_extend.lua
@@ -172,13 +172,13 @@ end
 --[[---------------------------------------------------------
 	Player Eye Trace
 -----------------------------------------------------------]]
-function meta:GetEyeTrace( skipcache )
+function meta:GetEyeTrace()
 	if ( CLIENT ) then
 		local framenum = FrameNumber()
 
 		-- Cache the trace results for the current frame, unless we're serverside
 		-- in which case it wouldn't play well with lag compensation at all
-		if ( !skipcache && self.LastPlayerTrace == framenum && istable( self.PlayerTrace ) ) then
+		if ( self.LastPlayerTrace == framenum ) then
 			return self.PlayerTrace
 		end
 
@@ -195,11 +195,11 @@ end
 	GetEyeTraceIgnoreCursor
 	Like GetEyeTrace but doesn't use the cursor aim vector..
 -----------------------------------------------------------]]
-function meta:GetEyeTraceNoCursor( skipcache )
+function meta:GetEyeTraceNoCursor()
 	if ( CLIENT ) then
 		local framenum = FrameNumber()
 
-		if ( !skipcache && self.LastPlayerAimTrace == framenum && istable( self.PlayerAimTrace ) ) then
+		if ( self.LastPlayerAimTrace == framenum ) then
 			return self.PlayerAimTrace
 		end
 

--- a/garrysmod/gamemodes/base/gamemode/obj_player_extend.lua
+++ b/garrysmod/gamemodes/base/gamemode/obj_player_extend.lua
@@ -173,13 +173,12 @@ end
 	Player Eye Trace
 -----------------------------------------------------------]]
 function meta:GetEyeTrace( skipcache )
-
 	if ( CLIENT ) then
 		local framenum = FrameNumber()
 
 		-- Cache the trace results for the current frame, unless we're serverside
 		-- in which case it wouldn't play well with lag compensation at all
-		if ( not skipcache and self.LastPlayerTrace == framenum and istable( self.PlayerTrace ) ) then
+		if ( !skipcache && self.LastPlayerTrace == framenum && istable( self.PlayerTrace ) ) then
 			return self.PlayerTrace
 		end
 
@@ -190,7 +189,6 @@ function meta:GetEyeTrace( skipcache )
 	self.PlayerTrace = tr
 
 	return tr
-
 end
 
 --[[---------------------------------------------------------
@@ -198,11 +196,10 @@ end
 	Like GetEyeTrace but doesn't use the cursor aim vector..
 -----------------------------------------------------------]]
 function meta:GetEyeTraceNoCursor( skipcache )
-
 	if ( CLIENT ) then
 		local framenum = FrameNumber()
 
-		if ( not skipcache and self.LastPlayerAimTrace == framenum and istable( self.PlayerAimTrace ) ) then
+		if ( !skipcache && self.LastPlayerAimTrace == framenum && istable( self.PlayerAimTrace ) ) then
 			return self.PlayerAimTrace
 		end
 
@@ -213,5 +210,4 @@ function meta:GetEyeTraceNoCursor( skipcache )
 	self.PlayerAimTrace = tr
 
 	return tr
-
 end

--- a/garrysmod/gamemodes/base/gamemode/obj_player_extend.lua
+++ b/garrysmod/gamemodes/base/gamemode/obj_player_extend.lua
@@ -172,18 +172,18 @@ end
 --[[---------------------------------------------------------
 	Player Eye Trace
 -----------------------------------------------------------]]
-function meta:GetEyeTrace()
+function meta:GetEyeTrace( skipcache )
 
 	if ( CLIENT ) then
-		local curtime = CurTime()
+		local framenum = FrameNumber()
 
 		-- Cache the trace results for the current frame, unless we're serverside
 		-- in which case it wouldn't play well with lag compensation at all
-		if ( self.LastPlayerTrace == curtime ) then
+		if ( not skipcache and self.LastPlayerTrace == framenum and istable( self.PlayerTrace ) ) then
 			return self.PlayerTrace
 		end
 
-		self.LastPlayerTrace = curtime
+		self.LastPlayerTrace = framenum
 	end
 
 	local tr = util.TraceLine( util.GetPlayerTrace( self ) )
@@ -197,16 +197,16 @@ end
 	GetEyeTraceIgnoreCursor
 	Like GetEyeTrace but doesn't use the cursor aim vector..
 -----------------------------------------------------------]]
-function meta:GetEyeTraceNoCursor()
+function meta:GetEyeTraceNoCursor( skipcache )
 
 	if ( CLIENT ) then
-		local curtime = CurTime()
+		local framenum = FrameNumber()
 
-		if ( self.LastPlayerAimTrace == curtime ) then
+		if ( not skipcache and self.LastPlayerAimTrace == framenum and istable( self.PlayerAimTrace ) ) then
 			return self.PlayerAimTrace
 		end
 
-		self.LastPlayertAimTrace = curtime
+		self.LastPlayerAimTrace = framenum
 	end
 
 	local tr = util.TraceLine( util.GetPlayerTrace( self, self:EyeAngles():Forward() ) )


### PR DESCRIPTION
Fixes https://github.com/Facepunch/garrysmod-issues/issues/4430.

Also use FrameNumber instead of CurTime for caching so that it doesn't clash with prediction.