### PR TITLE
Add More Arguments to derma.SkinHook

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/controlpanel.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/controlpanel.lua
@@ -51,7 +51,7 @@ end
 function PANEL:MatSelect( strConVar, tblOptions, bAutoStretch, iWidth, iHeight )
 
 	local MatSelect = vgui.Create( "MatSelect", self )
-	Derma_Hook( MatSelect.List, "Paint", "Paint", "Panel" )
+	Derma_Hook( MatSelect.List, "Paint", "PaintPanel" )
 
 	MatSelect:SetConVar( strConVar )
 
@@ -198,7 +198,7 @@ function PANEL:AddControl( control, data )
 		ctrl:ControlValues( data ) -- Yack.
 		self:AddPanel( ctrl )
 
-		Derma_Hook( ctrl.List, "Paint", "Paint", "Panel" )
+		Derma_Hook( ctrl.List, "Paint", "PaintPanel" )
 
 		return ctrl
 
@@ -360,7 +360,7 @@ function PANEL:AddControl( control, data )
 		ctrl:SetNumRows( data.rows or 4 )
 		ctrl:SetConVar( data.convar or nil )
 
-		Derma_Hook( ctrl.List, "Paint", "Paint", "Panel" )
+		Derma_Hook( ctrl.List, "Paint", "PaintPanel" )
 
 		for name, tab in pairs( data.options ) do
 

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contentsidebartoolbox.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contentsidebartoolbox.lua
@@ -3,7 +3,7 @@ include( "contentheader.lua" )
 
 local PANEL = {}
 
-Derma_Hook( PANEL, "Paint", "Paint", "Tree" )
+Derma_Hook( PANEL, "Paint", "PaintTree" )
 PANEL.m_bBackground = true -- Hack for above
 
 function PANEL:Init()

--- a/garrysmod/lua/derma/derma.lua
+++ b/garrysmod/lua/derma/derma.lua
@@ -187,7 +187,7 @@ function GetNamedSkin( name )
 end
 
 --[[---------------------------------------------------------
-	SkinHook( strType, strName, panel )
+	SkinHook( strName, panel, hookArgs )
 -----------------------------------------------------------]]
 function SkinHook( strName, panel, a, b, c, d, e, f, g )
 

--- a/garrysmod/lua/derma/derma.lua
+++ b/garrysmod/lua/derma/derma.lua
@@ -189,15 +189,15 @@ end
 --[[---------------------------------------------------------
 	SkinHook( strType, strName, panel )
 -----------------------------------------------------------]]
-function SkinHook( strType, strName, panel, w, h )
+function SkinHook( strName, panel, a, b, c, d, e, f, g )
 
 	local Skin = panel:GetSkin()
 	if ( !Skin ) then return end
 
-	local func = Skin[ strType .. strName ]
+	local func = Skin[ strName ]
 	if ( !func ) then return end
 
-	return func( Skin, panel, w, h )
+	return func( Skin, panel, a, b, c, d, e, f, g )
 
 end
 

--- a/garrysmod/lua/derma/init.lua
+++ b/garrysmod/lua/derma/init.lua
@@ -46,10 +46,10 @@ include( "derma_animation.lua" )
 include( "derma_utils.lua" )
 include( "derma_gwen.lua" )
 
-function Derma_Hook( panel, functionname, hookname, typename )
+function Derma_Hook( panel, functionname, hookname )
 
-	panel[ functionname ] = function ( self, a, b, c, d )
-		return derma.SkinHook( hookname, typename, self, a, b, c, d )
+	panel[ functionname ] = function ( self, a, b, c, d, e, f, g )
+		return derma.SkinHook( hookname, self, a, b, c, d, e, f, g )
 	end
 
 end

--- a/garrysmod/lua/menu/ugcpublish.lua
+++ b/garrysmod/lua/menu/ugcpublish.lua
@@ -176,7 +176,7 @@ function PANEL:Setup( ugcType, file, imageFile, handler )
 				if ( !val && num == 0 ) then s:SetValue( true ) end -- Don't allow to unselect the only 1 selected
 			end
 
