### PR TITLE
Make Bokeh DOF effect function callable from anywhere

### DIFF
--- a/garrysmod/lua/postprocess/bokeh_dof.lua
+++ b/garrysmod/lua/postprocess/bokeh_dof.lua
@@ -6,16 +6,16 @@ local pp_bokeh_blur = CreateClientConVar( "pp_bokeh_blur", "5", true, false )
 local pp_bokeh_distance = CreateClientConVar( "pp_bokeh_distance", "0.1", true, false )
 local pp_bokeh_focus = CreateClientConVar( "pp_bokeh_focus", "1.0", true, false )
 
-local function DrawBokehDOF()
+function DrawBokehDOF( intensity, distance, focus )
 
 	render.UpdateScreenEffectTexture()
 
 	blur_mat:SetTexture( "$BASETEXTURE", render.GetScreenEffectTexture() )
 	blur_mat:SetTexture( "$DEPTHTEXTURE", render.GetResolvedFullFrameDepth() )
 
-	blur_mat:SetFloat( "$size", pp_bokeh_blur:GetFloat() )
-	blur_mat:SetFloat( "$focus", pp_bokeh_distance:GetFloat() )
-	blur_mat:SetFloat( "$focusradius", pp_bokeh_focus:GetFloat() )
+	blur_mat:SetFloat( "$size", intensity )
+	blur_mat:SetFloat( "$focus", distance )
+	blur_mat:SetFloat( "$focusradius", focus )
 
 	render.SetMaterial( blur_mat )
 	render.DrawScreenQuad()
@@ -40,7 +40,7 @@ hook.Add( "RenderScreenspaceEffects", "RenderBokeh", function()
 	if ( !pp_bokeh:GetBool() ) then return end
 	if ( !GAMEMODE:PostProcessPermitted( "bokeh" ) ) then return end
 
-	DrawBokehDOF()
+	DrawBokehDOF( pp_bokeh_blur:GetFloat(), pp_bokeh_distance:GetFloat(), pp_bokeh_focus:GetFloat() )
 
 end )
 


### PR DESCRIPTION
The `DrawBokehDOF` function is now global to allow it to be called everywhere (like the other built-in effects). This can be useful to create some scripts using these effects without having to copy/paste these functions.