### PR TITLE
Allow returning false in undo.AddFunction to skip undo if it's no longer valid

### DIFF
--- a/garrysmod/lua/includes/modules/undo.lua
+++ b/garrysmod/lua/includes/modules/undo.lua
@@ -362,8 +362,10 @@ function Do_Undo( undo )
 	if ( undo.Functions ) then
 		for index, func in pairs( undo.Functions ) do
 
-			func[ 1 ]( undo, unpack( func[ 2 ] ) )
-			count = count + 1
+			local success = func[ 1 ]( undo, unpack( func[ 2 ] ) )
+			if ( success != false ) then
+				count = count + 1
+			end
 
 		end
 	end


### PR DESCRIPTION
This means you can return false in the function called by `undo.AddFunction` to "skip" the undo, just like `undo.AddEntity` would do if the entity is no longer valid.