-			Derma_Hook( rb.Button, "Paint", "Paint", "RadioButton" )
+			Derma_Hook( rb.Button, "Paint", "PaintRadioButton" )
 		end
 
 		self.Tags:InvalidateChildren( false ) -- Update position of all the docked elements

--- a/garrysmod/lua/vgui/dbutton.lua
+++ b/garrysmod/lua/vgui/dbutton.lua
@@ -74,7 +74,7 @@ end
 
 function PANEL:Paint( w, h )
 
-	derma.SkinHook( "Paint", "Button", self, w, h )
+	derma.SkinHook( "PaintButton", self, w, h )
 
 	--
 	-- Draw the button text

--- a/garrysmod/lua/vgui/dcategorycollapse.lua
+++ b/garrysmod/lua/vgui/dcategorycollapse.lua
@@ -75,7 +75,7 @@ end
 function PANEL:Add( strName )
 
 	local button = vgui.Create( "DButton", self )
-	button.Paint = function( panel, w, h ) derma.SkinHook( "Paint", "CategoryButton", panel, w, h ) end
+	button.Paint = function( panel, w, h ) derma.SkinHook( "PaintCategoryButton", panel, w, h ) end
 	button.UpdateColours = function( button, skin )
 
 		if ( button.AltLine ) then
@@ -167,7 +167,7 @@ end
 
 function PANEL:Paint( w, h )
 
-	derma.SkinHook( "Paint", "CollapsibleCategory", self, w, h )
+	derma.SkinHook( "PaintCollapsibleCategory", self, w, h )
 
 	return false
 

--- a/garrysmod/lua/vgui/dcategorylist.lua
+++ b/garrysmod/lua/vgui/dcategorylist.lua
@@ -29,7 +29,7 @@ end
 
 function PANEL:Paint( w, h )
 
-	derma.SkinHook( "Paint", "CategoryList", self, w, h )
+	derma.SkinHook( "PaintCategoryList", self, w, h )
 	return false
 
 end

--- a/garrysmod/lua/vgui/dcheckbox.lua
+++ b/garrysmod/lua/vgui/dcheckbox.lua
@@ -3,9 +3,9 @@ local PANEL = {}
 
 AccessorFunc( PANEL, "m_bChecked", "Checked", FORCE_BOOL )
 
-Derma_Hook( PANEL, "Paint", "Paint", "CheckBox" )
-Derma_Hook( PANEL, "ApplySchemeSettings", "Scheme", "CheckBox" )
-Derma_Hook( PANEL, "PerformLayout", "Layout", "CheckBox" )
+Derma_Hook( PANEL, "Paint", "PaintCheckBox" )
+Derma_Hook( PANEL, "ApplySchemeSettings", "SchemeCheckBox" )
+Derma_Hook( PANEL, "PerformLayout", "LayoutCheckBox" )
 
 Derma_Install_Convar_Functions( PANEL )
 

--- a/garrysmod/lua/vgui/dcombobox.lua
+++ b/garrysmod/lua/vgui/dcombobox.lua
@@ -1,7 +1,7 @@
 
 local PANEL = {}
 
-Derma_Hook( PANEL, "Paint", "Paint", "ComboBox" )
+Derma_Hook( PANEL, "Paint", "PaintComboBox" )
 
 Derma_Install_Convar_Functions( PANEL )
 
@@ -10,7 +10,7 @@ AccessorFunc( PANEL, "m_bDoSort", "SortItems", FORCE_BOOL )
 function PANEL:Init()
 
 	self.DropButton = vgui.Create( "DPanel", self )
-	self.DropButton.Paint = function( panel, w, h ) derma.SkinHook( "Paint", "ComboDownArrow", panel, w, h ) end
+	self.DropButton.Paint = function( panel, w, h ) derma.SkinHook( "PaintComboDownArrow", panel, w, h ) end
 	self.DropButton:SetMouseInputEnabled( false )
 	self.DropButton.ComboBox = self
 

