### PR TITLE
Replace backslashes with forward slashes in Hammer Sprinkle Example

### DIFF
--- a/garrysmod/scripts/hammer/sprinkle/example.txt
+++ b/garrysmod/scripts/hammer/sprinkle/example.txt
@@ -13,18 +13,19 @@
 	10 // This is the chance of this set of values being used, this can be any number
 	{
 		// The key-value(s) of this case, left part is the key as seen without SmartEdit, the right part is the value
-		"model" "models\props_junk\garbage128_composite001a.mdl" 
+		// Make sure to use forward slashes and not backslashes or models will not display
+		"model" "models/props_junk/garbage128_composite001a.mdl" 
 	}
 	10
 	{
-		"model" "models\props_junk\garbage128_composite001b.mdl"
+		"model" "models/props_junk/garbage128_composite001b.mdl"
 	}
 	10
 	{
-		"model" "models\props_junk\garbage128_composite001c.mdl"
+		"model" "models/props_junk/garbage128_composite001c.mdl"
 	}
 	10 // Since there's 4 cases with the same chance, each case has a 1/4 chance of being placed
 	{
-		"model" "models\props_junk\garbage_carboard001a.mdl"
+		"model" "models/props_junk/garbage_carboard001a.mdl"
 	}
 }


### PR DESCRIPTION
Using backslashes instead of forward slashes in a sprinkle script works fine until the map is reloaded at which point Hammer can not load the model due to the path truncating to just "models". I added a warning comment in as well as this is an example file others will work off of.