### PR TITLE
Implement correct hook behaviour for ENTITY.CanTool and ENTITY.CanProperty

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/shared.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/shared.lua
@@ -247,7 +247,10 @@ function GM:CanProperty( pl, property, ent )
 
 	-- Give the entity a chance to decide
 	if ( ent.CanProperty ) then
-		return ent:CanProperty( pl, property )
+		local entCanProperty = ent:CanProperty( pl, property )
+		if ( entCanProperty != nil ) then
+			return entCanProperty
+		end
 	end
 
 	return true

--- a/garrysmod/gamemodes/sandbox/gamemode/shared.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/shared.lua
@@ -70,7 +70,10 @@ function GM:CanTool( ply, trace, mode )
 	
 	-- Give the entity a chance to decide
 	if ( trace.Entity.CanTool ) then
-		return trace.Entity:CanTool( ply, trace, mode )
+		local entCanTool = trace.Entity:CanTool( ply, trace, mode )
+		if ( entCanTool != nil ) then
+			return entCanTool
+		end
 	end
 
 	return true


### PR DESCRIPTION
If a hook returns `nil` it should not affect any others