### PR TITLE
[TTT] Fix broken radio/drop animations

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -142,7 +142,6 @@ if CLIENT then
 
    local simple_runners = {
       ACT_GMOD_GESTURE_DISAGREE,
-      ACT_GMOD_GESTURE_SALUTE,
       ACT_GMOD_GESTURE_BECON,
       ACT_GMOD_GESTURE_AGREE,
       ACT_GMOD_GESTURE_WAVE,
@@ -150,10 +149,10 @@ if CLIENT then
       ACT_SIGNAL_FORWARD,
       ACT_SIGNAL_GROUP,
       ACT_SIGNAL_HALT,
-      ACT_GMOD_CHEER,
-      ACT_ITEM_PLACE,
-      ACT_ITEM_DROP,
-      ACT_ITEM_GIVE
+      ACT_GMOD_TAUNT_CHEER,
+      ACT_GMOD_GESTURE_ITEM_PLACE,
+      ACT_GMOD_GESTURE_ITEM_DROP,
+      ACT_GMOD_GESTURE_ITEM_GIVE
    }
    local function MakeSimpleRunner(act)
       return function (ply, w)

--- a/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
@@ -220,7 +220,7 @@ local function DropActiveWeapon(ply)
       return
    end
 
-   ply:AnimPerformGesture(ACT_ITEM_PLACE)
+   ply:AnimPerformGesture(ACT_GMOD_GESTURE_ITEM_PLACE)
 
    WEPS.DropNotifiedWeapon(ply, wep)
 end
@@ -248,7 +248,7 @@ local function DropActiveAmmo(ply)
 
    wep:SetClip1(0)
 
-   ply:AnimPerformGesture(ACT_ITEM_GIVE)
+   ply:AnimPerformGesture(ACT_GMOD_GESTURE_ITEM_GIVE)
 
    local box = ents.Create(wep.AmmoEnt)
    if not IsValid(box) then return end


### PR DESCRIPTION
There are some incorrect ACT references in the code that lead to various animations breaking, such as radio gestures. It got worse after recent changes such as the switch from pairs() to ipairs(), too.