### PR TITLE
Refactor gmod_hands hooks

### DIFF
--- a/garrysmod/gamemodes/base/entities/entities/gmod_hands.lua
+++ b/garrysmod/gamemodes/base/entities/entities/gmod_hands.lua
@@ -13,7 +13,9 @@ function ENT:Initialize()
 	self.viewHookID = "HandsViewModelChanged_" .. self:EntIndex()
 
 	if ( SERVER or self:GetOwner() == LocalPlayer() ) then
-		hook.Add( "OnViewModelChanged", self.viewHookID, self.ViewModelChanged )
+		hook.Add( "OnViewModelChanged", self.viewHookID, function( ... )
+			self:ViewModelChanged( ... )
+		end )
 
 		self:CallOnRemove( "RemoveViewModelChangedHook", function()
 			hook.Remove( "OnViewModelChanged", self.viewHookID )

--- a/garrysmod/gamemodes/base/entities/entities/gmod_hands.lua
+++ b/garrysmod/gamemodes/base/entities/entities/gmod_hands.lua
@@ -6,18 +6,21 @@ ENT.RenderGroup = RENDERGROUP_OTHER
 
 function ENT:Initialize()
 
+	self:SetNotSolid( true )
+	self:DrawShadow( false )
+	self:SetTransmitWithParent( true ) -- Transmit only when the viewmodel does!
+
+	-- We only need to worry about view model changes on the client that owns these hands
+	if not CLIENT then return end
+	if self:GetOwner() ~= LocalPlayer() then return end
+
 	self.viewHookID = "HandsViewModelChanged_" .. self:EntIndex()
 
 	self:CallOnRemove( "RemoveViewModelChangedHook", function()
 		hook.Remove( "OnViewModelChanged", self.viewHookID )
 	end )
 
-	-- TODO: Is this hook needed on both realms?
 	hook.Add( "OnViewModelChanged", self.viewHookID, self.ViewModelChanged )
-
-	self:SetNotSolid( true )
-	self:DrawShadow( false )
-	self:SetTransmitWithParent( true ) -- Transmit only when the viewmodel does!
 
 end
 
@@ -56,10 +59,7 @@ end
 function ENT:ViewModelChanged( vm, old, new )
 
 	-- Ignore other peoples viewmodel changes!
-	if ( vm:GetOwner() != self:GetOwner() ) then
-		if CLIENT then hook.Remove( "OnViewModelChanged", self.viewHookID ) end
-		return
-	end
+	if ( vm:GetOwner() != self:GetOwner() ) then return end
 
 	self:AttachToViewmodel( vm )
 

--- a/garrysmod/gamemodes/base/entities/entities/gmod_hands.lua
+++ b/garrysmod/gamemodes/base/entities/entities/gmod_hands.lua
@@ -6,7 +6,14 @@ ENT.RenderGroup = RENDERGROUP_OTHER
 
 function ENT:Initialize()
 
-	hook.Add( "OnViewModelChanged", self, self.ViewModelChanged )
+	self.viewHookID = "HandsViewModelChanged_" .. self:EntIndex()
+
+	self:CallOnRemove( "RemoveViewModelChangedHook", function()
+		hook.Remove( "OnViewModelChanged", self.viewHookID )
+	end )
+
+	-- TODO: Is this hook needed on both realms?
+	hook.Add( "OnViewModelChanged", self.viewHookID, self.ViewModelChanged )
 
 	self:SetNotSolid( true )
 	self:DrawShadow( false )
@@ -49,7 +56,10 @@ end
 function ENT:ViewModelChanged( vm, old, new )
 
 	-- Ignore other peoples viewmodel changes!
-	if ( vm:GetOwner() != self:GetOwner() ) then return end
+	if ( vm:GetOwner() != self:GetOwner() ) then
+		if CLIENT then hook.Remove( "OnViewModelChanged", self.viewHookID ) end
+		return
+	end
 
 	self:AttachToViewmodel( vm )
 

--- a/garrysmod/gamemodes/base/entities/entities/gmod_hands.lua
+++ b/garrysmod/gamemodes/base/entities/entities/gmod_hands.lua
@@ -10,17 +10,15 @@ function ENT:Initialize()
 	self:DrawShadow( false )
 	self:SetTransmitWithParent( true ) -- Transmit only when the viewmodel does!
 
-	-- We only need to worry about view model changes on the client that owns these hands
-	if not CLIENT then return end
-	if self:GetOwner() ~= LocalPlayer() then return end
-
 	self.viewHookID = "HandsViewModelChanged_" .. self:EntIndex()
 
-	self:CallOnRemove( "RemoveViewModelChangedHook", function()
-		hook.Remove( "OnViewModelChanged", self.viewHookID )
-	end )
+	if ( SERVER or self:GetOwner() == LocalPlayer() ) then
+		hook.Add( "OnViewModelChanged", self.viewHookID, self.ViewModelChanged )
 
-	hook.Add( "OnViewModelChanged", self.viewHookID, self.ViewModelChanged )
+		self:CallOnRemove( "RemoveViewModelChangedHook", function()
+			hook.Remove( "OnViewModelChanged", self.viewHookID )
+		end )
+	end
 
 end
 


### PR DESCRIPTION
Currently, `gmod_hands` creates a hook on `OnViewModelChanged` on both realms when initialized.

On our server, likely due to some addon conflict (ULX?), these hooks aren't cleaned up when the hands are deleted, leading to a massive pileup of hooks with entities as identifiers. Entity-identified hooks are supposed to be cleaned up by the hook system, so this isn't technically an issue with Gmod, but I don't see any reason not to use a string anyway.

**This PR aims to address three issues:**
1. Creating a hook with an entity as an identifier is technically less performant than using strings, as the entities will need to be validity checked every time the hook is run
2. `gmod_hands` currently do not handle their own hook cleanup
3. Hooks are created on every client, for every `gmod_hands` created. This is unnecessary. Because these directly relate to view models, only the client who owns the hands needs to care about them


**Extra notes:**

 - I believe that the hooks do not need to be made serverside at all, but I've been instructed to leave them to maintain compatibility. If others feel strongly otherwise, it's an easy change to ignore the hook serverside

 - While I was able to briefly test on the three major gamemodes (sandbox, darkrp, ttt) without issue, I'm unsure of how custom content might rely on the existing behavior, so if anyone has more insight on that, please share

 - There is another check in `ENT:OnViewModelChanged` that I don't believe needs to be there anymore, but that won't hurt to leave in. I'll work on testing it with and without to make sure it won't break anything, but I'm opening the PR without that change because it'll work either way

 - I believe the best way to address all of these issues succinctly is to make `gmod_hands` a clientside entity, but I didn't want to go overboard, so this is a middle-ground solution until a better one is proposed

 - While addressing the problem of other players' hands adding hooks to each client, I added an ownership check to make sure that `self:GetOwner() == LocalPlayer()`. This is fine so long as the hands have their owner set properly _before_ running `:Spawn()` on them. The default gamemodes do this properly by calling `ENT:DoSetup( ply )`, but anything else that relies on this without setting that ownership won't have the hooks added on any client (`self:GetOwner() == nil, nil ~= LocalPlayer()`)
