### PR TITLE
Added undo for weapons

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/commands.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/commands.lua
@@ -855,17 +855,10 @@ function Spawn_Weapon( ply, wepname, tr )
 
 	gamemode.Call( "PlayerSpawnedSWEP", ply, entity )
 
-	local PrintName = swep.PrintName
-
-    	-- We haven't got a nice name :/
-	if ( PrintName:sub( 0, 1 ) == "#" ) then
-		PrintName = swep.ClassName
-	end
-
 	undo.Create( "SWEP" )
 		undo.SetPlayer( ply )
 		undo.AddEntity( entity )
-		undo.SetCustomUndoText( "Undone " .. PrintName )
+		undo.SetCustomUndoText( "Undone " .. swep.PrintName )
 	undo.Finish( "Scripted Weapon (" .. swep.ClassName .. ")" )
 
 end

--- a/garrysmod/gamemodes/sandbox/gamemode/commands.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/commands.lua
@@ -855,6 +855,19 @@ function Spawn_Weapon( ply, wepname, tr )
 
 	gamemode.Call( "PlayerSpawnedSWEP", ply, entity )
 
+	local PrintName = swep.PrintName
+
+    	-- We haven't got a nice name :/
+	if ( PrintName:sub( 0, 1 ) == "#" ) then
+		PrintName = swep.ClassName
+	end
+
+	undo.Create( "SWEP" )
+		undo.SetPlayer( ply )
+		undo.AddEntity( entity )
+		undo.SetCustomUndoText( "Undone " .. PrintName )
+	undo.Finish( "Scripted Weapon (" .. swep.ClassName .. ")" )
+
 end
 concommand.Add( "gm_spawnswep", function( ply, cmd, args ) Spawn_Weapon( ply, args[1] ) end )
 


### PR DESCRIPTION
This adds an undo entry for weapons spawned via the Creator tool or `gm_spawnswep`. [Before](https://youtu.be/j_XEN6Q0Zrs), [after](https://youtu.be/wASzpnQTDGg).

I'm not aware of any reliable method to fetch a language phrase on the server, so I just used the weapon's class name as a fallback for when the weapon's print name is the key to a language phrase.

Tested on the dev branch, version 2020.06.19.