--- a/garrysmod/lua/vgui/dexpandbutton.lua
+++ b/garrysmod/lua/vgui/dexpandbutton.lua
@@ -2,7 +2,7 @@
 local PANEL = {}
 
 AccessorFunc( PANEL, "m_bExpanded", "Expanded", FORCE_BOOL )
-Derma_Hook( PANEL, "Paint", "Paint", "ExpandButton" )
+Derma_Hook( PANEL, "Paint", "PaintExpandButton" )
 
 function PANEL:Init()
 

--- a/garrysmod/lua/vgui/dform.lua
+++ b/garrysmod/lua/vgui/dform.lua
@@ -44,7 +44,7 @@ function PANEL:AddItem( left, right )
 	self:InvalidateLayout()
 
 	local Panel = vgui.Create( "DSizeToContents", self )
-	--Panel.Paint = function( panel, w, h ) derma.SkinHook( "Paint", "CategoryButton", panel, w, h ) end
+	--Panel.Paint = function( panel, w, h ) derma.SkinHook( "PaintCategoryButton", panel, w, h ) end
 	Panel:SetSizeX( false )
 	Panel:Dock( TOP )
 	Panel:DockPadding( 10, 10, 10, 0 )

--- a/garrysmod/lua/vgui/dframe.lua
+++ b/garrysmod/lua/vgui/dframe.lua
@@ -24,18 +24,18 @@ function PANEL:Init()
 	self.btnClose = vgui.Create( "DButton", self )
 	self.btnClose:SetText( "" )
 	self.btnClose.DoClick = function ( button ) self:Close() end
-	self.btnClose.Paint = function( panel, w, h ) derma.SkinHook( "Paint", "WindowCloseButton", panel, w, h ) end
+	self.btnClose.Paint = function( panel, w, h ) derma.SkinHook( "PaintWindowCloseButton", panel, w, h ) end
 
 	self.btnMaxim = vgui.Create( "DButton", self )
 	self.btnMaxim:SetText( "" )
 	self.btnMaxim.DoClick = function ( button ) self:Close() end
-	self.btnMaxim.Paint = function( panel, w, h ) derma.SkinHook( "Paint", "WindowMaximizeButton", panel, w, h ) end
+	self.btnMaxim.Paint = function( panel, w, h ) derma.SkinHook( "PaintWindowMaximizeButton", panel, w, h ) end
 	self.btnMaxim:SetDisabled( true )
 
 	self.btnMinim = vgui.Create( "DButton", self )
 	self.btnMinim:SetText( "" )
 	self.btnMinim.DoClick = function ( button ) self:Close() end
-	self.btnMinim.Paint = function( panel, w, h ) derma.SkinHook( "Paint", "WindowMinimizeButton", panel, w, h ) end
+	self.btnMinim.Paint = function( panel, w, h ) derma.SkinHook( "PaintWindowMinimizeButton", panel, w, h ) end
 	self.btnMinim:SetDisabled( true )
 
 	self.lblTitle = vgui.Create( "DLabel", self )
@@ -200,7 +200,7 @@ function PANEL:Paint( w, h )
 		Derma_DrawBackgroundBlur( self, self.m_fCreateTime )
 	end
 
-	derma.SkinHook( "Paint", "Frame", self, w, h )
+	derma.SkinHook( "PaintFrame", self, w, h )
 	return true
 
 end

--- a/garrysmod/lua/vgui/dhorizontalscroller.lua
+++ b/garrysmod/lua/vgui/dhorizontalscroller.lua
@@ -51,11 +51,11 @@ function PANEL:Init()
 
 	self.btnLeft = vgui.Create( "DButton", self )
 	self.btnLeft:SetText( "" )
