### PR TITLE
[TTT] Remove GetWeapons and HasWeapon overrides

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -106,28 +106,6 @@ function plymeta:HasEquipment()
    return self:HasEquipmentItem() or self:HasEquipmentWeapon()
 end
 
-if CLIENT then
-   -- Server has this, but isn't shared for some reason
-   function plymeta:HasWeapon(cls)
-      for _, wep in ipairs(self:GetWeapons()) do
-         if IsValid(wep) and wep:GetClass() == cls then
-            return true
-         end
-      end
-
-      return false
-   end
-   local ply = LocalPlayer
-   local gmod_GetWeapons = plymeta.GetWeapons
-   function plymeta:GetWeapons()
-      if self != ply() then
-         return {}
-      else
-         return gmod_GetWeapons(self)
-      end
-   end
-end
-
 -- Override GetEyeTrace for an optional trace mask param. Technically traces
 -- like GetEyeTraceNoCursor but who wants to type that all the time, and we
 -- never use cursor tracing anyway.


### PR DESCRIPTION
GetWeapons: altering the function to return nothing for other players isn't safe as if a player already has clientside Lua access, they can just use debug.getupvalue to get the original version. If not for that, they could also still use GetActiveWeapon, HasWeapon, and the savetable to check for another player's weapons.

HasWeapon: it's shared in the base game now.