### PR TITLE
Fix theme issues with DMenuOptions foreground text color

### DIFF
--- a/garrysmod/lua/vgui/dmenuoption.lua
+++ b/garrysmod/lua/vgui/dmenuoption.lua
@@ -9,7 +9,6 @@ function PANEL:Init()
 
 	self:SetContentAlignment( 4 )
 	self:SetTextInset( 32, 0 ) -- Room for icon on left
-	self:SetTextColor( Color( 10, 10, 10 ) )
 	self:SetChecked( false )
 
 end


### PR DESCRIPTION
This removes the call to SetTextColor in DMenuOption since it will override theme colors here:
https://github.com/Facepunch/garrysmod/blob/master/garrysmod/lua/vgui/dlabel.lua#L68

Before: 
![image](https://user-images.githubusercontent.com/204157/110142414-6d96ba00-7dd6-11eb-90cd-de4b14cc72d7.png)


After: 
![image](https://user-images.githubusercontent.com/204157/110142353-5bb51700-7dd6-11eb-89fd-8172c5c55e71.png)



Left side is the default skin and right side is this skin https://steamcommunity.com/sharedfiles/filedetails/?id=1596913191

You can also see that the default skin seems more accurate according to its design.