### PR TITLE
Fix table.RemoveByValue throwing an error when key is not a number

### DIFF
--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -651,7 +651,12 @@ function table.RemoveByValue( tbl, val )
 	local key = table.KeyFromValue( tbl, val )
 	if ( !key ) then return false end
 
-	table.remove( tbl, key )
+	if ( isnumber( key ) ) then
+		table.remove( tbl, key )
+	else
+		tbl[ key ] = nil
+	end
+
 	return key
 
 end


### PR DESCRIPTION
Title says it all, backwards compatibility is still maintained and when the key is not a number it just makes the value to the key nil.