### PR TITLE
[TTT] Fixed Magneto Stick ragdoll pinning instructions not showing for innocents when ttt_ragdoll_pinning_innocents is enabled

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
@@ -531,6 +531,7 @@ function SWEP:SetupDataTables()
    -- we've got these dt slots anyway, might as well use them instead of a
    -- globalvar, probably cheaper
    self:DTVar("Bool", 0, "can_rag_pin")
+   self:DTVar("Bool", 0, "can_rag_pin_inno")
 
    -- client actually has no idea what we're holding, and almost never needs to
    -- know
@@ -541,6 +542,7 @@ end
 if SERVER then
    function SWEP:Initialize()
       self.dt.can_rag_pin = pin_rag:GetBool()
+      self.dt.can_pin_rag_inno = pin_rag_inno:GetBool()
       self.dt.carried_rag = nil
 
       return self.BaseClass.Initialize(self)
@@ -582,7 +584,7 @@ if CLIENT then
       if self.dt.can_rag_pin and IsValid(self.dt.carried_rag) then
          local client = LocalPlayer()
 
-         if not client:IsSpec() and client:IsTraitor() then
+         if not client:IsSpec() and (self.dt.can_rag_pin_inno or client:IsTraitor()) then
             local tr = util.TraceLine({start  = client:EyePos(),
                endpos = client:EyePos() + (client:GetAimVector() * PIN_RAG_RANGE),
                filter = {client, self, self.dt.carried_rag},


### PR DESCRIPTION
Fixes the "Press E to pin body" instructions not showing for innocents when they are holding a ragdoll with a Magneto Stick and the  _ttt_ragdoll_pinning_innocents_ CVar is enabled