### PR TITLE
Allow select Post Processing effects to work with RenderTargets

### DIFF
--- a/garrysmod/lua/postprocess/bloom.lua
+++ b/garrysmod/lua/postprocess/bloom.lua
@@ -28,7 +28,7 @@ function DrawBloom( darken, multiply, sizex, sizey, passes, color, colr, colg, c
 	if ( !render.SupportsPixelShaders_2_0() ) then return end
 
 	-- Copy the backbuffer to the screen effect texture
-	render.UpdateScreenEffectTexture()
+	render.CopyRenderTargetToTexture( render.GetScreenEffectTexture() )
 
 	-- Store the render target so we can swap back at the end
 	local OldRT = render.GetRenderTarget()

--- a/garrysmod/lua/postprocess/color_modify.lua
+++ b/garrysmod/lua/postprocess/color_modify.lua
@@ -18,7 +18,7 @@ local pp_colormod_mulb = CreateClientConVar( "pp_colormod_mulb", "0", true, fals
 
 function DrawColorModify( tab )
 
-	render.UpdateScreenEffectTexture()
+	render.CopyRenderTargetToTexture( render.GetScreenEffectTexture() )
 
 	for k, v in pairs( tab ) do
 

--- a/garrysmod/lua/postprocess/sharpen.lua
+++ b/garrysmod/lua/postprocess/sharpen.lua
@@ -11,7 +11,7 @@ local pp_sharpen_distance = CreateClientConVar( "pp_sharpen_distance", "1", true
 
 function DrawSharpen( contrast, distance )
 
-	render.UpdateScreenEffectTexture()
+	render.CopyRenderTargetToTexture( render.GetScreenEffectTexture() )
 
 	matSharpen:SetFloat( "$contrast", contrast )
 	matSharpen:SetFloat( "$distance", distance / ScrW() )

--- a/garrysmod/lua/postprocess/sobel.lua
+++ b/garrysmod/lua/postprocess/sobel.lua
@@ -7,7 +7,7 @@ local pp_sobel_threshold = CreateClientConVar( "pp_sobel_threshold", "0.11", tru
 
 function DrawSobel( threshold )
 
-	render.UpdateScreenEffectTexture()
+	render.CopyRenderTargetToTexture( render.GetScreenEffectTexture() )
 
 	-- update threshold value
 	SobelMaterial:SetFloat( "$threshold", threshold )

--- a/garrysmod/lua/postprocess/sunbeams.lua
+++ b/garrysmod/lua/postprocess/sunbeams.lua
@@ -15,7 +15,7 @@ function DrawSunbeams( darken, multiply, sunsize, sunx, suny )
 
 	if ( !render.SupportsPixelShaders_2_0() ) then return end
 
-	render.UpdateScreenEffectTexture()
+	render.CopyRenderTargetToTexture( render.GetScreenEffectTexture() )
 
 	matSunbeams:SetFloat( "$darken", darken )
 	matSunbeams:SetFloat( "$multiply", multiply )

--- a/garrysmod/lua/postprocess/texturize.lua
+++ b/garrysmod/lua/postprocess/texturize.lua
@@ -7,7 +7,7 @@ local pp_texturize_scale = CreateClientConVar( "pp_texturize_scale", "1", true, 
 
 function DrawTexturize( scale, pMaterial )
 
-	render.UpdateScreenEffectTexture()
+	render.CopyRenderTargetToTexture( render.GetScreenEffectTexture() )
 
 	matMaterial:SetFloat( "$scalex", ( ScrW() / 64 ) * scale )
 	matMaterial:SetFloat( "$scaley", ( ScrH() / 64 / 8 ) * scale )

--- a/garrysmod/lua/postprocess/toytown.lua
+++ b/garrysmod/lua/postprocess/toytown.lua
@@ -17,7 +17,7 @@ function DrawToyTown( NumPasses, H )
 
 	for i = 1, NumPasses do
 
-		render.UpdateScreenEffectTexture()
+		render.CopyRenderTargetToTexture( render.GetScreenEffectTexture() )
 
 		surface.DrawTexturedRect( 0, 0, ScrW(), H )
 		surface.DrawTexturedRectUV( 0, ScrH() - H, ScrW(), H, 0, 1, 1, 0 )


### PR DESCRIPTION
Many post processing effects use render.UpdateScreenEffectTexture() to use the main screen space as the texture for the post processing material. This change allows other post processing effects that use a similar pattern to work correctly with render targets.