### PR TITLE
Remove odd concat from PrintTable

### DIFF
--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -78,17 +78,13 @@ function PrintTable( t, indent, done )
 		if  ( istable( value ) && !done[ value ] ) then
 
 			done[ value ] = true
-			Msg( tostring( key ) )
-			Msg( ":\n" )
+			Msg( key, ":\n" )
 			PrintTable ( value, indent + 2, done )
 			done[ value ] = nil
 
 		else
 
-			Msg( tostring( key ) )
-			Msg( "\t=\t" )
-			Msg( tostring( value ) )
-			Msg( "\n" )
+			Msg( key, "\t=\t", value, "\n" )
 
 		end
 

--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -57,6 +57,7 @@ include( "util/color.lua" )
 	Prints a table to the console
 -----------------------------------------------------------]]
 function PrintTable( t, indent, done )
+	local Msg = Msg
 
 	done = done or {}
 	indent = indent or 0
@@ -77,14 +78,17 @@ function PrintTable( t, indent, done )
 		if  ( istable( value ) && !done[ value ] ) then
 
 			done[ value ] = true
-			Msg( tostring( key ) .. ":" .. "\n" )
+			Msg( tostring( key ) )
+			Msg( ":\n" )
 			PrintTable ( value, indent + 2, done )
 			done[ value ] = nil
 
 		else
 
-			Msg( tostring( key ) .. "\t=\t" )
-			Msg( tostring( value ) .. "\n" )
+			Msg( tostring( key ) )
+			Msg( "\t=\t" )
+			Msg( tostring( value ) )
+			Msg( "\n" )
 
 		end
 


### PR DESCRIPTION
Seperate Msg instead of concat, also add Msg as local in the function to prevent checking the global all the time.
The odd concat is ":" .. "\n" why not just go ":\n" then? While we are add it just patch the function up a little.