### PR TITLE
Penalize massive servers (>80) heavily 

### DIFF
--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -286,8 +286,8 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 	if ( data.players >= 4 ) data.recommended -= 20;
 	if ( data.players >= 8 ) data.recommended -= 15;
 	if ( data.players >= 16 ) data.recommended -= 15;
-	if ( data.players >= 32 ) data.recommended += 20;
-	if ( data.players >= 64 ) data.recommended += 30;
+	if ( data.players >= 32 ) data.recommended -= 5;
+	if ( data.players >= 43 ) data.recommended += 30;
 	if ( data.players >= 80 ) data.recommended += 60;
 	if ( data.players >= 128 ) data.recommended += 90;
 

--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -283,11 +283,13 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 	if ( data.isAnon ) data.recommended += 1000; // Anonymous server
 
 	// The first few bunches of players reduce the impact of the server's ping on the ranking a little
-	if ( data.players >= 4 ) data.recommended -= 10;
+	if ( data.players >= 4 ) data.recommended -= 20;
 	if ( data.players >= 8 ) data.recommended -= 15;
 	if ( data.players >= 16 ) data.recommended -= 15;
-	if ( data.players >= 32 ) data.recommended -= 10;
-	if ( data.players >= 64 ) data.recommended -= 10;
+	if ( data.players >= 32 ) data.recommended += 20;
+	if ( data.players >= 64 ) data.recommended += 30;
+	if ( data.players >= 80 ) data.recommended += 60;
+	if ( data.players >= 128 ) data.recommended += 90;
 
 	data.listen = data.desc.indexOf( '[L]' ) >= 0;
 	if ( data.listen ) data.desc = data.desc.substr( 4 );

--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -282,7 +282,7 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 	if ( data.pass ) data.recommended += 300; // Password protected, can't join it
 	if ( data.isAnon ) data.recommended += 1000; // Anonymous server
 
-	// The first few bunches of players reduce the impact of the server's ping on the ranking a little
+	// Penalize massive servers while giving bonuses to small to medium servers
 	if ( data.players >= 4 ) data.recommended -= 20;
 	if ( data.players >= 8 ) data.recommended -= 15;
 	if ( data.players >= 16 ) data.recommended -= 15;


### PR DESCRIPTION
This PR will penalize massive servers in the server list and drop them much further down than small to medium servers. My reasoning for this change is that massive servers effectively suffocate smaller servers by not allowing them to get any players which doesn't allow them to gain a community. It's very difficult to start a successful server due to how massive servers have become and the rise of player + ping spoofing (including anycast). This PR attempts to alleviate this by penalizing servers that grow above 43-128 population by dropping them further below.
Owners of the massive servers who are targeted will not be affected too much as they have already developed a community. The only people who WILL be affected are the people who don't have a community, and they will be affected in a good way (being brought up to the top of the server list)

This will obviously not address the rise of certain hosting providers that provide ping spoofing disguised as anycast with their servers, nor player spoofing. 
This can also be improved by a player to max player ratio system.