-	self.btnLeft.Paint = function( panel, w, h ) derma.SkinHook( "Paint", "ButtonLeft", panel, w, h ) end
+	self.btnLeft.Paint = function( panel, w, h ) derma.SkinHook( "PaintButtonLeft", panel, w, h ) end
 
 	self.btnRight = vgui.Create( "DButton", self )
 	self.btnRight:SetText( "" )
-	self.btnRight.Paint = function( panel, w, h ) derma.SkinHook( "Paint", "ButtonRight", panel, w, h ) end
+	self.btnRight.Paint = function( panel, w, h ) derma.SkinHook( "PaintButtonRight", panel, w, h ) end
 
 end
 

--- a/garrysmod/lua/vgui/diconbrowser.lua
+++ b/garrysmod/lua/vgui/diconbrowser.lua
@@ -84,7 +84,7 @@ function PANEL:Fill()
 
 				if ( self.m_pSelectedIcon != btn ) then return end
 
-				derma.SkinHook( "Paint", "Selection", btn, w, h )
+				derma.SkinHook( "PaintSelection", btn, w, h )
 
 			end
 
@@ -119,7 +119,7 @@ function PANEL:Paint( w, h )
 
 	if ( !self.Filled ) then self:Fill() end
 
-	derma.SkinHook( "Paint", "Tree", self, w, h )
+	derma.SkinHook( "PaintTree", self, w, h )
 
 end
 

--- a/garrysmod/lua/vgui/dlistbox.lua
+++ b/garrysmod/lua/vgui/dlistbox.lua
@@ -65,7 +65,7 @@ local PANEL = {}
 AccessorFunc( PANEL, "m_bSelectMultiple", "Multiple", FORCE_BOOL )
 AccessorFunc( PANEL, "SelectedItems", "SelectedItems" )	-- All selected in a table
 
-Derma_Hook( PANEL, "Paint", "Paint", "ListBox" )
+Derma_Hook( PANEL, "Paint", "PaintListBox" )
 
 function PANEL:Init()
 

--- a/garrysmod/lua/vgui/dlistview.lua
+++ b/garrysmod/lua/vgui/dlistview.lua
@@ -10,7 +10,7 @@ AccessorFunc( PANEL, "m_iDataHeight", "DataHeight" )
 AccessorFunc( PANEL, "m_bMultiSelect", "MultiSelect" )
 AccessorFunc( PANEL, "m_bHideHeaders", "HideHeaders" )
 
-Derma_Hook( PANEL, "Paint", "Paint", "ListView" )
+Derma_Hook( PANEL, "Paint", "PaintListView" )
 
 function PANEL:Init()
 

--- a/garrysmod/lua/vgui/dlistview_column.lua
+++ b/garrysmod/lua/vgui/dlistview_column.lua
@@ -1,9 +1,9 @@
 
 local PANEL = {}
 
-Derma_Hook( PANEL, "Paint", "Paint", "ListViewHeaderLabel" )
-Derma_Hook( PANEL, "ApplySchemeSettings", "Scheme", "ListViewHeaderLabel" )
-Derma_Hook( PANEL, "PerformLayout", "Layout", "ListViewHeaderLabel" )
+Derma_Hook( PANEL, "Paint", "PaintListViewHeaderLabel" )
+Derma_Hook( PANEL, "ApplySchemeSettings", "SchemeListViewHeaderLabel" )
+Derma_Hook( PANEL, "PerformLayout", "LayoutListViewHeaderLabel" )
 
 function PANEL:Init()
 end
@@ -64,9 +64,9 @@ AccessorFunc( PANEL, "m_bFixedWidth", "FixedWidth" )
 AccessorFunc( PANEL, "m_bDesc", "Descending" )
 AccessorFunc( PANEL, "m_iColumnID", "ColumnID" )
 
-Derma_Hook( PANEL, "Paint", "Paint", "ListViewColumn" )
-Derma_Hook( PANEL, "ApplySchemeSettings", "Scheme", "ListViewColumn" )
-Derma_Hook( PANEL, "PerformLayout", "Layout", "ListViewColumn" )
+Derma_Hook( PANEL, "Paint", "PaintListViewColumn" )
+Derma_Hook( PANEL, "ApplySchemeSettings", "SchemeListViewColumn" )
+Derma_Hook( PANEL, "PerformLayout", "LayoutListViewColumn" )
 
 function PANEL:Init()
 

