### PR TITLE
New achievements sending method

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/entities/gmod_balloon.lua
+++ b/garrysmod/gamemodes/sandbox/entities/entities/gmod_balloon.lua
@@ -73,7 +73,7 @@ function ENT:OnTakeDamage( dmginfo )
 
 	local attacker = dmginfo:GetAttacker()
 	if ( IsValid( attacker ) && attacker:IsPlayer() ) then
-		achievements.Call(attacker, 0)
+		achievements.Call(attacker, "BalloonPopped")
 	end
 
 	self:Remove()

--- a/garrysmod/gamemodes/sandbox/entities/entities/gmod_balloon.lua
+++ b/garrysmod/gamemodes/sandbox/entities/entities/gmod_balloon.lua
@@ -73,7 +73,7 @@ function ENT:OnTakeDamage( dmginfo )
 
 	local attacker = dmginfo:GetAttacker()
 	if ( IsValid( attacker ) && attacker:IsPlayer() ) then
-		attacker:SendLua( "achievements.BalloonPopped()" )
+		achievements.Call(attacker, 0)
 	end
 
 	self:Remove()

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/remover.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/remover.lua
@@ -43,8 +43,10 @@ function TOOL:LeftClick( trace )
 
 	if ( DoRemoveEntity( trace.Entity ) ) then
 
-		achievements.Call(self:GetOwner(), 2, 1)
-
+		if ( !CLIENT ) then
+			achievements.Call(self:GetOwner(), 2, 1)
+		end
+		
 		return true
 
 	end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/remover.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/remover.lua
@@ -44,7 +44,7 @@ function TOOL:LeftClick( trace )
 	if ( DoRemoveEntity( trace.Entity ) ) then
 
 		if ( !CLIENT ) then
-			achievements.Call(self:GetOwner(), 2, 1)
+			achievements.Call(self:GetOwner(), "Remover", 1)
 		end
 		
 		return true
@@ -79,7 +79,7 @@ function TOOL:RightClick( trace )
 
 	end
 
-	achievements.Call(self:GetOwner(), 2, Count)
+	achievements.Call(self:GetOwner(), "Remover", Count)
 
 	return true
 

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/remover.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/remover.lua
@@ -43,9 +43,7 @@ function TOOL:LeftClick( trace )
 
 	if ( DoRemoveEntity( trace.Entity ) ) then
 
-		if ( !CLIENT ) then
-			self:GetOwner():SendLua( "achievements.Remover()" )
-		end
+		achievements.Call(self:GetOwner(), 2, 1)
 
 		return true
 
@@ -79,7 +77,7 @@ function TOOL:RightClick( trace )
 
 	end
 
-	self:GetOwner():SendLua( string.format( "for i=1,%i do achievements.Remover() end", Count ) )
+	achievements.Call(self:GetOwner(), 2, Count)
 
 	return true
 

--- a/garrysmod/gamemodes/sandbox/gamemode/commands.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/commands.lua
@@ -311,7 +311,7 @@ function DoPlayerEntitySpawn( ply, entity_name, model, iSkin, strBody )
 
 		-- Set new position
 		ent:SetPos( vFlushPoint )
-		ply:SendLua( "achievements.SpawnedProp()" )
+		achievements.Call(ply, 4)
 
 	else
 
@@ -322,7 +322,7 @@ function DoPlayerEntitySpawn( ply, entity_name, model, iSkin, strBody )
 			phys:SetPos( phys:GetPos() + VecOffset )
 		end
 
-		ply:SendLua( "achievements.SpawnedRagdoll()" )
+		achievements.Call(ply, 5)
 
 	end
 
@@ -529,7 +529,7 @@ function Spawn_NPC( ply, NPCClassName, WeaponName, tr )
 	-- And cleanup
 	ply:AddCleanup( "npcs", SpawnedNPC )
 
-	ply:SendLua( "achievements.SpawnedNPC()" )
+	achievements.Call(ply, 3)
 
 end
 concommand.Add( "gmod_spawnnpc", function( ply, cmd, args ) Spawn_NPC( ply, args[ 1 ], args[ 2 ] ) end )

--- a/garrysmod/gamemodes/sandbox/gamemode/commands.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/commands.lua
@@ -311,7 +311,7 @@ function DoPlayerEntitySpawn( ply, entity_name, model, iSkin, strBody )
 
 		-- Set new position
 		ent:SetPos( vFlushPoint )
-		achievements.Call(ply, 4)
+		achievements.Call(ply, "SpawnedProp")
 
 	else
 
@@ -322,7 +322,7 @@ function DoPlayerEntitySpawn( ply, entity_name, model, iSkin, strBody )
 			phys:SetPos( phys:GetPos() + VecOffset )
 		end
 
-		achievements.Call(ply, 5)
+		achievements.Call(ply, "SpawnedRagdoll")
 
 	end
 
