### PR TITLE
Dock the OpenURL disconnect button to the left

### DIFF
--- a/garrysmod/lua/menu/openurl.lua
+++ b/garrysmod/lua/menu/openurl.lua
@@ -76,7 +76,7 @@ function PANEL:Init()
 	self.Disconnect = vgui.Create( "DButton", self.Buttons )
 	self.Disconnect:SetText( "#openurl.disconnect" )
 	self.Disconnect.DoClick = function() self:DoNope() RunConsoleCommand( "disconnect" ) end
-	self.Disconnect:Dock( RIGHT )
+	self.Disconnect:Dock( LEFT )
 
 	self.Nope = vgui.Create( "DButton", self.Buttons )
 	self.Nope:SetText( "#openurl.nope" )


### PR DESCRIPTION
The new disconnect button that was added when calling gui.OpenURL is in a pretty questionable location. Users aren't expecting to see such a button, and if you're like me you'll naturally click it thinking it says cancel. This can cause a lot of frustration for the player, especially if they've been joining a server for 20 minutes+ just to leave it by accident.

The solution to this is to simply dock it to the left side instead, so mistakes can't occur but it's still easily accessible.