### PR TITLE
Use Brackets for keys in PrintTable

### DIFF
--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -73,7 +73,7 @@ function PrintTable( t, indent, done )
 	for i = 1, #keys do
 		local key = keys[ i ]
 		local value = t[ key ]
-		key = (type(key) == "number") && "[" .. key .. "]" || "[\"" .. key .. "\"]"
+		key = (type( key ) == "number") && "[" .. key .. "]" || "[\"" .. tostring( key ) .. "\"]"
 		Msg( string.rep( "\t", indent ) )
 
 		if  ( istable( value ) && !done[ value ] ) then

--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -73,6 +73,7 @@ function PrintTable( t, indent, done )
 	for i = 1, #keys do
 		local key = keys[ i ]
 		local value = t[ key ]
+		key = (type(key) == "number") && "[" .. key .. "]" || "[\"" .. key .. "\"]"
 		Msg( string.rep( "\t", indent ) )
 
 		if  ( istable( value ) && !done[ value ] ) then

--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -73,7 +73,7 @@ function PrintTable( t, indent, done )
 	for i = 1, #keys do
 		local key = keys[ i ]
 		local value = t[ key ]
-		key = (type( key ) == "number") && "[" .. key .. "]" || "[\"" .. tostring( key ) .. "\"]"
+		key = (type( key ) == "string") && "[\"" ..  key .. "\"]" || "[" .. tostring( key ) .. "]"
 		Msg( string.rep( "\t", indent ) )
 
 		if  ( istable( value ) && !done[ value ] ) then


### PR DESCRIPTION
To avoid confusion when there is [357] and ["357 "] for example.