### PR TITLE
[TTT] Change "Português brasileiro" to "Português (Brasil)"

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/lang/brazilian_portuguese.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/lang/brazilian_portuguese.lua
@@ -1,6 +1,6 @@
 ---- Brazilian Portuguese language strings
 
-local L = LANG.CreateLanguage("Português brasileiro")
+local L = LANG.CreateLanguage("Português (Brasil)")
 
 --- General text used in various places
 L.traitor    = "Traidor"


### PR DESCRIPTION
Most websites on the internet, when they distinguish the Brazilian Portuguese and European Portuguese they will separate in two ways: the European Portuguese will be described only as "Português" (in English: `Portuguese`) or "Português de Portugal" (in English: `Portuguese from Portugal`) , and the Brazilian Portuguese will be described as "Português brasileiro" (in English: `Brazilian Portuguese`) or "Português do Brasil" (in English: `Portuguese from Brazil`). Or they will separete in another way, that is "Português (Brasil)" (in English: `Portuguese (Brazil)`) for Brazilian Portuguese and "Portuguese (Portugal)" (in English: `Portuguese (Portugal)`) for European Portuguese.

So, to follow the pattern that most websites adopt, here is my PR to change that, since I think it is better to follow the default that most websites use.

This change has been tested and it does work.