@@ -529,7 +529,7 @@ function Spawn_NPC( ply, NPCClassName, WeaponName, tr )
 	-- And cleanup
 	ply:AddCleanup( "npcs", SpawnedNPC )
 
-	achievements.Call(ply, 3)
+	achievements.Call(ply, "SpawnedNPC")
 
 end
 concommand.Add( "gmod_spawnnpc", function( ply, cmd, args ) Spawn_NPC( ply, args[ 1 ], args[ 2 ] ) end )

--- a/garrysmod/lua/entities/sent_ball.lua
+++ b/garrysmod/lua/entities/sent_ball.lua
@@ -136,7 +136,7 @@ function ENT:Use( activator, caller )
 		-- Give the collecting player some free health
 		local health = activator:Health()
 		activator:SetHealth( health + 5 )
-		activator:SendLua( "achievements.EatBall()" )
+		achievements.Call(activator, 1)	
 
 	end
 

--- a/garrysmod/lua/entities/sent_ball.lua
+++ b/garrysmod/lua/entities/sent_ball.lua
@@ -136,7 +136,7 @@ function ENT:Use( activator, caller )
 		-- Give the collecting player some free health
 		local health = activator:Health()
 		activator:SetHealth( health + 5 )
-		achievements.Call(activator, 1)	
+		achievements.Call(activator, "EatBall")
 
 	end
 

--- a/garrysmod/lua/includes/extensions/achievements.lua
+++ b/garrysmod/lua/includes/extensions/achievements.lua
@@ -1,13 +1,13 @@
 if SERVER then
 	util.AddNetworkString("achievements")
+	achievements = { }
 end
 
 function achievements.Call(ply, aID, removerCount)
-	if CLIENT then return end
-	net.Start("achievements")
+	if (CLIENT) then return end
 	net.WriteUInt(aID, 3)
 
-	if removerCount then
+	if (aID == 2) then
 		net.WriteUInt(removerCount, 16)
 	end
 
