### PR TITLE
Added Whitelist Feature for Server connects/hopping (via LUA)

### DIFF
--- a/garrysmod/lua/menu/openurl.lua
+++ b/garrysmod/lua/menu/openurl.lua
@@ -69,13 +69,10 @@ local function parseAddress(serverip)
 	return 1, Host, Port
 end
 local function writeWhitelist(newWhitelist)
-	PrintTable(newWhitelist)
 	-- TODO: Protect this filepath, or maybe write to a different directory where only the menu Context can write
 	local f = file.Open(_whitelistFilePath, "wb", _whitelistDir)
 	if ( !f ) then MsgN("FAILED WRITING WHITELIST") return false end
 	f:Write(util.TableToJSON(newWhitelist))
-	MsgN("writing to file")
-	MsgN(util.TableToJSON(newWhitelist))
 	f:Close()
 	return true
 end
@@ -88,8 +85,6 @@ local function readWhitelist()
 		f:Close()
 		if ( !str ) then str = "" end
 		whitelist = util.JSONToTable(str)
-		MsgN("Read Whitelist File")
-		PrintTable(whitelist)
 	end
 	return whitelist
 end
@@ -105,7 +100,7 @@ local function getEntryForAddress( address )
 			if #HostParts > 2 then -- if we have a subdomain, lets just take the domain+tld itself
 				Domain = HostParts[ #HostParts - 1 ] .. "." .. HostParts[ #HostParts ]
 			end
-			return Domain .. ":" .. Port
+			return Domain
 		else -- if IPv4
 			return Host .. ":" .. Port
 		end


### PR DESCRIPTION
See https://github.com/Facepunch/garrysmod-requests/issues/1751

We would only need to optimize/handle the saving of the whitelist, to be write protected against malicious code writing to it.
But it should be clear (according to the Server Operator Rules) to not write to this file. So its not a must-have to merge this.

(Maybe a Path where only the `MenuLua` can write to?).


It adds a Checkbox to the connect requests, and if you check it. It will save the IP/Domain, to never ask again.
(everything can be cleared with the concmd `connect_clearwhitelist`).
  
IPv4 Address will be matched exactly, where as Domain Names will only match to the `Domain.TLD`, so you can have multiple Servers under "yourdomain.tld" like "server1.yourdomain.tld" and "server2.yourdomain.tld".. Therefore it will only ask you once if you want to allow "yourdomain.tld".
  
Does ask you to whitelist the entire domain:
![image](https://user-images.githubusercontent.com/63829136/115973068-a5a6b780-a552-11eb-9106-8d6e96402169.png)

Does match the whitelist Entries accordingly(no trickery possible):
![image](https://user-images.githubusercontent.com/63829136/115973064-9fb0d680-a552-11eb-9d82-3c985cc06dfe.png)

Also works for IPs:
![image](https://user-images.githubusercontent.com/63829136/115973067-a2133080-a552-11eb-8bbc-2a70dc49c4ca.png)

If whitelisted, it just directly connects.