### PR TITLE
Dtree node - self.Expanded validity check

### DIFF
--- a/garrysmod/lua/vgui/dtree_node.lua
+++ b/garrysmod/lua/vgui/dtree_node.lua
@@ -234,9 +234,9 @@ end
 
 function PANEL:PerformRootNodeLayout()
 
-	self.Expander:SetVisible( false )
-	self.Label:SetVisible( false )
-	self.Icon:SetVisible( false )
+	if ( IsValid(self.Expander) ) then self.Expander:SetVisible( false ) end
+	if ( IsValid(self.Label) ) then self.Label:SetVisible( false ) end
+	if ( IsValid(self.Icon) ) then self.Icon:SetVisible( false ) end
 
 	if ( IsValid( self.ChildNodes ) ) then
 


### PR DESCRIPTION
In my gamemode I edited the default spawnmenu. I derived the gamemode from Sandbox and deleted some `Panels` at start. I got an error telling me that `:SetVisible ` could not be used on a nil value. `self.Expanded` was nil. This pull request removed that error for me.