### PR TITLE
[TTT] Update CLSCORE

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -64,16 +64,16 @@ function CLSCORE.DeclareEventDisplay(event_id, event_fns)
    -- basic input vetting, can't check returned value types because the
    -- functions may be impure
    if not tonumber(event_id) then
-      error("Event ??? display: invalid event id")
+      error("Event ??? display: invalid event id", 2)
    end
    if (not event_fns) or not istable(event_fns) then
-      error(string.format("Event %d display: no display functions found.", event_id))
+      error(string.format("Event %d display: no display functions found.", event_id), 2)
    end
    if not event_fns.text then
-      error(string.format("Event %d display: no text display function found.", event_id))
+      error(string.format("Event %d display: no text display function found.", event_id), 2)
    end
    if not event_fns.icon then
-      error(string.format("Event %d display: no icon and tooltip display function found.", event_id))
+      error(string.format("Event %d display: no icon and tooltip display function found.", event_id), 2)
    end
 
    CLSCORE.EventDisplay[event_id] = event_fns

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -20,10 +20,13 @@ CLSCORE.EventDisplay = {}
 
 local skull_icon = Material("HUD/killicons/default")
 
-surface.CreateFont("WinHuge", {font = "Trebuchet24",
-                               size = 72,
-                               weight = 1000,
-                               shadow = true})
+surface.CreateFont("WinHuge", {
+   font = "Trebuchet24",
+   size = 72,
+   weight = 1000,
+   shadow = true,
+   extended = true
+})
 
 -- so much text here I'm using shorter names than usual
 local T = LANG.GetTranslation
@@ -61,25 +64,26 @@ function CLSCORE.DeclareEventDisplay(event_id, event_fns)
    -- basic input vetting, can't check returned value types because the
    -- functions may be impure
    if not tonumber(event_id) then
-      Error("Event ??? display: invalid event id\n")
+      error("Event ??? display: invalid event id")
    end
    if (not event_fns) or not istable(event_fns) then
-      Error(Format("Event %d display: no display functions found.\n", event_id))
+      error(string.format("Event %d display: no display functions found.", event_id))
    end
    if not event_fns.text then
-      Error(Format("Event %d display: no text display function found.\n", event_id))
+      error(string.format("Event %d display: no text display function found.", event_id))
    end
    if not event_fns.icon then
-      Error(Format("Event %d display: no icon and tooltip display function found.\n", event_id))
+      error(string.format("Event %d display: no icon and tooltip display function found.", event_id))
    end
 
    CLSCORE.EventDisplay[event_id] = event_fns
 end
 
 function CLSCORE:FillDList(dlst)
+   local events = self.Events
 
-   for k, e in pairs(self.Events) do
-
+   for i = 1, #events do
+      local e = events[i]
       local etxt = self:TextForEvent(e)
       local eicon, ttip = self:IconForEvent(e)
       local etime = self:TimeForEvent(e)
@@ -93,7 +97,6 @@ function CLSCORE:FillDList(dlst)
             eicon:SetKeepAspect(true)
             eicon:SizeToContents()
          end
-
 
          dlst:AddLine(etime, eicon, "  " .. etxt)
       end
@@ -127,6 +130,19 @@ function CLSCORE:BuildEventLogPanel(dpanel)
    self:FillDList(dlist)
 end
 
+CLSCORE.ScorePanelNames = {
+   "",
+   "col_player",
+   "col_role",
+   "col_kills1",
+   "col_kills2",
+   "col_points",
+   "col_team",
+   "col_total"
+}
+
+CLSCORE.ScorePanelColor = Color(150, 50, 50)
+
 function CLSCORE:BuildScorePanel(dpanel)
    local margin = 10
    local w, h = dpanel:GetSize()
@@ -137,20 +153,27 @@ function CLSCORE:BuildScorePanel(dpanel)
    dlist:SetSortable(true)
    dlist:SetMultiSelect(false)
 
