### PR TITLE
Fix color_white corruption

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/colour.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/colour.lua
@@ -83,7 +83,7 @@ function TOOL:Reload( trace )
 	if ( !IsValid( ent ) ) then return false end -- The entity is valid and isn't worldspawn
 	if ( CLIENT ) then return true end
 
-	SetColour( self:GetOwner(), ent, { Color = color_white, RenderMode = 0, RenderFX = 0 } )
+	SetColour( self:GetOwner(), ent, { Color = Color( 255, 255, 255, 255 ), RenderMode = 0, RenderFX = 0 } )
 	return true
 
 end


### PR DESCRIPTION
How to:

Press R on prop, then left click on it. There you go, color_white is corrupted by duplicator.StoreEntityModifier.