### PR TITLE
Front page links update

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Next Update
 ---
 Current game discussion as well as update progress can be found on [Discord](https://discord.gg/gmod).
 
-You can test [changes for the next update](http://wiki.garrysmod.com/changelist/) on the [Garry's Mod Dev Branch](http://wiki.garrysmod.com/page/Dev_Branch) through Steam.
+You can test [changes for the next update](https://docs.google.com/document/d/e/2PACX-1vTzEJEpdEje8e-FgsbyWGydu_Ez7p82MwOUPmRlUAAJ-KpkNJhHctyadZosfUYjVTz26KGip7bI7M9T/pub) on the [Garry's Mod Dev Branch](https://wiki.facepunch.com/gmod/Dev_Branch) through Steam.
 
 Pull Requests
 ---
@@ -15,14 +15,13 @@ Pull requests are welcome.
 
 Please make sure your [line endings are correct](https://help.github.com/articles/dealing-with-line-endings/).
 
-Also try to condense multiple commits down to easily see the changes made, either through [resetting the head](http://stackoverflow.com/a/5201642) or [rebasing the branch](http://stackoverflow.com/a/5189600).
+Also try to condense multiple commits down to easily see the changes made, either through [resetting the head](https://stackoverflow.com/questions/5189560/squash-my-last-x-commits-together-using-git/5201642#5201642) or [rebasing the branch](https://stackoverflow.com/questions/5189560/squash-my-last-x-commits-together-using-git/5189600#5189600).
 
 Issues and Requests
 ---
 To report bugs please visit the [Garry's Mod Issue tracker](https://github.com/Facepunch/garrysmod-issues/).
 
 To request features please visit the [Garry's Mod Request tracker](https://github.com/Facepunch/garrysmod-requests/).
-
 
 Translations
 ---


### PR DESCRIPTION
Some links simply didn't exist anymore or led to automatic redirections.

- http://wiki.garrysmod.com/changelist/ => Redirect to https://wiki.facepunch.com/gmod.
- http://wiki.garrysmod.com/page/Dev_Branch => Same as above.
- http://stackoverflow.com/a/5201642 => Redirects cleanly to the new link (web version) but I was experiencing some 404 errors from the mobile website/Github Android app.
- http://stackoverflow.com/a/5189600 => Same as above.