### PR TITLE
Fix cvars.AddChangeCallback adding duplicate callbacks

### DIFF
--- a/garrysmod/lua/includes/modules/cvars.lua
+++ b/garrysmod/lua/includes/modules/cvars.lua
@@ -66,7 +66,7 @@ function AddChangeCallback( name, func, sIdentifier )
 	if ( sIdentifier ) then
 		for i = 1, #tab do
 			local a = tab[ i ];
-			if ( istable( v ) and a[ 2 ] == sIdentifier ) then
+			if ( istable( a ) and a[ 2 ] == sIdentifier ) then
 				tab[ i ][ 1 ] = func
 				return
 			end


### PR DESCRIPTION
Fix cvars.AddChangeCallback adding a new callback instead of replacing the existing one, when called multiple times with the same identifier.