### PR TITLE
Create ping categories to reduce impact of miniscule ping differences

### DIFF
--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -262,7 +262,9 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 
 	data.hasmap = DoWeHaveMap( data.map );
 
-	data.recommended = data.ping;
+	data.recommended = 40;
+	if(data.ping >= 60) data.recommended = data.ping - (data.ping % 50)
+	
 	if ( data.players == 0 ) data.recommended += 75; // Server is empty
 	if ( data.players >= data.maxplayers ) data.recommended += 100; // Server is full, can't join it
 	if ( data.pass ) data.recommended += 300; // Password protected, can't join it

--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -263,7 +263,7 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 	data.hasmap = DoWeHaveMap( data.map );
 
 	data.recommended = 40;
-	if(data.ping >= 60) data.recommended = data.ping - (data.ping % 50)
+	if(data.ping >= 60) data.recommended = data.ping;
 	
 	if ( data.players == 0 ) data.recommended += 75; // Server is empty
 	if ( data.players >= data.maxplayers ) data.recommended += 100; // Server is full, can't join it


### PR DESCRIPTION
Tl;dr:
If this gets added anycast is much less of an advantage.

Long desc:
If there's a miniscule ping difference in the lower bound then it should not make a difference.

I propose this change to make the serverlist a fairer place to everyone, since some serverhosts spoof to get super low pings which are only 10 to 20 lower than the other servers actually within that region. It gives them a ranking advantage which you can not get with real servers. This counters that.

Meanwhile gameplay wise for the players there's basically no difference.