### PR TITLE
remove OnStopDragging from DragMouseRelease to prevent double-calling

### DIFF
--- a/garrysmod/lua/includes/extensions/client/panel/dragdrop.lua
+++ b/garrysmod/lua/includes/extensions/client/panel/dragdrop.lua
@@ -459,13 +459,6 @@ function meta:DragMouseRelease( mcode )
 		return false
 	end
 
-	for k, v in pairs( dragndrop.m_Dragging ) do
-
-		if ( !IsValid( v ) ) then continue end
-		v:OnStopDragging()
-
-	end
-
 	dragndrop.Drop()
 
 	-- Todo.. we should only do this if we enabled it!


### PR DESCRIPTION
DragMouseRelease calls dragndrop.Drop() which calls dragndrop.StopDragging() which, in turn, already calls panels' OnStopDragging()

by having DragMouseRelease also call OnStopDragging() there was a double-call to that function

reproduction of bug:

```lua
a = vgui.Create("DFrame")
a:MakePopup()
a:SetSize(300, 400)

b = vgui.Create("DButton", a)
b:Droppable("a")
b:SetSize(120, 80)
b:Center()
b:SetText("drag'n'drop me")

b.OnStopDragging = function()
	print("Dropped @", FrameNumber())
end
```