### PR TITLE
Remove string.__index error

### DIFF
--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -293,8 +293,6 @@ function meta:__index( key )
 		return val
 	elseif ( tonumber( key ) ) then
 		return self:sub( key, key )
-	else
-		error( "attempt to index a string value with bad key ('" .. tostring( key ) .. "' is not part of the string library)", 2 )
 	end
 end
 

--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -289,7 +289,7 @@ local meta = getmetatable( "" )
 
 function meta:__index( key )
 	local val = string[ key ]
-	if ( val ) then
+	if ( val ~= nil ) then
 		return val
 	elseif ( tonumber( key ) ) then
 		return self:sub( key, key )


### PR DESCRIPTION
We don't need this exclusive error.
Let it be `attempt to call method foo` instead of `attempt to index a string value with bad key ('foo' is not part of the string library)`.