### PR TITLE
Fix parent IsModal check

### DIFF
--- a/garrysmod/lua/vgui/dmenu.lua
+++ b/garrysmod/lua/vgui/dmenu.lua
@@ -220,7 +220,7 @@ function PANEL:Open( x, y, skipanimation, ownerpanel )
 	if ( x < 1 ) then x = 1 end
 
 	local p = self:GetParent()
-	if ( IsValid( p ) && p:IsModal() ) then
+	if ( IsValid( p ) && p.IsModal && p:IsModal() ) then
 		-- Can't popup while we are parented to a modal panel
 		-- We will end up behind the modal panel in that case
 


### PR DESCRIPTION
After the last commit in this file, this error happens constantly:
```
[murder] lua/vgui/dmenu.lua:223: attempt to call method 'IsModal' (a nil value)
  1. Open - lua/vgui/dmenu.lua:223
   2. DoScoreboardActionPopup - addons/murder/gamemodes/murder/gamemode/cl_scoreboard.lua:161
    3. DoClick - addons/murder/gamemodes/murder/gamemode/cl_endroundboard.lua:131
     4. unknown - lua/vgui/dlabel.lua:237
```

With this check we ensure there are no breaking changes on `dmenu`.