### PR TITLE
"Legal wall hack" fix

### DIFF
--- a/garrysmod/lua/postprocess/stereoscopy.lua
+++ b/garrysmod/lua/postprocess/stereoscopy.lua
@@ -15,7 +15,7 @@ function RenderStereoscopy( ViewOrigin, ViewAngles )
 	local w = ScrW() / 2.2
 	local h = ScrH() / 2.2
 
-	local Right = ViewAngles:Right() * pp_stereoscopy_size:GetFloat()
+	local Right = ViewAngles:Right() * math.Clamp( pp_stereoscopy_size:GetFloat(), 0, 10 )
 
 	local view = {}
 

--- a/garrysmod/lua/vgui/dnumslider.lua
+++ b/garrysmod/lua/vgui/dnumslider.lua
@@ -11,15 +11,7 @@ function PANEL:Init()
 	self.TextArea:SetWide( 45 )
 	self.TextArea:SetNumeric( true )
 	self.TextArea:SetUpdateOnType( true )
-	self.TextArea.OnValueChange = function( textentry, val )
-		local cPos = self.TextArea:GetCaretPos()
-		local clamped = math.Clamp( tonumber( val ) || 0, self:GetMin(), self:GetMax() )
-		if clamped != val then
-			self.TextArea:SetText( clamped )
-			self.TextArea:SetCaretPos( cPos )
-		end
-		self:SetValue( clamped )
-	end
+	self.TextArea.OnValueChange = function(textentry, val) self:SetValue( val ) end
 	-- Causes automatic clamp to min/max, disabled for now. TODO: Enforce this with a setter/getter?
 	--self.TextArea.OnEnter = function( textarea, val ) textarea:SetText( self.Scratch:GetTextValue() ) end -- Update the text
 
@@ -112,6 +104,12 @@ function PANEL:SetValue( val )
 
 	val = math.Clamp( tonumber( val ) || 0, self:GetMin(), self:GetMax() )
 
+	if ( val ~= ( tonumber( self.TextArea:GetText() ) || 0 ) ) then
+		local cPos = self.TextArea:GetCaretPos()
+		self.TextArea:SetText( tostring( val ) )
+		self.TextArea:SetCaretPos( cPos )
+	end
+
 	if ( self:GetValue() == val ) then return end
 
 	self.Scratch:SetValue( val ) -- This will also call ValueChanged
@@ -157,7 +155,7 @@ end
 
 function PANEL:SetConVar( cvar )
 	self.Scratch:SetConVar( cvar )
-	self.TextArea:SetConVar( cvar )
+	self:SetValue( GetConVar( cvar ):GetString() )
 end
 
 function PANEL:SetText( text )

--- a/garrysmod/lua/vgui/dnumslider.lua
+++ b/garrysmod/lua/vgui/dnumslider.lua
@@ -104,7 +104,7 @@ function PANEL:SetValue( val )
 
 	val = math.Clamp( tonumber( val ) || 0, self:GetMin(), self:GetMax() )
 
-	if ( val ~= ( tonumber( self.TextArea:GetText() ) || 0 ) ) then
+	if ( val != ( tonumber( self.TextArea:GetText() ) || 0 ) ) then
 		local cPos = self.TextArea:GetCaretPos()
 		self.TextArea:SetText( tostring( val ) )
 		self.TextArea:SetCaretPos( cPos )

--- a/garrysmod/lua/vgui/dnumslider.lua
+++ b/garrysmod/lua/vgui/dnumslider.lua
@@ -10,7 +10,16 @@ function PANEL:Init()
 	self.TextArea:SetPaintBackground( false )
 	self.TextArea:SetWide( 45 )
 	self.TextArea:SetNumeric( true )
-	self.TextArea.OnChange = function( textarea, val ) self:SetValue( self.TextArea:GetText() ) end
+	self.TextArea:SetUpdateOnType( true )
+	self.TextArea.OnValueChange = function( textentry, val )
+		local cPos = self.TextArea:GetCaretPos()
+		local clamped = math.Clamp( tonumber( val ) || 0, self:GetMin(), self:GetMax() )
+		if clamped != val then
+			self.TextArea:SetText( clamped )
+			self.TextArea:SetCaretPos( cPos )
+		end
+		self:SetValue( clamped )
+	end
 	-- Causes automatic clamp to min/max, disabled for now. TODO: Enforce this with a setter/getter?
 	--self.TextArea.OnEnter = function( textarea, val ) textarea:SetText( self.Scratch:GetTextValue() ) end -- Update the text
 


### PR DESCRIPTION
Recently we received a bug report from one of our community members. You can enter ANY value in "Post Process / Stereoscopy" Text Entry and it didn't clamp. This way you could see through walls:

![](https://steamuserimages-a.akamaihd.net/ugc/1263771316479415654/891FECC0A587AF83D0E182E0E768ADAEF4AEACA6/)

![](https://steamuserimages-a.akamaihd.net/ugc/1263771316479420305/6CCA7A93538BF77D051C7C47E094E272E841C149/)

These commits fix clamping for DNumSlider and pp_stereoscopy_size ConVar.