### PR TITLE
Fix Disconnect button width with other languages (russian, etc.)

### DIFF
--- a/garrysmod/lua/menu/openurl.lua
+++ b/garrysmod/lua/menu/openurl.lua
@@ -78,7 +78,7 @@ function PANEL:Init()
 	self.Disconnect.DoClick = function() self:DoNope() RunConsoleCommand( "disconnect" ) end
 	self.Disconnect:Dock( LEFT )
 	self.Disconnect:SizeToContents()
-	self.Disconnect:SetWide(self.Disconnect:GetWide() + 10)
+	self.Disconnect:SetWide( self.Disconnect:GetWide() + 10 )
 
 	self.Nope = vgui.Create( "DButton", self.Buttons )
 	self.Nope:SetText( "#openurl.nope" )

--- a/garrysmod/lua/menu/openurl.lua
+++ b/garrysmod/lua/menu/openurl.lua
@@ -77,6 +77,8 @@ function PANEL:Init()
 	self.Disconnect:SetText( "#openurl.disconnect" )
 	self.Disconnect.DoClick = function() self:DoNope() RunConsoleCommand( "disconnect" ) end
 	self.Disconnect:Dock( LEFT )
+	self.Disconnect:SizeToContents()
+	self.Disconnect:SetWide(self.Disconnect:GetWide() + 10)
 
 	self.Nope = vgui.Create( "DButton", self.Buttons )
 	self.Nope:SetText( "#openurl.nope" )


### PR DESCRIPTION
Fixes this:

![](https://cdn.discordapp.com/attachments/589120351238225940/796427600733536327/unknown.png)