### PR TITLE
Add new types to AccessorFunc

### DIFF
--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -170,6 +170,9 @@ end
 FORCE_STRING	= 1
 FORCE_NUMBER	= 2
 FORCE_BOOL		= 3
+FORCE_ANGLE		= 4
+FORCE_COLOR		= 5
+FORCE_VECTOR	= 6
 
 --[[---------------------------------------------------------
 	AccessorFunc
@@ -191,6 +194,24 @@ function AccessorFunc( tab, varname, name, iForce )
 
 	if ( iForce == FORCE_BOOL ) then
 		tab[ "Set" .. name ] = function( self, v ) self[ varname ] = tobool( v ) end
+	return end
+
+	if ( iForce == FORCE_ANGLE ) then
+		tab[ "Set" .. name ] = function( self, v ) self[ varname ] = Angle( v ) end
+	return end
+
+	if ( iForce == FORCE_COLOR ) then
+		tab[ "Set" .. name ] = function( self, v )
+			if ( type( v ) == "Vector" ) then self[ varname ] = v:ToColor()
+			else self[ varname ] = string.ToColor( tostring( v ) ) end
+		end
+	return end
+
+	if ( iForce == FORCE_VECTOR ) then
+		tab[ "Set" .. name ] = function( self, v )
+			if ( IsColor( v ) ) then self[ varname ] = v:ToVector()
+			else self[ varname ] = Vector( v ) end
+		end
 	return end
 
 	tab[ "Set" .. name ] = function( self, v ) self[ varname ] = v end


### PR DESCRIPTION
### Description
This commit adds 3 new types to `AccessorFunc()`. Colors, vectors and angles. 
### Tested Code
```lua
local TEST = {}
TEST.__index = TEST

AccessorFunc( TEST, "_color", "Color", FORCE_COLOR )
AccessorFunc( TEST, "_vector", "Vector", FORCE_VECTOR )
AccessorFunc( TEST, "_angle", "Angle", FORCE_ANGLE )

function NewTest()
    return setmetatable( {}, TEST )
end

local test = NewTest()

test:SetColor( color_red ) -- color
print( test:GetColor() )

test:SetColor( Color( 255, 0, 0, 255 ) ) -- new color
print( test:GetColor() )

test:SetColor( "255 0 0 255" ) -- string
print( test:GetColor() )

test:SetColor( LocalPlayer():GetPlayerColor() ) -- vector
print( test:GetColor() )

test:SetVector( color_red ) -- color
print( test:GetVector() )

test:SetAngle( "90 90 90" ) -- string
print( test:GetAngle() )
```
### Output
![](https://i.imgur.com/MA98SNE.png)