### PR TITLE
net.WriteArray and net.ReadArray

### DIFF
--- a/garrysmod/lua/includes/extensions/net.lua
+++ b/garrysmod/lua/includes/extensions/net.lua
@@ -127,6 +127,34 @@ function net.ReadTable()
 
 end
 
+function net.WriteArray(tab)
+
+	for k, v in ipairs(tab) do
+
+		net.WriteType(v)
+
+	end
+
+	-- End of table
+	net.WriteType(nil)
+
+end
+
+function net.ReadArray()
+
+	local tab, n = {}, 1
+
+	while true do
+
+		local v = net.ReadType()
+		if (v == nil) then return tab end
+
+		tab[n] = v
+		n = n + 1
+
+	end
+end
+
 net.WriteVars = 
 {
 	[TYPE_NIL]			= function ( t, v )	net.WriteUInt( t, 8 )								end,


### PR DESCRIPTION
These functions help to reduce the net cost for arrays.

Writing arrays by net.WriteTable costs `(8 + 64 + 8 + v)` per value. Which is `(80 + v)` per value. Where `v` is the value's cost.

Writing arrays by net.WriteArray costs `(8 + v)` per value. This is 72 bits less.

The reason why net.ReadArray uses `tab[n] = v; n = n + 1` because external counter is faster than `tab[#tab + 1] = v`