### PR TITLE
Markup Library Improvements

### DIFF
--- a/garrysmod/lua/includes/modules/markup.lua
+++ b/garrysmod/lua/includes/modules/markup.lua
@@ -245,10 +245,14 @@ end
 	Desc: Converts a string to its escaped, markup-safe equivalent
 	Usage: markup.Escape("<font=Default>The font will remain unchanged & these < > & symbols will also appear normally</font>")
 -----------------------------------------------------------]]
-local escapeEntities = {
+local escapeEntities, unescapeEntities = {
 	["&"] = "&amp;",
 	["<"] = "&lt;",
 	[">"] = "&gt;"
+}, {
+	["&amp;"] = "&",
+	["&lt;"] = "<",
+	["&gt;"] = ">"
 }
 function Escape( str )
 	return ( string.gsub( tostring( str ), "[&<>]", escapeEntities ) )
@@ -293,10 +297,8 @@ function Parse( ml, maxwidth )
 	for i, blk in ipairs( blocks ) do
 
 		surface.SetFont( blocks[ i ].font )
-
-		blocks[ i ].text = string.gsub( blocks[ i ].text, "&gt;", ">" )
-		blocks[ i ].text = string.gsub( blocks[ i ].text, "&lt;", "<" )
-		blocks[ i ].text = string.gsub( blocks[ i ].text, "&amp;", "&" )
+		
+		blocks[ i ].text = string.gsub( blocks[ i ].text, "(&.-;)", unescapeEntities )
 
 		local thisY = 0
 		local curString = ""

--- a/garrysmod/lua/includes/modules/markup.lua
+++ b/garrysmod/lua/includes/modules/markup.lua
@@ -402,18 +402,14 @@ function Parse( ml, maxwidth )
 							end
 						end
 
-						local previous_blk = new_block_list[ #new_block_list ]
+						local previous_block = new_block_list[ #new_block_list ]
 						local wrap = lastSpacePos == string.len( curString ) && lastSpacePos > 0
-						if ( wrap and surface.GetTextSize( blk.text ) < maxwidth ) then
-							-- Wrap the block onto the next line first, as we can probably fit it there
-							if ( previous_blk ) then
-								local trimmed, trimCharNum = previous_blk.text:gsub(" +$", "")
-								if ( trimCharNum > 0 ) then
-									previous_blk.text = trimmed
-								else
-									previous_blk.text = previous_blk.text .. "-"
-								end
-								previous_blk.thisX = surface.GetTextSize( previous_blk.text )
+						if ( previous_block and previous_block.text:match(" $") and wrap and surface.GetTextSize( blk.text ) < maxwidth ) then
+							-- If the block was preceded by a space, wrap the block onto the next line first, as we can probably fit it there
+							local trimmed, trimCharNum = previous_block.text:gsub(" +$", "")
+							if ( trimCharNum > 0 ) then
+								previous_block.text = trimmed
+								previous_block.thisX = surface.GetTextSize( previous_block.text )
 							end
 						else
 							if ( wrap ) then
@@ -423,6 +419,7 @@ function Parse( ml, maxwidth )
 								j = utf8.offset( curString, 1, sequenceStartPos )
 								curString = string.sub( curString, 1, sequenceStartPos - 1 )
 							else
+								-- Otherwise, strip the trailing space and start a new line
 								ch = string.sub( curString, lastSpacePos + 1 ) .. ch
 								j = lastSpacePos + 1
 								curString = string.sub( curString, 1, math.max( lastSpacePos - 1, 0 ) )

--- a/garrysmod/lua/includes/modules/markup.lua
+++ b/garrysmod/lua/includes/modules/markup.lua
@@ -296,13 +296,13 @@ function Parse( ml, maxwidth )
 	local lineHeight = 0
 	for i, blk in ipairs( blocks ) do
 
-		surface.SetFont( blocks[ i ].font )
+		surface.SetFont( blk.font )
 		
-		blocks[ i ].text = string.gsub( blocks[ i ].text, "(&.-;)", unescapeEntities )
+		blk.text = string.gsub( blk.text, "(&.-;)", unescapeEntities )
 
 		local thisY = 0
 		local curString = ""
-		for j, c in utf8.codes( blocks[ i ].text ) do
+		for j, c in utf8.codes( blk.text ) do
 
 			local ch = utf8.char( c )
 
@@ -318,15 +318,17 @@ function Parse( ml, maxwidth )
 				if ( string.len( curString ) > 0 ) then
 					local x1 = surface.GetTextSize( curString )
 
-					local new_block = {}
-					new_block.text = curString
-					new_block.font = blocks[ i ].font
-					new_block.colour = blocks[ i ].colour
-					new_block.thisY = thisY
-					new_block.thisX = x1
-					new_block.offset = {}
-					new_block.offset.x = xOffset
-					new_block.offset.y = yOffset
+					local new_block = {
+						text = curString,
+						font = blk.font,
+						colour = blk.colour,
+						thisY = thisY,
+						thisX = x1,
+						offset = {
+							x = xOffset,
+							y = yOffset
+						}
+					}
 					table.insert( new_block_list, new_block )
 					if ( xOffset + x1 > xMax ) then
 						xMax = xOffset + x1
@@ -345,15 +347,17 @@ function Parse( ml, maxwidth )
 				if ( string.len( curString ) > 0 ) then
 					local x1 = surface.GetTextSize( curString )
 
-					local new_block = {}
-					new_block.text = curString
-					new_block.font = blocks[ i ].font
-					new_block.colour = blocks[ i ].colour
-					new_block.thisY = thisY
-					new_block.thisX = x1
-					new_block.offset = {}
-					new_block.offset.x = xOffset
-					new_block.offset.y = yOffset
+					local new_block = {
+						text = curString,
+						font = blk.font,
+						colour = blk.colour,
+						thisY = thisY,
+						thisX = x1,
+						offset = {
+							x = xOffset,
+							y = yOffset
+						}
+					}
 					table.insert( new_block_list, new_block )
 					if ( xOffset + x1 > xMax ) then
 						xMax = xOffset + x1
@@ -441,15 +445,17 @@ function Parse( ml, maxwidth )
 								lineHeight = y1
 							end
 
-							local new_block = {}
-							new_block.text = curString
-							new_block.font = blocks[ i ].font
-							new_block.colour = blocks[ i ].colour
-							new_block.thisY = thisY
-							new_block.thisX = x1
-							new_block.offset = {}
-							new_block.offset.x = xOffset
-							new_block.offset.y = yOffset
+							local new_block = {
+								text = curString,
+								font = blk.font,
+								colour = blk.colour,
+								thisY = thisY,
+								thisX = x1,
+								offset = {
+									x = xOffset,
+									y = yOffset
+								}
+							}
 							table.insert( new_block_list, new_block )
 
 							if ( xOffset + x1 > xMax ) then
@@ -485,15 +491,17 @@ function Parse( ml, maxwidth )
 
 			local x1 = surface.GetTextSize( curString )
 
-			local new_block = {}
-			new_block.text = curString
-			new_block.font = blocks[ i ].font
-			new_block.colour = blocks[ i ].colour
-			new_block.thisY = thisY
-			new_block.thisX = x1
-			new_block.offset = {}
-			new_block.offset.x = xOffset
-			new_block.offset.y = yOffset
+			local new_block = {
+				text = curString,
+				font = blk.font,
+				colour = blk.colour,
+				thisY = thisY,
+				thisX = x1,
+				offset = {
+					x = xOffset,
+					y = yOffset
+				}
+			}
 			table.insert( new_block_list, new_block )
 
 			lineHeight = thisY

--- a/garrysmod/lua/includes/modules/markup.lua
+++ b/garrysmod/lua/includes/modules/markup.lua
@@ -3,7 +3,7 @@ local string = string
 local table = table
 local surface = surface
 local tostring = tostring
-local pairs = pairs
+local ipairs = ipairs
 local setmetatable = setmetatable
 local math = math
 local utf8 = utf8
@@ -174,6 +174,15 @@ function MarkupObject:GetWidth()
 end
 
 --[[---------------------------------------------------------
+	Name: MarkupObject:GetMaxWidth()
+	Desc: Returns the maximum width of a markup block
+	Usage: ml:GetMaxWidth()
+-----------------------------------------------------------]]
+function MarkupObject:GetMaxWidth()
+	return self.maxWidth or self.totalWidth
+end
+
+--[[---------------------------------------------------------
 	Name: MarkupObject:GetHeight()
 	Desc: Returns the height of a markup block
 	Usage: ml:GetHeight()
@@ -188,14 +197,14 @@ end
 
 --[[---------------------------------------------------------
 	Name: MarkupObject:Draw(xOffset, yOffset, halign, valign, alphaoverride)
-	Desc: Draw the markup text to the screen as position
-		  xOffset, yOffset. Halign and Valign can be used
-		  to align the text. Alphaoverride can be used to override
-		  the alpha value of the text-colour.
+	Desc: Draw the markup text to the screen as position xOffset, yOffset.
+		  Halign and Valign can be used to align the text relative to its offset.
+		  Alphaoverride can be used to override the alpha value of the text-colour.
+		  textAlign can be used to align the actual text inside of its bounds.
 	Usage: MarkupObject:Draw(100, 100)
 -----------------------------------------------------------]]
-function MarkupObject:Draw( xOffset, yOffset, halign, valign, alphaoverride )
-	for i, blk in pairs( self.blocks ) do
+function MarkupObject:Draw( xOffset, yOffset, halign, valign, alphaoverride, textAlign )
+	for i, blk in ipairs( self.blocks ) do
 		local y = yOffset + ( blk.height - blk.thisY ) + blk.offset.y
 		local x = xOffset
 
@@ -214,9 +223,35 @@ function MarkupObject:Draw( xOffset, yOffset, halign, valign, alphaoverride )
 
 		surface.SetFont( blk.font )
 		surface.SetTextColor( blk.colour.r, blk.colour.g, blk.colour.b, alpha )
+
 		surface.SetTextPos( x, y )
+		if ( textAlign ~= TEXT_ALIGN_LEFT and self.maxWidth ) then
+			local lineWidth = self.lineWidths[ blk.offset.y ]
+			if ( lineWidth ) then
+				if ( textAlign == TEXT_ALIGN_CENTER ) then
+					surface.SetTextPos( x + ( ( self.maxWidth - lineWidth ) / 2 ), y )
+				elseif ( textAlign == TEXT_ALIGN_RIGHT ) then
+					surface.SetTextPos( x + ( self.maxWidth - lineWidth ), y )
+				end
+			end
+		end
+
 		surface.DrawText( blk.text )
 	end
+end
+
+--[[---------------------------------------------------------
+	Name: Escape(str)
+	Desc: Converts a string to its escaped, markup-safe equivalent
+	Usage: markup.Escape("<font=Default>The font will remain unchanged & these < > & symbols will also appear normally</font>")
+-----------------------------------------------------------]]
+local escapeEntities = {
+	["&"] = "&amp;",
+	["<"] = "&lt;",
+	[">"] = "&gt;"
+}
+function Escape( str )
+	return ( string.gsub( tostring( str ), "[&<>]", escapeEntities ) )
 end
 
 --[[---------------------------------------------------------
@@ -227,7 +262,8 @@ end
 		  \n and \t are also available to move to the next line,
 		  or insert a tab character.
 		  Maxwidth can be used to make the text wrap to a specific
-		  width.
+		  width and allows for text alignment (e.g. centering) inside
+		  the bounds.
 	Usage: markup.Parse("<font=Default>changed font</font>\n<colour=255,0,255,255>changed colour</colour>")
 -----------------------------------------------------------]]
 function Parse( ml, maxwidth )
@@ -251,17 +287,19 @@ function Parse( ml, maxwidth )
 	local thisMaxY = 0
 	local new_block_list = {}
 	local ymaxes = {}
+	local lineWidths = {}
 
 	local lineHeight = 0
-	for i, blk in pairs( blocks ) do
+	for i, blk in ipairs( blocks ) do
 
 		surface.SetFont( blocks[ i ].font )
 
+		blocks[ i ].text = string.gsub( blocks[ i ].text, "&gt;", ">" )
+		blocks[ i ].text = string.gsub( blocks[ i ].text, "&lt;", "<" )
+		blocks[ i ].text = string.gsub( blocks[ i ].text, "&amp;", "&" )
+
 		local thisY = 0
 		local curString = ""
-		blocks[ i ].text = string.gsub( blocks[i].text, "&gt;", ">" )
-		blocks[ i ].text = string.gsub( blocks[i].text, "&lt;", "<" )
-		blocks[ i ].text = string.gsub( blocks[i].text, "&amp;", "&" )
 		for j, c in utf8.codes( blocks[ i ].text ) do
 
 			local ch = utf8.char( c )
@@ -276,7 +314,7 @@ function Parse( ml, maxwidth )
 				end
 
 				if ( string.len( curString ) > 0 ) then
-					local x1, y1 = surface.GetTextSize( curString )
+					local x1 = surface.GetTextSize( curString )
 
 					local new_block = {}
 					new_block.text = curString
@@ -303,7 +341,7 @@ function Parse( ml, maxwidth )
 			elseif ( ch == "\t" ) then
 
 				if ( string.len( curString ) > 0 ) then
-					local x1, y1 = surface.GetTextSize( curString )
+					local x1 = surface.GetTextSize( curString )
 
 					local new_block = {}
 					new_block.text = curString
@@ -319,15 +357,30 @@ function Parse( ml, maxwidth )
 						xMax = xOffset + x1
 					end
 				end
+				
+				curString = ""
 
 				local xOldSize = xSize
 				xSize = 0
-				curString = ""
 				local xOldOffset = xOffset
 				xOffset = math.ceil( ( xOffset + xOldSize ) / 50 ) * 50
 
 				if ( xOffset == xOldOffset ) then
 					xOffset = xOffset + 50
+					
+					if ( maxwidth and xOffset > maxwidth ) then
+						-- Needs a new line
+						if ( thisY == 0 ) then
+							thisY = lineHeight
+							thisMaxY = lineHeight
+						else
+							lineHeight = thisY
+						end
+						xOffset = 0
+						yOffset = yOffset + thisMaxY
+						thisY = 0
+						thisMaxY = 0
+					end
 				end
 			else
 				local x, y = surface.GetTextSize( ch )
@@ -339,7 +392,6 @@ function Parse( ml, maxwidth )
 
 						-- need to: find the previous space in the curString
 						--          if we can't find one, take off the last character
-						--          and add a -. add the character to ch
 						--          and insert as a new block, incrementing the y etc
 
 						local lastSpacePos = string.len( curString )
@@ -350,44 +402,62 @@ function Parse( ml, maxwidth )
 							end
 						end
 
-						if ( lastSpacePos == string.len( curString ) && lastSpacePos > 0 ) then
-							local sequenceStartPos = utf8.offset( curString, 0, lastSpacePos )
-							ch = string.match( curString, utf8.charpattern, sequenceStartPos ) .. ch
-							j = utf8.offset( curString, 1, sequenceStartPos )
-							curString = string.sub( curString, 1, sequenceStartPos - 1 )
+						local previous_blk = new_block_list[ #new_block_list ]
+						local wrap = lastSpacePos == string.len( curString ) && lastSpacePos > 0
+						if ( wrap and surface.GetTextSize( blk.text ) < maxwidth ) then
+							-- Wrap the block onto the next line first, as we can probably fit it there
+							if ( previous_blk ) then
+								local trimmed, trimCharNum = previous_blk.text:gsub(" +$", "")
+								if ( trimCharNum > 0 ) then
+									previous_blk.text = trimmed
+								else
+									previous_blk.text = previous_blk.text .. "-"
+								end
+								previous_blk.thisX = surface.GetTextSize( previous_blk.text )
+							end
 						else
-							ch = string.sub( curString, lastSpacePos + 1 ) .. ch
-							j = lastSpacePos + 1
-							curString = string.sub( curString, 1, lastSpacePos )
-						end
+							if ( wrap ) then
+								-- If the block takes up multiple lines (and has no spaces), split it up
+								local sequenceStartPos = utf8.offset( curString, 0, lastSpacePos )
+								ch = string.match( curString, utf8.charpattern, sequenceStartPos ) .. ch
+								j = utf8.offset( curString, 1, sequenceStartPos )
+								curString = string.sub( curString, 1, sequenceStartPos - 1 )
+							else
+								ch = string.sub( curString, lastSpacePos + 1 ) .. ch
+								j = lastSpacePos + 1
+								curString = string.sub( curString, 1, math.max( lastSpacePos - 1, 0 ) )
+							end
 
-						local m = 1
-						while string.sub( ch, m, m ) == " " do
-							m = m + 1
-						end
-						ch = string.sub( ch, m )
+							local m = 1
+							while string.sub( ch, m, m ) == " " do
+								m = m + 1
+							end
+							ch = string.sub( ch, m )
 
-						local x1,y1 = surface.GetTextSize( curString )
+							local x1,y1 = surface.GetTextSize( curString )
 
-						if ( y1 > thisMaxY ) then
-							thisMaxY = y1
-							ymaxes[ yOffset ] = thisMaxY
-							lineHeight = y1
-						end
+							if ( y1 > thisMaxY ) then
+								thisMaxY = y1
+								ymaxes[ yOffset ] = thisMaxY
+								lineHeight = y1
+							end
 
-						local new_block = {}
-						new_block.text = curString
-						new_block.font = blocks[ i ].font
-						new_block.colour = blocks[ i ].colour
-						new_block.thisY = thisY
-						new_block.thisX = x1
-						new_block.offset = {}
-						new_block.offset.x = xOffset
-						new_block.offset.y = yOffset
-						table.insert( new_block_list, new_block )
+							local new_block = {}
+							new_block.text = curString
+							new_block.font = blocks[ i ].font
+							new_block.colour = blocks[ i ].colour
+							new_block.thisY = thisY
+							new_block.thisX = x1
+							new_block.offset = {}
+							new_block.offset.x = xOffset
+							new_block.offset.y = yOffset
+							table.insert( new_block_list, new_block )
 
-						if ( xOffset + x1 > xMax ) then
-							xMax = xOffset + x1
+							if ( xOffset + x1 > xMax ) then
+								xMax = xOffset + x1
+							end
+
+							curString = ""
 						end
 
 						xOffset = 0
@@ -395,7 +465,6 @@ function Parse( ml, maxwidth )
 						x, y = surface.GetTextSize( ch )
 						yOffset = yOffset + thisMaxY
 						thisY = 0
-						curString = ""
 						thisMaxY = 0
 					end
 				end
@@ -415,7 +484,7 @@ function Parse( ml, maxwidth )
 
 		if ( string.len( curString ) > 0 ) then
 
-			local x1, y1 = surface.GetTextSize( curString )
+			local x1 = surface.GetTextSize( curString )
 
 			local new_block = {}
 			new_block.text = curString
@@ -439,17 +508,21 @@ function Parse( ml, maxwidth )
 	end
 
 	local totalHeight = 0
-	for i, blk in pairs( new_block_list ) do
-		new_block_list[ i ].height = ymaxes[ new_block_list[ i ].offset.y ]
+	for i, blk in ipairs( new_block_list ) do
+		blk.height = ymaxes[ blk.offset.y ]
 
-		if ( new_block_list[ i ].offset.y + new_block_list[ i ].height > totalHeight ) then
-			totalHeight = new_block_list[ i ].offset.y + new_block_list[ i ].height
+		if ( blk.offset.y + blk.height > totalHeight ) then
+			totalHeight = blk.offset.y + blk.height
 		end
+
+		lineWidths[ blk.offset.y ] = math.max( lineWidths[ blk.offset.y ] or 0, blk.offset.x + blk.thisX )
 	end
 
 	return setmetatable( {
 		totalHeight = totalHeight,
 		totalWidth = xMax,
+		maxWidth = maxwidth,
+		lineWidths = lineWidths,
 		blocks = new_block_list
 	}, MarkupObject )
 end

--- a/garrysmod/lua/includes/modules/markup.lua
+++ b/garrysmod/lua/includes/modules/markup.lua
@@ -7,7 +7,7 @@ local ipairs = ipairs
 local setmetatable = setmetatable
 local math = math
 local utf8 = utf8
-local Color = Color
+local _Color = Color
 
 local MarkupObject = {}
 MarkupObject.__index = MarkupObject
@@ -24,6 +24,28 @@ TEXT_ALIGN_CENTER	= 1
 TEXT_ALIGN_RIGHT	= 2
 TEXT_ALIGN_TOP		= 3
 TEXT_ALIGN_BOTTOM	= 4
+
+--[[---------------------------------------------------------
+	Name: Color(Color(r, g, b, a))
+	Desc: Convenience function which converts a Color object into a string
+	      which can be used in the <color=r,g,b,a></color> tag
+
+	      e.g. Color(255, 0, 0, 150) -> 255,0,0,150
+	           Color(255, 0, 0)      -> 255,0,0
+	           Color(255, 0, 0, 255) -> 255,0,0
+
+	Usage: markup.Color(Color(r, g, b, a))
+-----------------------------------------------------------]]
+function Color( col )
+	return
+		col.r .. "," ..
+		col.g .. "," ..
+		col.b ..
+		-- If the alpha value is 255, we don't need to include it in the <color> tag, so just omit it:
+		( col.a == 255 and "" or ( "," .. col.a ) )
+end
+
+local Color = _Color
 
 --[[---------------------------------------------------------
 	Name: Temporary information used when building text frames.


### PR DESCRIPTION
- New argument to `MarkupObject:Draw()` (`textAlign`) allows for text alignment inside the maxWidth bounds (i.e. align text center, align text right)
- Added `MarkupObject:GetMaxWidth()`
- Added `markup.Color` which converts a Color into a string for use in `<color>` tags (this does not modify the original Color object)
- #1614 Added `markup.Escape` which escapes markup-sensitive characters (`& < >`)
- Fixed trailing spaces on new lines
- Fixed issue where new blocks were unnecessarily being split in the middle of a word
- Changed pairs to ipairs
- Improved code readability, cleaned up comments, removed a redundant comment
- Removed some unused variables
- Some small optimizations

### Demonstration of new text alignment

#### `TEXT_ALIGN_CENTER`
![TEXT_ALIGN_CENTER](https://user-images.githubusercontent.com/14863743/95920433-5a436d80-0da7-11eb-8ee7-60f732383354.png)

![UTF-8 Test](https://user-images.githubusercontent.com/14863743/95923103-ab099500-0dac-11eb-954f-66ff13d74602.png)

#### `TEXT_ALIGN_RIGHT`
![TEXT_ALIGN_RIGHT](https://user-images.githubusercontent.com/14863743/95920467-66c7c600-0da7-11eb-8fdd-26a4e09ae0b8.png)

#### Default

![Default](https://user-images.githubusercontent.com/14863743/95920511-7810d280-0da7-11eb-88e2-cfaee46b8f1c.png)

![Default](https://user-images.githubusercontent.com/14863743/95922481-3eda6180-0dab-11eb-8acc-ba5867857332.png)