### PR TITLE
Stop teleporting players to players they're not spectating

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/player.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player.lua
@@ -56,7 +56,7 @@ end
 function GM:PlayerSpawn(ply)
    -- stop bleeding
    util.StopBleeding(ply)
-  
+
    -- Some spawns may be tilted
    ply:ResetViewRoll()
 
@@ -343,7 +343,7 @@ function GM:KeyPress(ply, key)
          local ang = ply:EyeAngles()
 
          local target = ply:GetObserverTarget()
-         if IsValid(target) and target:IsPlayer() then
+         if IsValid(target) and target:IsPlayer() and ply:GetObserverMode() != 6 then -- Only set the spectator's position to the player they are spectating if they are in chase or eye mode. They can use the reload key if they want to return to the person they're spectating
             pos = target:EyePos()
             ang = target:EyeAngles()
          end
@@ -357,7 +357,7 @@ function GM:KeyPress(ply, key)
          return true
       elseif key == IN_JUMP then
          -- unfuck if you're on a ladder etc
-         if not (ply:GetMoveType() == MOVETYPE_NOCLIP) then
+         if (ply:GetMoveType() != MOVETYPE_NOCLIP) then
             ply:SetMoveType(MOVETYPE_NOCLIP)
          end
       elseif key == IN_RELOAD then

--- a/garrysmod/gamemodes/terrortown/gamemode/player.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player.lua
@@ -343,7 +343,7 @@ function GM:KeyPress(ply, key)
          local ang = ply:EyeAngles()
 
          local target = ply:GetObserverTarget()
-         if IsValid(target) and target:IsPlayer() and ply:GetObserverMode() != 6 then -- Only set the spectator's position to the player they are spectating if they are in chase or eye mode. They can use the reload key if they want to return to the person they're spectating
+         if IsValid(target) and target:IsPlayer() and ply:GetObserverMode() != OBS_MODE_ROAMING then -- Only set the spectator's position to the player they are spectating if they are in chase or eye mode. They can use the reload key if they want to return to the person they're spectating
             pos = target:EyePos()
             ang = target:EyeAngles()
          end


### PR DESCRIPTION
If you crouch to stop spectating a player and then want to slowly move while free-roaming and hold duck, you are teleported back to the person you were previously spectating. There is no need for this since if you want to return to the person you were spectating, you can just use your reload bind.

Also changed the way checking if you are checking when using jump bind.