### PR TITLE
Fixed CVar Callback identifiers not being unique

### DIFF
--- a/garrysmod/lua/includes/modules/cvars.lua
+++ b/garrysmod/lua/includes/modules/cvars.lua
@@ -65,8 +65,9 @@ function AddChangeCallback( name, func, sIdentifier )
 
 	if ( sIdentifier ) then
 		for i = 1, #tab do
-			local a = tab[ i ];
-			if ( istable( v ) and a[ 2 ] == sIdentifier ) then
+			local a = tab[ i ]
+
+			if ( istable( a ) and a[ 2 ] == sIdentifier ) then
 				tab[ i ][ 1 ] = func
 				return
 			end


### PR DESCRIPTION
`v` is not declared within the scope, leading to `istable( v )` always returning false. The unique-ness of `sIdentifier` is therefore forfeit, as the `func` tied to the `sIdentifier` is never overwritten.

This also prevents the `return` that would stop the `table.insert` below from running, creating multiple callbacks tied to the same `sIdentifier`.

And since `cvars.RemoveChangeCallback` has a `break` statement after it has found an entry for the `sIdentifier`, any other callbacks with the same identifier will not be removed.