### PR TITLE
Make spawnlists divider width cookie work as intended

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/content.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/content.lua
@@ -72,6 +72,10 @@ function PANEL:SwitchPanel( panel )
 
 end
 
+function PANEL:OnSizeChanged()
+	self.HorizontalDivider:LoadCookies()
+end
+
 vgui.Register( "SpawnmenuContentPanel", PANEL, "DPanel" )
 
 local function CreateContentPanel()


### PR DESCRIPTION
The horizontal divider for spawnmenu content panels has a named cookie coming from its base panel to save its width across sessions, but it doesn't work properly.

It sets the width of the left panel properly, but because the spawnmenu didn't expand to the screen edges yet and is tiny at that point, it ended up being clamped to its minimum width by the divider's `PerformLayout`.

So to counter that I simply made it so the spawnmenu content panel reset the divider's left width to the cookie on size change.

This is the simplest solution that I've found, I don't think this should break anything or cause unexpected behavior? Maybe someone else has a better idea to make this fix more intuitive?