### PR TITLE
Toolgun bug fixes

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/shared.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/shared.lua
@@ -176,7 +176,7 @@ function SWEP:Think()
 
 		if ( lastmode_obj ) then
 			-- We want to release the ghost entity just in case
-			lastmode_obj:Holster()
+			lastmode_obj:ReleaseGhostEntity()
 		end
 	end
 

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/shared.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/shared.lua
@@ -171,18 +171,13 @@ function SWEP:Think()
 		return
 	end
 
-	if ( lastmode ) then
-		if ( lastmode != curmode ) then
-			local lastmode_obj = self:GetToolObject( lastmode )
+	if ( lastmode && lastmode != curmode ) then
+		local lastmode_obj = self:GetToolObject( lastmode )
 
-			if ( lastmode_obj ) then
-				-- We want to release the ghost entity just in case
-				lastmode_obj:Holster()
-			end
+		if ( lastmode_obj ) then
+			-- We want to release the ghost entity just in case
+			lastmode_obj:Holster()
 		end
-	elseif ( !self.m_bSTOOLDeployed ) then
-		-- We've just initalized, so we need to call Deploy on the tool
-		tool:Deploy()
 	end
 
 	self.Primary.Automatic = tool.LeftClickAutomatic || false
@@ -310,9 +305,6 @@ function SWEP:Deploy()
 
 	self:GetToolObject():UpdateData()
 
-	-- Prevent calling Deploy twice on the tool when we first initialize
-	self.m_bSTOOLDeployed = true
-
 	local CanDeploy = self:GetToolObject():Deploy()
 	if ( CanDeploy ~= nil ) then return CanDeploy end
 
@@ -322,7 +314,7 @@ end
 
 function SWEP:GetToolObject( tool )
 
-	local mode = tool or self:GetMode()
+	local mode = tool or self:GetMode() or ( self:GetOwner():IsPlayer() and self:GetOwner():GetInfo( "gmod_toolmode" ) )
 
 	if ( !self.Tool[ mode ] ) then return false end
 

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/shared.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/shared.lua
@@ -171,13 +171,18 @@ function SWEP:Think()
 		return
 	end
 
-	if ( lastmode && lastmode != curmode ) then
-		local lastmode_obj = self:GetToolObject( lastmode )
+	if ( lastmode ) then
+		if ( lastmode != curmode ) then
+			local lastmode_obj = self:GetToolObject( lastmode )
 
-		if ( lastmode_obj ) then
-			-- We want to release the ghost entity just in case
-			lastmode_obj:Holster()
+			if ( lastmode_obj ) then
+				-- We want to release the ghost entity just in case
+				lastmode_obj:Holster()
+			end
 		end
+	elseif ( !self.m_bSTOOLDeployed ) then
+		-- We've just initalized, so we need to call Deploy on the tool
+		tool:Deploy()
 	end
 
 	self.Primary.Automatic = tool.LeftClickAutomatic || false
@@ -304,6 +309,9 @@ function SWEP:Deploy()
 	if ( !self:GetToolObject() ) then return self.CanDeploy end
 
 	self:GetToolObject():UpdateData()
+
+	-- Prevent calling Deploy twice on the tool when we first initialize
+	self.m_bSTOOLDeployed = true
 
 	local CanDeploy = self:GetToolObject():Deploy()
 	if ( CanDeploy ~= nil ) then return CanDeploy end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/shared.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/shared.lua
@@ -314,7 +314,14 @@ end
 
 function SWEP:GetToolObject( tool )
 
-	local mode = tool or self:GetMode() or ( self:GetOwner():IsPlayer() and self:GetOwner():GetInfo( "gmod_toolmode" ) )
+	local mode = tool or self:GetMode()
+
+	if ( !mode ) then
+		local owner = self:GetOwner()
+		if ( IsValid( owner ) and owner:IsPlayer() ) then
+			mode = owner:GetInfo( "gmod_toolmode" )
+		end
+	end
 
 	if ( !self.Tool[ mode ] ) then return false end
 

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stool.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stool.lua
@@ -34,27 +34,20 @@ function ToolObj:CreateConVars()
 
 	local mode = self:GetMode()
 
+	self.AllowedCVar = CreateConVar( "toolmode_allow_" .. mode, 1, { FCVAR_NOTIFY, FCVAR_REPLICATED } )
+
 	if ( CLIENT ) then
 
 		for cvar, default in pairs( self.ClientConVar ) do
-
 			CreateClientConVar( mode .. "_" .. cvar, default, true, true )
-
 		end
-
-		return
-	end
-
-	-- Note: I changed this from replicated because replicated convars don't work
-	-- when they're created via Lua.
-
-	if ( SERVER ) then
-
-		self.AllowedCVar = CreateConVar( "toolmode_allow_" .. mode, 1, FCVAR_NOTIFY )
+		
+	else
 
 		for cvar, default in pairs( self.ServerConVar ) do
 			CreateConVar( mode .. "_" .. cvar, default, FCVAR_ARCHIVE )
 		end
+
 	end
 
 end
@@ -92,7 +85,6 @@ end
 
 function ToolObj:Allowed()
 
-	if ( CLIENT ) then return true end
 	return self.AllowedCVar:GetBool()
 
 end


### PR DESCRIPTION
I noticed that there is a bug where the toolgun does not call Deploy on the first tool that is selected (both realms, so it's not a prediction thing), it's a simple fix. The bug is caused by SWEP:GetToolObject() being called before SWEP:Think(), which sets SWEP.Mode.

Also fixed Holster being called twice in the name of releasing ghost entities.

And finally, I have also re-enabled ToolObj:Allowed() on the client as FCVAR_REPLICATE now works for Lua ConVars.