-   local colnames = {"", "col_player", "col_role", "col_kills1", "col_kills2", "col_points", "col_team", "col_total"}
-   for k, name in pairs(colnames) do
-      if name == "" then
-         -- skull icon column
-         local c = dlist:AddColumn("")
-         c:SetFixedWidth(18)
-      else
-         dlist:AddColumn(T(name))
+   local scorenames = self.ScorePanelNames
+
+   for i = 1, #scorenames do
+      local name = scorenames[i]
+	  
+      if isstring(name) then
+         if name == "" then
+            -- skull icon column
+            local c = dlist:AddColumn("")
+            c:SetFixedWidth(18)
+         else
+            dlist:AddColumn(T(name))
+         end
       end
    end
 
    -- the type of win condition triggered is relevant for team bonus
    local wintype = WIN_NONE
-   for i=#self.Events, 1, -1 do
+   local events = self.Events
+
+   for i = #events, 1, -1 do
       local e = self.Events[i]
       if e.id == EVENT_FINISH then
          wintype = e.win
@@ -170,7 +193,7 @@ function CLSCORE:BuildScorePanel(dpanel)
          local surv = ""
          if s.deaths > 0 then
             surv = vgui.Create("ColoredBox", dlist)
-            surv:SetColor(Color(150, 50, 50))
+            surv:SetColor(self.ScorePanelColor)
             surv:SetBorder(false)
             surv:SetSize(18,18)
 
@@ -196,7 +219,7 @@ function CLSCORE:BuildScorePanel(dpanel)
          -- because images can't be sorted, so instead hack in a dummy value
          local surv_col = l.Columns[1]
          if surv_col then
-            surv_col.Value = type(surv_col.Value) == "Panel" and "1" or "0"
+            surv_col.Value = TypeID(surv_col.Value) == TYPE_PANEL and "1" or "0"
          end
       end
    end
@@ -242,56 +265,54 @@ end
 
 -- double check that we have no nils
 local function ValidAward(a)
-   return a and a.nick and a.text and a.title and a.priority
+   return istable(a) and isstring(a.nick) and isstring(a.text) and isstring(a.title) and isnumber(a.priority)
 end
 
