### PR TITLE
Fix cookie lib cache

### DIFF
--- a/garrysmod/lua/includes/modules/cookie.lua
+++ b/garrysmod/lua/includes/modules/cookie.lua
@@ -60,11 +60,13 @@ end
 local function SetCache( key, value )
 	if ( value == nil ) then return Delete( key ) end
 
-	if !CachedEntries[ key ] then
+	if CachedEntries[ key ] then
+		CachedEntries[ key ][ 1 ] = SysTime() + 30
+		CachedEntries[ key ][ 2 ] = value
+	else
 		CachedEntries[ key ] = { SysTime() + 30, value }
 	end
 
-	CachedEntries[ key ][ 2 ] = value
 	BufferedWrites[ key ] = value
 
 	ScheduleCommit()


### PR DESCRIPTION
test code:

```lua
local key = "test"

local function printState()
	PrintTable({
		realval = sql.QueryValue( "SELECT value FROM cookies WHERE key = " .. SQLStr(key) ),
		cached  = cookie.GetString(key),
	})
end

cookie.Set(key, 1) -- set initial value

printState() -- ok. cached but not commited so realval is nil for now

timer.Simple(31, function() -- wait cache ttl (time to live) period
	-- Update cached value immediately but don't refresh cache's ttl so it's expires
	-- At this point, we also schedule a commit to the DB
	cookie.Set(key, 2)

	-- Because the caches ttl is expired, the cookie.GetString function should request a value from the DB
	-- But as we remember, in the previous step we just scheduled a value update
	-- It has not been commuted so the cache will be updated with the wrong value and contain the wrong value for the next 30 seconds
	printState() -- realval and cache values are both "1"

	-- Wait for scheduled commit
	timer.Simple(2, function()
		-- As stated before, cache now and for the next 30 seconds (28 seconds) will be wrong
		printState() -- We have "1" for cached value and "2" for real value in database
	end)
end)
```

Output before:
![image](https://user-images.githubusercontent.com/9200174/111716822-846def80-885f-11eb-9dba-9ea9c7d75b65.png)

Output after:
![image](https://user-images.githubusercontent.com/9200174/111716970-c5fe9a80-885f-11eb-8404-a6c75d5022c9.png)
