### PR TITLE
Add PANEL:GetValues function

### DIFF
--- a/garrysmod/lua/vgui/dlistview.lua
+++ b/garrysmod/lua/vgui/dlistview.lua
@@ -565,7 +565,7 @@ function PANEL:GetValues(bOnlySelected)
 		local lineTbl = {}
 
 		for columnID, column in ipairs(columns) do
-			lineTbl[column.Header:GetText()] = line:GetValue(columnID)
+			lineTbl[columnID] = line:GetValue(columnID)
 		end
 		table.insert(tbl, lineTbl)
 	end

--- a/garrysmod/lua/vgui/dlistview.lua
+++ b/garrysmod/lua/vgui/dlistview.lua
@@ -556,6 +556,23 @@ function PANEL:SizeToContents()
 
 end
 
+function PANEL:GetValues(bOnlySelected)
+	local tbl = {}
+	local columns = self.Columns
+	local linesToExtract = bOnlySelected && self:GetSelected() || self:GetLines()
+
+	for lineID, line in ipairs(linesToExtract) do
+		local lineTbl = {}
+
+		for columnID, column in ipairs(columns) do
+			lineTbl[column.Header:GetText()] = line:GetValue(columnID)
+		end
+		table.insert(tbl, lineTbl)
+	end
+
+	return tbl
+end
+
 function PANEL:GenerateExample( ClassName, PropertySheet, Width, Height )
 
 	local ctrl = vgui.Create( ClassName )


### PR DESCRIPTION
Allows for easy extraction of values from  a DListView.

Nested table's keys are the same as the related column's text.