### PR TITLE
Network Entity.Set/GetCreator

### DIFF
--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -49,6 +49,7 @@ function meta:GetVar( name, default )
 end
 
 function meta:SetCreator( ply )
+	self.m_PlayerCreator = ply -- Backward compatibility
 	self:SetNWEntity( "PlayerCreator", ply )
 end
 

--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -48,16 +48,12 @@ function meta:GetVar( name, default )
 
 end
 
-if ( SERVER ) then
+function meta:SetCreator( ply )
+	self:SetNWEntity( "PlayerCreator", ply )
+end
 
-	function meta:SetCreator( ply )
-		self:SetNWEntity( "PlayerCreator", ply )
-	end
-
-	function meta:GetCreator()
-		return self:GetNWEntity( "PlayerCreator" )
-	end
-
+function meta:GetCreator()
+	return self:GetNWEntity( "PlayerCreator" )
 end
 
 --[[---------------------------------------------------------

--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -51,11 +51,11 @@ end
 if ( SERVER ) then
 
 	function meta:SetCreator( ply )
-		self.m_PlayerCreator = ply
+		self:SetNWEntity( "PlayerCreator", ply )
 	end
 
 	function meta:GetCreator()
-		return self.m_PlayerCreator || NULL
+		return self:GetNWEntity( "PlayerCreator" )
 	end
 
 end


### PR DESCRIPTION
This will add a useful simple owning system to Garry's Mod. I know that CPPI already exists but it is not used everywhere...

This modification will avoid workshop & gmodstore addon from creating their own ownabiliy functions to support gamemode that hasn't CPPI.

The only downside I see is that addons which already used this function will unnecessarily network the owner.

