### PR TITLE
Fix label PerformLayout in DCheckBoxLabel

### DIFF
--- a/garrysmod/lua/vgui/dcheckbox.lua
+++ b/garrysmod/lua/vgui/dcheckbox.lua
@@ -124,7 +124,7 @@ function PANEL:PerformLayout()
 	self.Button:SetPos( x, math.floor( ( self:GetTall() - self.Button:GetTall() ) / 2 ) )
 
 	self.Label:SizeToContents()
-	self.Label:SetPos( x + self.Button:GetWide() + 9, 0 )
+	self.Label:SetPos( x + self.Button:GetWide() + 9, math.floor( ( self:GetTall() - self.Label:GetTall() ) / 2 ) )
 
 end
 


### PR DESCRIPTION
Label in DCheckBoxLabel is centered vertically as well as the button. No refactoring, no broken addons :)
Also perfectly works with multi-line label.

![изображение](https://user-images.githubusercontent.com/7351599/105625460-9bcdc500-5e3a-11eb-923c-2d00ceb046d5.png)