### PR TITLE
SmoothDamp function for math.* and vectors.

### DIFF
--- a/garrysmod/lua/includes/extensions/math.lua
+++ b/garrysmod/lua/includes/extensions/math.lua
@@ -215,3 +215,30 @@ end
 function math.Remap( value, inMin, inMax, outMin, outMax )
 	return outMin + ( ( ( value - inMin ) / ( inMax - inMin ) ) * ( outMax - outMin ) )
 end
+
+function math.SmoothDamp( current, target, current_velocity, smooth_time, max_speed, delta_time )
+	smooth_time = math.max( 1e-4, smooth_time )
+	max_speed = max_speed or math.huge
+	delta_time = delta_time or FrameTime()
+
+	local omega = 2 / smooth_time
+	local x = omega * delta_time
+	local max_length = max_speed * smooth_time
+	local exp = 1 / ( 1 + x + 0.48 * x * x + 0.235 * x * x * x )
+
+	local delta = math.Clamp( current - target, -max_length, max_length )
+
+	local new_target = current - delta
+
+	local tmp = ( current_velocity + delta * omega ) * delta_time
+	local output = new_target + ( delta + tmp ) * exp
+
+	current_velocity = ( current_velocity - omega * tmp ) * exp
+
+	if ( target - current > 0 ) == ( output > target ) then
+		output = target
+		current_velocity = ( output - target ) / delta_time
+	end
+
+	return output, current_velocity
+end

--- a/garrysmod/lua/includes/extensions/vector.lua
+++ b/garrysmod/lua/includes/extensions/vector.lua
@@ -1,12 +1,47 @@
 local meta = FindMetaTable( "Vector" )
 
--- Nothing in here, still leaving this file here just in case
-
 --[[---------------------------------------------------------
 	Converts Vector To Color - alpha precision lost, must reset
 -----------------------------------------------------------]]
 function meta:ToColor( )
+	return Color( self[1] * 255, self[2] * 255, self[3] * 255 )
+end
 
-	return Color( self.x * 255, self.y * 255, self.z * 255 )
+function meta:ClampLength( max )
+	if self:LengthSqr() > max * max then
+		self:Normalize()
+		self:Mul( max )
+	end
+end
 
+function meta.SmoothDamp( current, target, current_velocity, smooth_time, max_speed, delta_time )
+	smooth_time = math.max( 1e-4, smooth_time )
+	max_speed = max_speed or math.huge
+	delta_time = delta_time or FrameTime()
+
+	local omega = 2 / smooth_time
+	local x = omega * delta_time
+	local max_length = max_speed * smooth_time
+	local exp = 1 / ( 1 + x + 0.48 * x * x + 0.235 * x * x * x )
+
+	local delta = current - target
+	delta:ClampLength( max_length )
+
+	local new_target = current - delta
+
+	local tmp = ( current_velocity + ( delta * omega ) ) * delta_time
+	local output = new_target + ( delta + tmp ) * exp
+
+	current_velocity:Sub( tmp * omega )
+	current_velocity:Mul( exp )
+
+	if ( target - current ):Dot( output - target ) > 0 then
+		output = target
+
+		current_velocity[1] = 0
+		current_velocity[2] = 0
+		current_velocity[3] = 0
+	end
+
+	return output
 end

--- a/garrysmod/lua/includes/extensions/vector.lua
+++ b/garrysmod/lua/includes/extensions/vector.lua
@@ -43,5 +43,5 @@ function meta.SmoothDamp( current, target, current_velocity, smooth_time, max_sp
 		current_velocity[3] = 0
 	end
 
-	return output
+	return output, current_velocity
 end


### PR DESCRIPTION
Critically damped smoothing function for the math library and Vector metatable. Useful for camera motion, path following, and as an alternative to `Lerp`/`LerpVector`.

Produces smoother results than `Lerp`/`LerpVector` with a constant fraction argument.

Based on `Game Programming Gems 4` chapter 1.10.