--- a/garrysmod/lua/vgui/dlistview_line.lua
+++ b/garrysmod/lua/vgui/dlistview_line.lua
@@ -29,9 +29,9 @@ derma.DefineControl( "DListViewLabel", "", PANEL, "DLabel" )
 
 local PANEL = {}
 
-Derma_Hook( PANEL, "Paint", "Paint", "ListViewLine" )
-Derma_Hook( PANEL, "ApplySchemeSettings", "Scheme", "ListViewLine" )
-Derma_Hook( PANEL, "PerformLayout", "Layout", "ListViewLine" )
+Derma_Hook( PANEL, "Paint", "PaintListViewLine" )
+Derma_Hook( PANEL, "ApplySchemeSettings", "SchemeListViewLine" )
+Derma_Hook( PANEL, "PerformLayout", "LayoutListViewLine" )
 
 AccessorFunc( PANEL, "m_iID", "ID" )
 AccessorFunc( PANEL, "m_pListView", "ListView" )

--- a/garrysmod/lua/vgui/dmenu.lua
+++ b/garrysmod/lua/vgui/dmenu.lua
@@ -67,7 +67,7 @@ function PANEL:AddSpacer( strText, funcFunction )
 
 	local pnl = vgui.Create( "DPanel", self )
 	pnl.Paint = function( p, w, h )
-		derma.SkinHook( "Paint", "MenuSpacer", p, w, h )
+		derma.SkinHook( "PaintMenuSpacer", p, w, h )
 	end
 
 	pnl:SetTall( 1 )
@@ -137,7 +137,7 @@ function PANEL:Paint( w, h )
 
 	if ( !self:GetPaintBackground() ) then return end
 
-	derma.SkinHook( "Paint", "Menu", self, w, h )
+	derma.SkinHook( "PaintMenu", self, w, h )
 	return true
 
 end
@@ -180,7 +180,7 @@ function PANEL:PerformLayout( w, h )
 
 	self:SetTall( y )
 
-	derma.SkinHook( "Layout", "Menu", self )
+	derma.SkinHook( "LayoutMenu", self )
 
 	DScrollPanel.PerformLayout( self, w, h )
 

--- a/garrysmod/lua/vgui/dmenubar.lua
+++ b/garrysmod/lua/vgui/dmenubar.lua
@@ -5,7 +5,7 @@ AccessorFunc( PANEL, "m_bBackground",		"PaintBackground",	FORCE_BOOL )
 AccessorFunc( PANEL, "m_bBackground",		"DrawBackground",	FORCE_BOOL ) -- deprecated
 AccessorFunc( PANEL, "m_bIsMenuComponent",	"IsMenu",			FORCE_BOOL )
 
-Derma_Hook( PANEL, "Paint", "Paint", "MenuBar" )
+Derma_Hook( PANEL, "Paint", "PaintMenuBar" )
 
 function PANEL:Init()
 

--- a/garrysmod/lua/vgui/dmenuoption.lua
+++ b/garrysmod/lua/vgui/dmenuoption.lua
@@ -21,7 +21,7 @@ function PANEL:SetSubMenu( menu )
 	if ( !IsValid( self.SubMenuArrow ) ) then
 
 		self.SubMenuArrow = vgui.Create( "DPanel", self )
-		self.SubMenuArrow.Paint = function( panel, w, h ) derma.SkinHook( "Paint", "MenuRightArrow", panel, w, h ) end
+		self.SubMenuArrow.Paint = function( panel, w, h ) derma.SkinHook( "PaintMenuRightArrow", panel, w, h ) end
 
 	end
 
@@ -55,7 +55,7 @@ end
 
 function PANEL:Paint( w, h )
 
