### PR TITLE
Optimize player:__index

### DIFF
--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -27,8 +27,7 @@ function meta:__index( key )
 	--
 	local tab = entity.GetTable( self )
 	if ( tab ) then
-		local val = tab[ key ]
-		if ( val != nil ) then return val end
+		return tab[ key ]
 	end
 
 	return nil


### PR DESCRIPTION
If the value in the entity table is nil, it would return nil anyway, so we don't need to check it.