### PR TITLE
Fix WeaponColor matproxy on physcannon to work with scripted weapons

### DIFF
--- a/garrysmod/lua/matproxy/player_weapon_color.lua
+++ b/garrysmod/lua/matproxy/player_weapon_color.lua
@@ -20,7 +20,7 @@ matproxy.Add( {
 
 		-- A hack for the mega gravity gun
 		local wep = owner:GetActiveWeapon()
-		if ( IsValid( wep ) && wep:GetClass() == "weapon_physcannon" ) then
+		if ( IsValid( wep ) && wep:GetClass() == "weapon_physcannon" && !wep:IsScripted() ) then
 			col = Vector( 0.4, 1, 1 )
 		end
 


### PR DESCRIPTION
Just a solution to this issue I posted [here #4851](https://github.com/Facepunch/garrysmod-issues/issues/4851)

Added a IsScripted check to this matproxy hack to only work on the engine weapons.