@@ -17,14 +17,20 @@ end
 if CLIENT then
 	local idToAchievement = {
 		[0] = achievements.BalloonPopped,
-achievements.EatBall, achievements.Remover, achievements.SpawnedNPC, achievements.SpawnedProp, achievements.SpawnedRagdoll
+		achievements.EatBall,
+		achievements.Remover,
+		achievements.SpawnedNPC,
+		achievements.SpawnedProp,
+		achievements.SpawnedRagdoll
 	}
 
 	net.Receive("achievements", function()
 		local aID = net.ReadUInt(3)
-		if aID == 2 then
+
+		if (aID == 2) then
 			local func = idToAchievement[aID]
-			for k=1, net.ReadUInt(16) do
+
+			for k = 1, net.ReadUInt(16) do
 				func()
 			end
 		else

--- a/garrysmod/lua/includes/extensions/achievements.lua
+++ b/garrysmod/lua/includes/extensions/achievements.lua
@@ -30,7 +30,7 @@ function achievements.Register(name,func)
 	end
 
 	achievementsN = achievementsN + 1
-	bitsize = math.ceil(math.log(achievementsN) / math.log(2)) + 1
+	bitsize = math.ceil(math.log(achievementsN + 1, 2))
 end
 
 if CLIENT then

--- a/garrysmod/lua/includes/extensions/achievements.lua
+++ b/garrysmod/lua/includes/extensions/achievements.lua
@@ -1,40 +1,53 @@
+local bitsize = 0
+local achievementsN = 0
+local achievementsLookup = {}
+
 if SERVER then
 	util.AddNetworkString("achievements")
 	achievements = {}
+
+	function achievements.Call(ply, aName, data)
+		local aID = achievementsLookup[aName]
+		if not aID then error("Attempt to call unregistered achievement (" .. tostring(aName) .. ")") end
+		net.Start("achievements")
+		net.WriteUInt(aID, bitsize)
+
+		if data then
+			net.WriteUInt(data, 16)
+		end
+
+		net.Send(ply)
+	end
 end
 
-function achievements.Call(ply, aID, removerCount)
-	if (CLIENT) then return end
-	net.WriteUInt(aID, 3)
+function achievements.Register(name,func)
+	if CLIENT and not isfunction(func) then error("Second argument must be a function") end
 
-	if (aID == 2) then
-		net.WriteUInt(removerCount, 16)
+	if (SERVER) then
+		achievementsLookup[name] = achievementsN
+	else
+		achievementsLookup[achievementsN] = func
 	end
 
-	net.Send(ply)
+	achievementsN = achievementsN + 1
+	bitsize = math.ceil(math.log(achievementsN) / math.log(2)) + 1
 end
 
 if CLIENT then
-	local idToAchievement = {
-		[0] = achievements.BalloonPopped,
-		achievements.EatBall,
-		achievements.Remover,
-		achievements.SpawnedNPC,
-		achievements.SpawnedProp,
-		achievements.SpawnedRagdoll
-	}
-
 	net.Receive("achievements", function()
-		local aID = net.ReadUInt(3)
+		local aID = net.ReadUInt(bitsize)
+		local func = achievementsLookup[aID]
+		print(aID,func,bitsize)
 
-		if (aID == 2) then
-			local func = idToAchievement[aID]
-
-			for k = 1, net.ReadUInt(16) do
-				func()
-			end
-		else
-			idToAchievement[aID]()
+		if func then
+			func(net.ReadUInt(16))
 		end
 	end)
 end
+
+achievements.Register("BalloonPopped",achievements.BalloonPopped)
+achievements.Register("EatBall",achievements.EatBall)
+achievements.Register("Remover",function(count) for i = 1, count do achievements.Remover() end end)
+achievements.Register("SpawnedNPC",achievements.SpawnedNPC)
+achievements.Register("SpawnedProp",achievements.SpawnedProp)
+achievements.Register("SpawnedRagdoll",achievements.SpawnedRagdoll)

--- a/garrysmod/lua/includes/extensions/achievements.lua
+++ b/garrysmod/lua/includes/extensions/achievements.lua
@@ -8,11 +8,11 @@ if SERVER then
 
 	function achievements.Call(ply, aName, data)
 		local aID = achievementsLookup[aName]
-		if not aID then error("Attempt to call unregistered achievement (" .. tostring(aName) .. ")") end
+		if (not aID) then error("Attempt to call unregistered achievement (" .. tostring(aName) .. ")") end
 		net.Start("achievements")
 		net.WriteUInt(aID, bitsize)
 
-		if data then
+		if (data) then
 			net.WriteUInt(data, 16)
 		end
 
@@ -37,9 +37,8 @@ if CLIENT then
 	net.Receive("achievements", function()
 		local aID = net.ReadUInt(bitsize)
 		local func = achievementsLookup[aID]
-		print(aID,func,bitsize)
 
-		if func then
+		if (func) then
 			func(net.ReadUInt(16))
 		end
 	end)

--- a/garrysmod/lua/includes/extensions/achievements.lua
+++ b/garrysmod/lua/includes/extensions/achievements.lua
@@ -1,6 +1,6 @@
 if SERVER then
 	util.AddNetworkString("achievements")
-	achievements = { }
+	achievements = {}
 end
 
 function achievements.Call(ply, aID, removerCount)

--- a/garrysmod/lua/includes/extensions/achievements.lua
+++ b/garrysmod/lua/includes/extensions/achievements.lua
@@ -1,0 +1,34 @@
+if SERVER then
+	util.AddNetworkString("achievements")
+end
+
+function achievements.Call(ply, aID, removerCount)
+	if CLIENT then return end
+	net.Start("achievements")
+	net.WriteUInt(aID, 3)
+
+	if removerCount then
+		net.WriteUInt(removerCount, 16)
+	end
+
+	net.Send(ply)
+end
+
+if CLIENT then
+	local idToAchievement = {
+		[0] = achievements.BalloonPopped,
+achievements.EatBall, achievements.Remover, achievements.SpawnedNPC, achievements.SpawnedProp, achievements.SpawnedRagdoll
+	}
+
+	net.Receive("achievements", function()
+		local aID = net.ReadUInt(3)
+		if aID == 2 then
+			local func = idToAchievement[aID]
+			for k=1, net.ReadUInt(16) do
+				func()
+			end
+		else
+			idToAchievement[aID]()
+		end
+	end)
+end

--- a/garrysmod/lua/includes/init.lua
+++ b/garrysmod/lua/includes/init.lua
@@ -95,6 +95,7 @@ include( "gmsave.lua" )
 -----------------------------------------------------------]]
 
 include ( "extensions/file.lua" )
+include ( "extensions/achievements.lua" )
 include ( "extensions/angle.lua" )
 include ( "extensions/debug.lua" )
 include ( "extensions/entity.lua" )

--- a/garrysmod/lua/send.txt
+++ b/garrysmod/lua/send.txt
@@ -145,6 +145,7 @@ lua\includes\util\tooltips.lua
 lua\includes\util\client.lua
 lua\includes\gui\icon_progress.lua
 lua\includes\extensions\util\worldpicker.lua
+lua\includes\extensions\achievements.lua
 lua\includes\extensions\debug.lua
 lua\includes\extensions\entity.lua
 lua\includes\extensions\net.lua


### PR DESCRIPTION
This PR changes achievements sending method from SendLua to networking 1-2 numbers.
The problem was recently mentioned in https://github.com/Facepunch/garrysmod/pull/1375

6 achievements are sent by server from Lua. Server calls `achievements.Call` with player, achievement ID (note it's not internal achievement ID, IDs are written in `idToAchievement` table lookup.) and additional number for Remover.

`achievements.Call` exists clientside as well but does nothing.

Net cost: 3 bits per call, except Remover achievement: 19 bits per call.

Remover sends additional number for massive removing, for the count it sends 16 bits becuase it's a maximum EntIndex.