### PR TITLE
Fix reliance on the sandbox gamemode for DoF

### DIFF
--- a/garrysmod/lua/postprocess/super_dof.lua
+++ b/garrysmod/lua/postprocess/super_dof.lua
@@ -160,6 +160,13 @@ local texFSB = render.GetSuperFPTex()
 local matFSB = Material( "pp/motionblur" )
 local matFB = Material( "pp/fb" )
 
+surface.CreateFont( "DofText",
+{
+	font		= "Helvetica",
+	size		= 20,
+	weight		= 700
+})
+
 function RenderDoF( vOrigin, vAngle, vFocus, fAngleSize, radial_steps, passes, bSpin, inView, ViewFOV )
 
 	local OldRT = render.GetRenderTarget()
@@ -242,8 +249,8 @@ function RenderDoF( vOrigin, vAngle, vFocus, fAngleSize, radial_steps, passes, b
 				cam.Start2D()
 					local add = ( i / ( math.pi * 2 ) ) * ( 1 / passes )
 					local percent = string.format( "%.1f", ( mul - ( 1 / passes ) + add ) * 100 )
-					draw.DrawText( percent .. "%", "GModWorldtip", view.w - 100, view.h - 100, color_black, TEXT_ALIGN_CENTER )
-					draw.DrawText( percent .. "%", "GModWorldtip", view.w - 101, view.h - 101, color_white, TEXT_ALIGN_CENTER )
+					draw.DrawText( percent .. "%", "DofText", view.w - 100, view.h - 100, color_black, TEXT_ALIGN_CENTER )
+					draw.DrawText( percent .. "%", "DofText", view.w - 101, view.h - 101, color_white, TEXT_ALIGN_CENTER )
 				cam.End2D()
 
 				render.Spin()


### PR DESCRIPTION
When I attempted to use pp_superdof, I kept getting an error about an invalid font. Turns out that the progress % text font is from the sandbox gamemode causing it to break on non-sandbox gamemodes.
I just created a separate font for the DoF to fix this.