### PR TITLE
[TTT] Fix GetEyeTrace override

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -132,18 +132,26 @@ end
 -- like GetEyeTraceNoCursor but who wants to type that all the time, and we
 -- never use cursor tracing anyway.
 function plymeta:GetEyeTrace(mask)
-   if self.LastPlayerTraceMask == mask and self.LastPlayerTrace == CurTime() then
-      return self.PlayerTrace
+   mask = mask or MASK_SOLID
+
+   if CLIENT then
+      local framenum = FrameNumber()
+      
+      if self.LastPlayerTrace == framenum and self.LastPlayerTraceMask == mask then
+         return self.PlayerTrace
+      end
+
+      self.LastPlayerTrace = framenum
+      self.LastPlayerTraceMask = mask
    end
 
    local tr = util.GetPlayerTrace(self)
    tr.mask = mask
 
-   self.PlayerTrace = util.TraceLine(tr)
-   self.LastPlayerTrace = CurTime()
-   self.LastPlayerTraceMask = mask
+   tr = util.TraceLine(tr)
+   self.PlayerTrace = tr
 
-   return self.PlayerTrace
+   return tr
 end
 
 


### PR DESCRIPTION
- Only do caching clientside so that it allows lag compensation to retrace
- Use FrameNumber instead of CurTime so that it doesn't clash with prediction
- Default to MASK_SOLID as the trace does internally