-local wintitle = {
-   [WIN_TRAITOR] = {txt = "hilite_win_traitors", c = Color(190, 5, 5, 255)},
-   [WIN_INNOCENT] = {txt = "hilite_win_innocent", c = Color(5, 190, 5, 255)}
+CLSCORE.WinTypes = {
+   [WIN_INNOCENT] = {
+      Text = "hilite_win_innocent",
+      BoxColor = Color(5, 190, 5, 255),
+      TextColor = COLOR_WHITE,
+      BackgroundColor = Color(50, 50, 50, 255)
+   },
+   [WIN_TRAITOR] = {
+      Text = "hilite_win_traitors",
+      BoxColor = Color(190, 5, 5, 255),
+      TextColor = COLOR_WHITE,
+      BackgroundColor = Color(50, 50, 50, 255)
+   }
 }
 
-function CLSCORE:BuildHilitePanel(dpanel)
+-- when win is due to timeout, innocents win
+CLSCORE.WinTypes[WIN_TIMELIMIT] = CLSCORE.WinTypes[WIN_INNOCENT]
+
+-- The default wintype if no EVENT_FINISH is specified
+CLSCORE.WinTypes.Default = CLSCORE.WinTypes[WIN_INNOCENT]
+
+function CLSCORE:BuildHilitePanel(dpanel, title, starttime, endtime)
    local w, h = dpanel:GetSize()
-
-   local title = wintitle[WIN_INNOCENT]
-   local endtime = self.StartTime
-   for i=#self.Events, 1, -1 do
-      local e = self.Events[i]
-      if e.id == EVENT_FINISH then
-         endtime = e.t
-
-         -- when win is due to timeout, innocents win
-         local wintype = e.win
-         if wintype == WIN_TIMELIMIT then wintype = WIN_INNOCENT end
-
-         title = wintitle[wintype]
-         break
-      end
-   end
-
-   local roundtime = endtime - self.StartTime
 
    local numply = table.Count(self.Players)
    local numtr = table.Count(self.TraitorIDs)
 
 
    local bg = vgui.Create("ColoredBox", dpanel)
-   bg:SetColor(Color(50, 50, 50, 255))
+   bg:SetColor(title.BackgroundColor or self.WinTypes.Default.BackgroundColor)
    bg:SetSize(w,h)
    bg:SetPos(0,0)
 
    local winlbl = vgui.Create("DLabel", dpanel)
    winlbl:SetFont("WinHuge")
-   winlbl:SetText( T(title.txt) )
-   winlbl:SetTextColor(COLOR_WHITE)
+   winlbl:SetText( T(title.Text or self.WinTypes.Default.Text) )
+   winlbl:SetTextColor(title.TextColor or self.WinTypes.Default.TextColor)
    winlbl:SizeToContents()
    local xwin = (w - winlbl:GetWide())/2
    local ywin = 30
    winlbl:SetPos(xwin, ywin)
 
    bg.PaintOver = function()
-                     draw.RoundedBox(8, xwin - 15, ywin - 5, winlbl:GetWide() + 30, winlbl:GetTall() + 10, title.c)
-                  end
+      draw.RoundedBox(8, xwin - 15, ywin - 5, winlbl:GetWide() + 30, winlbl:GetTall() + 10, title.BoxColor or self.WinTypes.Default.BoxColor)
+   end
 
    local ysubwin = ywin + winlbl:GetTall()
    local partlbl = vgui.Create("DLabel", dpanel)
@@ -304,7 +325,7 @@ function CLSCORE:BuildHilitePanel(dpanel)
    partlbl:SetPos(xwin, ysubwin + 8)
 
    local timelbl = vgui.Create("DLabel", dpanel)
-   timelbl:SetText(PT("hilite_duration", {time= util.SimpleTime(roundtime, "%02i:%02i")}))
+   timelbl:SetText(PT("hilite_duration", {time= util.SimpleTime(endtime - starttime, "%02i:%02i")}))
    timelbl:SizeToContents()
    timelbl:SetPos(xwin + winlbl:GetWide() - timelbl:GetWide(), ysubwin + 8)
 
@@ -322,7 +343,7 @@ function CLSCORE:BuildHilitePanel(dpanel)
    -- Before we pick awards, seed the rng in a way that is the same on all
    -- clients. We can do this using the round start time. To make it a bit more
    -- random, involve the round's duration too.
-   math.randomseed(self.StartTime + endtime)
+   math.randomseed(starttime + endtime)
 
    -- Attempt to generate every award, then sort the succeeded ones based on
    -- priority/interestingness
@@ -350,11 +371,40 @@ function CLSCORE:BuildHilitePanel(dpanel)
 end
 
 function CLSCORE:ShowPanel()
+   if IsValid(self.Panel) then
+      self:ClearPanel()
+   end
+
    local margin = 15
 
    local dpanel = vgui.Create("DFrame")
-   local w, h = 700, 500
-   dpanel:SetSize(700, 500)
+
+   local title
+   local starttime = self.StartTime
+   local endtime = starttime
+   local events = self.Events
+
+   for i = #events, 1, -1 do
+      local e = events[i]
+      if e.id == EVENT_FINISH then
+         endtime = e.t
+         title = self.WinTypes[e.win]
+         break
+      end
+   end
+
+   if title == nil then
+      title = self.WinTypes.Default
+   end
+
+   -- size the panel based on the win text w/ 88px horizontal padding and 44px veritcal padding
+   surface.SetFont("WinHuge")
+   local w, h = surface.GetTextSize(title.Text or self.WinTypes.Default.Text)
+
+   -- w + padding (100) + DPropertySheet padding (8) + winlbl padding (30) + offset margin (margin * 2) + size margin (margin)
+   w, h = math.max(700, w + 138 + margin * 3), 500
+
+   dpanel:SetSize(w, h)
    dpanel:Center()
    dpanel:SetTitle(T("report_title"))
    dpanel:SetVisible(true)
@@ -391,7 +441,7 @@ function CLSCORE:ShowPanel()
    local dtabhilite = vgui.Create("DPanel", dtabsheet)
    dtabhilite:SetPaintBackground(false)
    dtabhilite:StretchToParent(padding,padding,padding,padding)
-   self:BuildHilitePanel(dtabhilite)
+   self:BuildHilitePanel(dtabhilite, title, starttime, endtime)
 
    dtabsheet:AddSheet(T("report_tab_hilite"), dtabhilite, "icon16/star.png", false, false, T("report_tab_hilite_tip"))
 
@@ -419,7 +469,7 @@ end
 
 function CLSCORE:ClearPanel()
 
-   if self.Panel then
+   if IsValid(self.Panel) then
       -- move the mouse off any tooltips and then remove the panel next tick
 
       -- we need this hack as opposed to just calling Remove because gmod does
@@ -427,12 +477,14 @@ function CLSCORE:ClearPanel()
       -- properly on Remove
       input.SetCursorPos( ScrW()/2, ScrH()/2 )
       local pnl = self.Panel
-      timer.Simple(0, function() pnl:Remove() end)
+      timer.Simple(0, function() if IsValid(pnl) then pnl:Remove() end end)
    end
 end
 
 function CLSCORE:SaveLog()
-   if self.Events and #self.Events <= 0 then
+   local events = self.Events
+
+   if events == nil or #events == 0 then
       chat.AddText(COLOR_WHITE, T("report_save_error"))
       return
    end
@@ -447,7 +499,7 @@ function CLSCORE:SaveLog()
 
    log = log .. string.format("%s | %-25s | %s\n", " TIME", "TYPE", "WHAT HAPPENED") .. string.rep("-", 50) .."\n"
 
-   for _, e in pairs(self.Events) do
+   for i = 1, #events do
       local etxt = self:TextForEvent(e)
       local etime = self:TimeForEvent(e)
       local _, etype = self:IconForEvent(e)
@@ -463,7 +515,6 @@ end
 
 function CLSCORE:Reset()
    self.Events = {}
-   --self.StoredEvents = nil
    self.TraitorIDs = {}
    self.DetectiveIDs = {}
    self.Scores = {}
@@ -474,32 +525,47 @@ function CLSCORE:Reset()
 end
 
 function CLSCORE:Init(events)
-   -- Get start time and traitors
-   local starttime = nil
-   local traitors = nil
-   local detectives = nil
-   for k, e in pairs(events) do
-      if e.id == EVENT_GAME and e.state == ROUND_ACTIVE then
-         starttime = e.t
+   -- Get start time, traitors, detectives, scores, and nicks
+   local starttime = 0
+   local traitors, detectives
+   local scores, nicks = {}, {}
+   
+   local game, selected, spawn = false, false, false
+   for i = 1, #events do
+      e = events[i]
+      if e.id == EVENT_GAME then
+         if e.state == ROUND_ACTIVE then
+            starttime = e.t
+
+            if selected and spawn then
+               break
+            end
+
+            game = true
+         end
       elseif e.id == EVENT_SELECTED then
          traitors = e.traitor_ids
          detectives = e.detective_ids
-      end
 
-      if starttime and traitors then
-         break
-      end
-   end
+         if game and spawn then
+            break
+         end
 
-   -- Get scores and players
-   local scores = {}
-   local nicks = {}
-   for k, e in pairs(events) do
-      if e.id == EVENT_SPAWN then
+         selected = true
+      elseif e.id == EVENT_SPAWN then
          scores[e.sid] = ScoreInit()
          nicks[e.sid] = e.ni
+
+         if game and selected then
+            break
+         end
+
+         spawn = true
       end
    end
+
+   if traitors == nil then traitors = {} end
+   if detectives == nil then detectives = {} end
 
    scores = ScoreEventLog(events, scores, traitors, detectives)
 

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -500,6 +500,7 @@ function CLSCORE:SaveLog()
    log = log .. string.format("%s | %-25s | %s\n", " TIME", "TYPE", "WHAT HAPPENED") .. string.rep("-", 50) .."\n"
 
    for i = 1, #events do
+      local e = events[i]
       local etxt = self:TextForEvent(e)
       local etime = self:TimeForEvent(e)
       local _, etype = self:IconForEvent(e)
@@ -532,7 +533,7 @@ function CLSCORE:Init(events)
    
    local game, selected, spawn = false, false, false
    for i = 1, #events do
-      e = events[i]
+      local e = events[i]
       if e.id == EVENT_GAME then
          if e.state == ROUND_ACTIVE then
             starttime = e.t

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -379,7 +379,7 @@ function CLSCORE:ShowPanel()
 
    local dpanel = vgui.Create("DFrame")
 
-   local title
+   local title = self.WinTypes.Default
    local starttime = self.StartTime
    local endtime = starttime
    local events = self.Events
@@ -393,16 +393,12 @@ function CLSCORE:ShowPanel()
       end
    end
 
-   if title == nil then
-      title = self.WinTypes.Default
-   end
-
    -- size the panel based on the win text w/ 88px horizontal padding and 44px veritcal padding
    surface.SetFont("WinHuge")
-   local w, h = surface.GetTextSize(title.Text or self.WinTypes.Default.Text)
+   local w, h = surface.GetTextSize( T(title.Text or self.WinTypes.Default.Text) )
 
-   -- w + padding (100) + DPropertySheet padding (8) + winlbl padding (30) + offset margin (margin * 2) + size margin (margin)
-   w, h = math.max(700, w + 138 + margin * 3), 500
+   -- w + DPropertySheet padding (8) + winlbl padding (30) + offset margin (margin * 2) + size margin (margin)
+   w, h = math.max(700, w + 38 + margin * 3), 500
 
    dpanel:SetSize(w, h)
    dpanel:Center()

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -66,7 +66,7 @@ function CLSCORE.DeclareEventDisplay(event_id, event_fns)
    if not tonumber(event_id) then
       error("Event ??? display: invalid event id", 2)
    end
-   if (not event_fns) or not istable(event_fns) then
+   if not istable(event_fns) then
       error(string.format("Event %d display: no display functions found.", event_id), 2)
    end
    if not event_fns.text then


### PR DESCRIPTION
- The CLSCORE panel now adjusts its width to the win text, fixing clipping with some languages (https://github.com/Facepunch/garrysmod/pull/1672). This required moving the win calculations to ``CLSCORE:ShowPanel`` from ``CLSCORE:BuildHilitePanel``

Before:
![](https://user-images.githubusercontent.com/4593679/82495724-2773a280-9ab1-11ea-90fc-936d313e9087.png)
After:
![](https://user-images.githubusercontent.com/4593679/82492387-b67dbc00-9aab-11ea-9b73-55b286b7a1f2.png)


- ``CLSCORE:BuildHilitePanel(Panel base)`` -> ``CLSCORE:BuildHilitePanel(Panel base, WinTitle /*See definition at the bottom*/ title, Number starttime, Number endtime)``
- Changed ``Error`` calls to ``error`` as ``Error`` is no longer halting (https://github.com/Facepunch/garrysmod-issues/issues/2113)
- ``pairs`` loops of ``CLSCORE.Events`` are now numeric-for loops to make sure no stray string keys are considered
- Changed a usage of ``type`` to ``TypeID`` - using ``type`` is not safe for checking userdata types since the ``MetaName`` key of its metatable affects the output
- ``ValidAward`` now checks the types of its members instead of verifying they are simply non-nil
- ``CLSCORE:ShowPanel`` now deletes the last panel instead of creating a duplicate
- ``CLSCORE:ClearPanel`` now properly checks panel validity before trying to remove it
- Merged two loops over the event table in ``CLSCORE:Init``. Events with no traitor or detective tables no longer error from there
- Some hardcoded tables and colors are now members of ``CLSCORE`` so addons can modify them without overriding the whole system. These new members include:
-- Array<values = String> ``CLSCORE.ScorePanelNames``
-- Color ``CLSCORE.ScorePanelColor``
-- Table<keys = Number, values = WinTitle> ``CLSCORE.WinTypes``. This must have a string key ``Default`` pointing to a default WinTitle with all keys provided. WinTitle is defined as a Table<keys = String> {[String] ``Text`` /* Will be translated */, [Color] ``BoxColor``, [Color] ``TextColor``, [Color] ``BackgroundColor``}. All keys are optional and will fall back to the ``Default`` WinTitle table if not specified