### PR TITLE
Conditionally prevent drawing voice panels

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/cl_voice.lua
+++ b/garrysmod/gamemodes/base/gamemode/cl_voice.lua
@@ -97,6 +97,8 @@ function GM:PlayerStartVoice( ply )
 
 	if ( !IsValid( ply ) ) then return end
 
+	if hook.Run("ShouldDrawPlayerVoicePanel", ply) == false then return end
+
 	local pnl = g_VoicePanelList:Add( "VoiceNotify" )
 	pnl:Setup( ply )
 	


### PR DESCRIPTION
In an event where you might want to only conditionally replace them with something else.