### PR TITLE
Add NiceText to the undo table

### DIFF
--- a/garrysmod/lua/includes/modules/undo.lua
+++ b/garrysmod/lua/includes/modules/undo.lua
@@ -314,6 +314,8 @@ function Finish( NiceText )
 
 	local index = Current_Undo.Owner:UniqueID()
 	PlayerUndo[ index ] = PlayerUndo[ index ] or {}
+	
+	Current_Undo.NiceText = NiceText
 
 	local id = table.insert( PlayerUndo[ index ], Current_Undo )
 


### PR DESCRIPTION
This is so that the "nice text" of the undo (the message that appears in the player's spawnmenu undo list) can be accessed from inside hooks like [`GM:CanUndo()`](https://github.com/Facepunch/garrysmod/pull/1623).

Before this, the table that's returned from the 2nd argument of that hook would be something like:

```
CustomUndoText  =       Undone SMG Ammo
Entities:
                1       =       Entity [20][item_ammo_smg1]
Functions:
Name    =       SENT
Owner   =       Player [1][viral32111]
```

After it looks like:

```
CustomUndoText  =       Undone SMG Ammo
Entities:
                1       =       Entity [102][item_ammo_smg1]
Functions:
Name    =       SENT
NiceText        =       Scripted Entity (item_ammo_smg1)
Owner   =       Player [1][viral32111]
```

If no `NiceText` is provided to `undo.Finish()`, then it simply doesn't add the key, which is exactly the same as what happens when `GM:CanUndo()` is called without any `Entities`, `Name` or `Owner` keys.

The purpose of the `GM:CanUndo()` hook is to prevent undo's, and with this extra information it may be easier to do that.

Tested on x86-64, version 2020.06.19.