### PR TITLE
Add duplicator.Disallow

### DIFF
--- a/garrysmod/lua/includes/modules/duplicator.lua
+++ b/garrysmod/lua/includes/modules/duplicator.lua
@@ -304,6 +304,15 @@ function Allow( classname )
 end
 
 --
+-- Disallow this entity to be duplicated
+--
+function Disallow( classname )
+
+	DuplicateAllowed[ classname ] = false
+
+end
+
+--
 -- Returns true if we can copy/paste this entity
 --
 function IsAllowed( classname )


### PR DESCRIPTION
Mainly this is because I want to be able to duplicate doors in code without letting players do it, but I'm sure there are other uses around blocking entities introduced by workshop addons.

Usage:
```lua
duplicator.Allow( "prop_door_rotating" )
local tab = duplicator.CopyEnts( Ents )
duplicator.Disallow( "prop_door_rotating" )
```