### PR TITLE
Add: Feature to clear errors for problem panel

### DIFF
--- a/garrysmod/lua/menu/problems/problems.lua
+++ b/garrysmod/lua/menu/problems/problems.lua
@@ -17,6 +17,15 @@ local function CountProb( severity, add )
 	end
 end
 
+function SetProblems(count, severity)
+	ProblemsCount = count or 0
+	ProblemSeverity = math.max( severity, 1 )
+
+	if ( IsValid( pnlMainMenu ) ) then
+		pnlMainMenu:Call( "SetProblemCount(" .. ProblemsCount .. ", " .. tostring( ProblemSeverity > 0 ) .. ")" )
+	end
+end
+
 function ClearProblem( id )
 
 	if ( !Problems[ id ] ) then return end

--- a/garrysmod/lua/menu/problems/problems_pnl.lua
+++ b/garrysmod/lua/menu/problems/problems_pnl.lua
@@ -39,20 +39,20 @@ function PANEL:Init()
 	self.ProblemsList = problemsList
 
 	-- Clear button
-	ProblemsFrame.btnClear = ProblemsFrame:Add("DButton")
-	ProblemsFrame.btnClear:SetPos(ProblemsFrame.btnMaxim:GetPos())
+	ProblemsFrame.btnClear = ProblemsFrame:Add( "DButton" )
+	ProblemsFrame.btnClear:SetPos( ProblemsFrame.btnMaxim:GetPos() )
 	ProblemsFrame.btnClear.X = ProblemsFrame.btnClear.X - 4
 	ProblemsFrame.btnClear.Y = ProblemsFrame.btnClear.Y + 3
-	ProblemsFrame.btnClear:SetText("Clear")
+	ProblemsFrame.btnClear:SetText( "Clear" )
 	ProblemsFrame.btnClear:SizeToContents()
 	ProblemsFrame.btnClear:MoveToFront()
 	ProblemsFrame.btnClear.DoClick = function()
 		ErrorLog = {}
-		SetProblems(table.Count(Problems), 0)
+		SetProblems( table.Count(Problems), 0 )
 
-		for i, child in ipairs(self.LuaErrorList:GetCanvas():GetChildren()) do child:Remove() end
+		for i, child in ipairs( self.LuaErrorList:GetCanvas():GetChildren() ) do child:Remove() end
 
-		self.NoErrorsLabel = self:AddEmptyWarning("#problems.no_lua_errors", self.LuaErrorList)
+		self.NoErrorsLabel = self:AddEmptyWarning( "#problems.no_lua_errors", self.LuaErrorList )
 	end
 
 	ProblemsFrame.btnClose:MoveToFront()

--- a/garrysmod/lua/menu/problems/problems_pnl.lua
+++ b/garrysmod/lua/menu/problems/problems_pnl.lua
@@ -29,16 +29,35 @@ function PANEL:Init()
 	-- Lua errors
 	local luaErrorList = ProblemsFrame:Add( "DScrollPanel" )
 	sheet:AddSheet( "#problems.lua_errors", luaErrorList, "icon16/error.png" )
+	luaErrorList.IsErrorList = true
 	self.LuaErrorList = luaErrorList
 
 	-- Generic problems
 	local problemsList = ProblemsFrame:Add( "DScrollPanel" )
 	sheet:AddSheet( "#problems.problems", problemsList, "icon16/tick.png" )
+	problemsList.IsProblemsList = true
 	self.ProblemsList = problemsList
 
+	-- Clear button
+	ProblemsFrame.btnClear = ProblemsFrame:Add("DButton")
+	ProblemsFrame.btnClear:SetPos(ProblemsFrame.btnMaxim:GetPos())
+	ProblemsFrame.btnClear.X = ProblemsFrame.btnClear.X - 4
+	ProblemsFrame.btnClear.Y = ProblemsFrame.btnClear.Y + 3
+	ProblemsFrame.btnClear:SetText("Clear")
+	ProblemsFrame.btnClear:SizeToContents()
+	ProblemsFrame.btnClear:MoveToFront()
+	ProblemsFrame.btnClear.DoClick = function()
+		ErrorLog = {}
+		SetProblems(table.Count(Problems), 0)
+
+		for i, child in ipairs(self.LuaErrorList:GetCanvas():GetChildren()) do child:Remove() end
+
+		self.NoErrorsLabel = self:AddEmptyWarning("#problems.no_lua_errors", self.LuaErrorList)
+	end
+
 	ProblemsFrame.btnClose:MoveToFront()
-	ProblemsFrame.btnMaxim:MoveToFront()
-	ProblemsFrame.btnMinim:MoveToFront()
+	ProblemsFrame.btnMaxim:Hide()
+	ProblemsFrame.btnMinim:Hide()
 
 end
 


### PR DESCRIPTION
Added a button to clear errors.
This is useful when you've fixed old errors and want to see new ones.
This is how it looks:
<img src="https://user-images.githubusercontent.com/34854689/115539931-39079080-a2a6-11eb-9b94-2990bfd51b96.png">