### PR TITLE
Allow for color arg to be nil on RoundedBoxEx

### DIFF
--- a/garrysmod/lua/includes/modules/draw.lua
+++ b/garrysmod/lua/includes/modules/draw.lua
@@ -179,7 +179,9 @@ end
 -----------------------------------------------------------]]
 function RoundedBoxEx( bordersize, x, y, w, h, color, tl, tr, bl, br )
 
-	surface.SetDrawColor( color.r, color.g, color.b, color.a )
+	if ( color ) then
+		surface.SetDrawColor( color.r, color.g, color.b, color.a )
+	end
 
 	-- Do not waste performance if they don't want rounded corners
 	if ( bordersize <= 0 ) then


### PR DESCRIPTION
Having to create a Color metatable every time you use a RoundedBox is a pain.
Adding this will allow the `color` argument to be nil, enabling people to use `surface.SetDrawColor` instead.

Example:
```
surface.SetDrawColor(0, 0, 0)
draw.RoundedBox(16, 50, 50, 200, 200)
```
![image](https://user-images.githubusercontent.com/53242610/117486317-65d3cd00-af61-11eb-92b5-c575d87f81fe.png)
Not a single `Color` object to deal with!