-	derma.SkinHook( "Paint", "MenuOption", self, w, h )
+	derma.SkinHook( "PaintMenuOption", self, w, h )
 
 	--
 	-- Draw the button text

--- a/garrysmod/lua/vgui/dnumberwang.lua
+++ b/garrysmod/lua/vgui/dnumberwang.lua
@@ -47,7 +47,7 @@ function PANEL:Init()
 	self.Up = vgui.Create( "DButton", self )
 	self.Up:SetText( "" )
 	self.Up.DoClick = function( button, mcode ) self:SetValue( self:GetValue() + self:GetInterval() ) end
-	self.Up.Paint = function( panel, w, h ) derma.SkinHook( "Paint", "NumberUp", panel, w, h ) end
+	self.Up.Paint = function( panel, w, h ) derma.SkinHook( "PaintNumberUp", panel, w, h ) end
 
 	self.Up.OldOnMousePressed = self.Up.OnMousePressed
 	self.Up.OldOnMouseReleased = self.Up.OnMouseReleased
@@ -58,7 +58,7 @@ function PANEL:Init()
 	self.Down = vgui.Create( "DButton", self )
 	self.Down:SetText( "" )
 	self.Down.DoClick = function( button, mcode ) self:SetValue( self:GetValue() - self:GetInterval() ) end
-	self.Down.Paint = function( panel, w, h ) derma.SkinHook( "Paint", "NumberDown", panel, w, h ) end
+	self.Down.Paint = function( panel, w, h ) derma.SkinHook( "PaintNumberDown", panel, w, h ) end
 
 	self.Down.OldOnMousePressed = self.Down.OnMousePressed
 	self.Down.OldOnMouseReleased = self.Down.OnMouseReleased

--- a/garrysmod/lua/vgui/dnumslider.lua
+++ b/garrysmod/lua/vgui/dnumslider.lua
@@ -27,7 +27,7 @@ function PANEL:Init()
 		end
 		self.Slider:OnMousePressed( mcode )
 	end
-	Derma_Hook( self.Slider, "Paint", "Paint", "NumSlider" )
+	Derma_Hook( self.Slider, "Paint", "PaintNumSlider" )
 
 	self.Label = vgui.Create ( "DLabel", self )
 	self.Label:Dock( LEFT )

--- a/garrysmod/lua/vgui/dpanel.lua
+++ b/garrysmod/lua/vgui/dpanel.lua
@@ -9,9 +9,9 @@ AccessorFunc( PANEL, "m_bDisableTabbing",	"TabbingDisabled",	FORCE_BOOL )
 AccessorFunc( PANEL, "m_bDisabled",	"Disabled" )
 AccessorFunc( PANEL, "m_bgColor",	"BackgroundColor" )
 
-Derma_Hook( PANEL, "Paint", "Paint", "Panel" )
-Derma_Hook( PANEL, "ApplySchemeSettings", "Scheme", "Panel" )
-Derma_Hook( PANEL, "PerformLayout", "Layout", "Panel" )
+Derma_Hook( PANEL, "Paint", "PaintPanel" )
+Derma_Hook( PANEL, "ApplySchemeSettings", "SchemePanel" )
+Derma_Hook( PANEL, "PerformLayout", "LayoutPanel" )
 
 function PANEL:Init()
 

--- a/garrysmod/lua/vgui/dpanellist.lua
+++ b/garrysmod/lua/vgui/dpanellist.lua
@@ -329,7 +329,7 @@ end
 
 function PANEL:Paint( w, h )
 
-	derma.SkinHook( "Paint", "PanelList", self, w, h )
+	derma.SkinHook( "PaintPanelList", self, w, h )
 	return true
 
 end

--- a/garrysmod/lua/vgui/dprogress.lua
+++ b/garrysmod/lua/vgui/dprogress.lua
@@ -3,7 +3,7 @@ local PANEL = {}
 
 AccessorFunc( PANEL, "m_fFraction", "Fraction" )
 
