### PR TITLE
Add list.GetTable()

### DIFF
--- a/garrysmod/lua/includes/modules/list.lua
+++ b/garrysmod/lua/includes/modules/list.lua
@@ -33,6 +33,15 @@ function GetForEdit( list )
 end
 
 --
+--	Get all list names
+--
+function GetTable()
+
+	return table.GetKeys( g_Lists )
+
+end
+
+--
 --	Set a key value
 --
 function Set( list, key, value )


### PR DESCRIPTION
This simply returns a table containing the names of all created lists.

It's useful for if a developer wants to view every list or doesn't know the exact name to one of the default lists. For example, they want to view everything that's been added to the various spawnmenu categories but they don't know the names of each of those lists.

Consistency has been kept with the [other `.GetTable()` functions](https://i.imgur.com/QAJzyjz.png).


<details>
  <summary>Example output</summary>

```
1       =       Vehicles
2       =       SpawnableEntities
3       =       OverrideMaterials
4       =       DesktopWindows
5       =       NPC
6       =       PaintMaterials
7       =       EffectType
8       =       RenderModes
9       =       ButtonModels
10      =       HoverballModels
11      =       RenderFX
12      =       SkeletonConvertor
13      =       WheelModels
14      =       trail_materials
15      =       DynamiteModels
16      =       BalloonModels
17      =       LampTextures
18      =       ThrusterModels
19      =       LampModels
20      =       PhysicsMaterials
21      =       PlayerOptionsAnimations
22      =       Weapon
23      =       NPCUsableWeapons
24      =       ThrusterEffects
25      =       ThrusterSounds
```

</details>

Tested on x86-64 branch, version 2020.06.19.