### PR TITLE
Add default value and custom validators to AccessorFunc

### DIFF
--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -175,26 +175,30 @@ FORCE_BOOL		= 3
 	AccessorFunc
 	Quickly make Get/Set accessor fuctions on the specified table
 -----------------------------------------------------------]]
-function AccessorFunc( tab, varname, name, iForce )
+function AccessorFunc( tab, varname, name, iForce, default )
 
 	if ( !tab ) then debug.Trace() end
 
 	tab[ "Get" .. name ] = function( self ) return self[ varname ] end
-
-	if ( iForce == FORCE_STRING ) then
-		tab[ "Set" .. name ] = function( self, v ) self[ varname ] = tostring( v ) end
-	return end
-
-	if ( iForce == FORCE_NUMBER ) then
-		tab[ "Set" .. name ] = function( self, v ) self[ varname ] = tonumber( v ) end
-	return end
-
-	if ( iForce == FORCE_BOOL ) then
-		tab[ "Set" .. name ] = function( self, v ) self[ varname ] = tobool( v ) end
-	return end
-
-	tab[ "Set" .. name ] = function( self, v ) self[ varname ] = v end
-
+	
+	local setFunc
+	
+	if ( isfunction( iForce ) ) then
+		setFunc = function( self, v ) self[ varname ] = iForce( v ) end
+	elseif ( iForce == FORCE_STRING ) then
+		setFunc = function( self, v ) self[ varname ] = tostring( v ) end
+	elseif ( iForce == FORCE_NUMBER ) then
+		setFunc = function( self, v ) self[ varname ] = tonumber( v ) end
+	elseif ( iForce == FORCE_BOOL ) then
+		setFunc = function( self, v ) self[ varname ] = tobool( v ) end
+	else
+		setFunc = function( self, v ) self[ varname ] = v end
+	end
+	
+	tab[ "Set" .. name ] = setFunc
+	
+	if ( default != nil ) then setFunc( tab, default ) end
+	
 end
 
 --[[---------------------------------------------------------


### PR DESCRIPTION
As the title states. Default values are nice and custom validators would be very useful.

Some examples:

```
local tab = {}


function FORCE_PLAYER(v)
	return isentity(v) and v:IsValid() and v:IsPlayer() and v or NULL
end
AccessorFunc(tab, "m_Player", "Player", FORCE_PLAYER, NULL)
tab:SetPlayer(player.GetAll()[1])
tab:SetPlayer("lol")
tab:SetPlayer(5)


function FORCE_STEAMID(v)
	return string.match(tostring(v), "^STEAM_[0-5]:[01]:%d+$") or "UNKNOWN"
end
AccessorFunc(tab, "m_SteamID", "SteamID", FORCE_STEAMID, "")
tab:SetSteamID("STEAM_1:1:123456")
tab:SetSteamID("STEAM_9:1:123456")
tab:SetSteamID("STEAM_1:1:")


function FORCE_BETWEEN(a, b)
	return function(v) return math.Clamp(tonumber(v), a, b) end
end
AccessorFunc(tab, "m_Test", "Test", FORCE_BETWEEN(5, 10), 1)
tab:SetTest(2)
tab:SetTest(7)
tab:SetTest(13)


PrintTable(tab)
```