-Derma_Hook( PANEL, "Paint", "Paint", "Progress" )
+Derma_Hook( PANEL, "Paint", "PaintProgress" )
 
 function PANEL:Init()
 

--- a/garrysmod/lua/vgui/dpropertysheet.lua
+++ b/garrysmod/lua/vgui/dpropertysheet.lua
@@ -4,7 +4,7 @@ local PANEL = {}
 AccessorFunc( PANEL, "m_pPropertySheet", "PropertySheet" )
 AccessorFunc( PANEL, "m_pPanel", "Panel" )
 
-Derma_Hook( PANEL, "Paint", "Paint", "Tab" )
+Derma_Hook( PANEL, "Paint", "PaintTab" )
 
 function PANEL:Init()
 
@@ -146,7 +146,7 @@ derma.DefineControl( "DTab", "A Tab for use on the PropertySheet", PANEL, "DButt
 
 local PANEL = {}
 
-Derma_Hook( PANEL, "Paint", "Paint", "PropertySheet" )
+Derma_Hook( PANEL, "Paint", "PaintPropertySheet" )
 
 AccessorFunc( PANEL, "m_pActiveTab", "ActiveTab" )
 AccessorFunc( PANEL, "m_iPadding", "Padding" )

--- a/garrysmod/lua/vgui/dscrollbargrip.lua
+++ b/garrysmod/lua/vgui/dscrollbargrip.lua
@@ -12,7 +12,7 @@ end
 
 function PANEL:Paint( w, h )
 
-	derma.SkinHook( "Paint", "ScrollBarGrip", self, w, h )
+	derma.SkinHook( "PaintScrollBarGrip", self, w, h )
 	return true
 
 end

--- a/garrysmod/lua/vgui/dslider.lua
+++ b/garrysmod/lua/vgui/dslider.lua
@@ -13,7 +13,7 @@ AccessorFunc( PANEL, "Dragging", "Dragging" )
 AccessorFunc( PANEL, "m_bTrappedInside", "TrapInside" )
 AccessorFunc( PANEL, "m_iNotches", "Notches" )
 
-Derma_Hook( PANEL, "Paint", "Paint", "Slider" )
+Derma_Hook( PANEL, "Paint", "PaintSlider" )
 
 function PANEL:Init()
 
@@ -26,7 +26,7 @@ function PANEL:Init()
 	self.Knob:SetText( "" )
 	self.Knob:SetSize( 15, 15 )
 	self.Knob:NoClipping( true )
-	self.Knob.Paint = function( panel, w, h ) derma.SkinHook( "Paint", "SliderKnob", panel, w, h ) end
+	self.Knob.Paint = function( panel, w, h ) derma.SkinHook( "PaintSliderKnob", panel, w, h ) end
 	self.Knob.OnCursorMoved = function( panel, x, y )
 		local x, y = panel:LocalToScreen( x, y )
 		x, y = self:ScreenToLocal( x, y )

--- a/garrysmod/lua/vgui/dtextentry.lua
+++ b/garrysmod/lua/vgui/dtextentry.lua
@@ -104,7 +104,7 @@ function PANEL:ApplySchemeSettings()
 
 	self:SetFontInternal( self.m_FontName )
 
-	derma.SkinHook( "Scheme", "TextEntry", self )
+	derma.SkinHook( "SchemeTextEntry", self )
 
 end
 
@@ -255,14 +255,14 @@ end
 
 function PANEL:Paint( w, h )
 
-	derma.SkinHook( "Paint", "TextEntry", self, w, h )
+	derma.SkinHook( "PaintTextEntry", self, w, h )
 	return false
 
 end
 
 function PANEL:PerformLayout()
 
-	derma.SkinHook( "Layout", "TextEntry", self )
+	derma.SkinHook( "LayoutTextEntry", self )
 
 end
 

--- a/garrysmod/lua/vgui/dtooltip.lua
+++ b/garrysmod/lua/vgui/dtooltip.lua
@@ -91,7 +91,7 @@ end
 function PANEL:Paint( w, h )
 
 	self:PositionTooltip()
-	derma.SkinHook( "Paint", "Tooltip", self, w, h )
+	derma.SkinHook( "PaintTooltip", self, w, h )
 
 end
 

--- a/garrysmod/lua/vgui/dtree.lua
+++ b/garrysmod/lua/vgui/dtree.lua
@@ -69,7 +69,7 @@ end
 
 function PANEL:Paint( w, h )
 
-	derma.SkinHook( "Paint", "Tree", self, w, h )
+	derma.SkinHook( "PaintTree", self, w, h )
 	return true
 
 end

--- a/garrysmod/lua/vgui/dtree_node.lua
+++ b/garrysmod/lua/vgui/dtree_node.lua
@@ -638,7 +638,7 @@ end
 
 function PANEL:Paint( w, h )
 
-	derma.SkinHook( "Paint", "TreeNode", self, w, h )
+	derma.SkinHook( "PaintTreeNode", self, w, h )
 
 end
 

--- a/garrysmod/lua/vgui/dtree_node_button.lua
+++ b/garrysmod/lua/vgui/dtree_node_button.lua
@@ -10,7 +10,7 @@ end
 
 function PANEL:Paint( w, h )
 
-	derma.SkinHook( "Paint", "TreeNodeButton", self, w, h )
+	derma.SkinHook( "PaintTreeNodeButton", self, w, h )
 
 	--
 	-- Draw the button text

--- a/garrysmod/lua/vgui/dvscrollbar.lua
+++ b/garrysmod/lua/vgui/dvscrollbar.lua
@@ -56,12 +56,12 @@ function PANEL:Init()
 	self.btnUp = vgui.Create( "DButton", self )
 	self.btnUp:SetText( "" )
 	self.btnUp.DoClick = function( self ) self:GetParent():AddScroll( -1 ) end
-	self.btnUp.Paint = function( panel, w, h ) derma.SkinHook( "Paint", "ButtonUp", panel, w, h ) end
+	self.btnUp.Paint = function( panel, w, h ) derma.SkinHook( "PaintButtonUp", panel, w, h ) end
 
 	self.btnDown = vgui.Create( "DButton", self )
 	self.btnDown:SetText( "" )
 	self.btnDown.DoClick = function( self ) self:GetParent():AddScroll( 1 ) end
-	self.btnDown.Paint = function( panel, w, h ) derma.SkinHook( "Paint", "ButtonDown", panel, w, h ) end
+	self.btnDown.Paint = function( panel, w, h ) derma.SkinHook( "PaintButtonDown", panel, w, h ) end
 
 	self.btnGrip = vgui.Create( "DScrollBarGrip", self )
 
@@ -202,7 +202,7 @@ end
 
 function PANEL:Paint( w, h )
 
-	derma.SkinHook( "Paint", "VScrollBar", self, w, h )
+	derma.SkinHook( "PaintVScrollBar", self, w, h )
 	return true
 
 end

--- a/garrysmod/lua/vgui/propselect.lua
+++ b/garrysmod/lua/vgui/propselect.lua
@@ -23,7 +23,7 @@ function PANEL:Init()
 	self.List:SetSpacing( 1 )
 	self.List:SetPadding( 3 )
 
-	Derma_Hook( self.List, "Paint", "Paint", "Panel" )
+	Derma_Hook( self.List, "Paint", "PaintPanel" )
 
 	self.Controls = {}
 	self.Height = 2


### PR DESCRIPTION
Also removes useless concatenation of hookType and hookName arguments that will break thirdparty implementations of derma.SkinHook & Derma_Hook

`derma.SkinHook( "Paint", "Frame", panel, width, height )` turns into `derma.SkinHook( "PaintFrame", panel, width, height )`
`Derma_Hook( PANEL, "Paint", "Paint", "Frame" )` turns into `Derma_Hook( PANEL, "Paint", "PaintFrame" )`