### PR TITLE
Change disabled button border to fit button color

### DIFF
--- a/garrysmod/html/css/menu/Menu.css
+++ b/garrysmod/html/css/menu/Menu.css
@@ -94,6 +94,7 @@ UL.category LI.icon
 
 .btn-primary-disabled
 {
+	border-color: #424242;
 	background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#888), to(#555));
 }
 


### PR DESCRIPTION
When looking about in the server browser, I noticed the "Server is full" button had a blue border color, this didn't really fit the grey color of the button, so I updated the border to a dark grey.

Before:
![image](https://user-images.githubusercontent.com/53242610/110831144-ddeb8280-8291-11eb-8381-16224ed5998b.png)

After:
![image](https://user-images.githubusercontent.com/53242610/110831218-ea6fdb00-8291-11eb-8fd0-02ecf13f4333.png)