### PR TITLE
TTT: Fix low-karma autokick evasion

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -648,6 +648,9 @@ function BeginRound()
    -- Remove their ragdolls
    ents.TTT.RemoveRagdolls(true)
 
+   -- Check for low-karma players that weren't banned on round end
+   if KARMA.cv.autokick:GetBool() then KARMA.CheckAutoKickAll() end
+
    if CheckForAbort() then return end
 
    -- Select traitors & co. This is where things really start so we can't abort

--- a/garrysmod/gamemodes/terrortown/gamemode/karma.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/karma.lua
@@ -259,9 +259,7 @@ function KARMA.RoundEnd()
       KARMA.RememberAll()
 
       if config.autokick:GetBool() then
-         for _, ply in ipairs(player.GetAll()) do
-            KARMA.CheckAutoKick(ply)
-         end
+         KARMA.CheckAutoKickAll()
       end
    end
 end
@@ -356,6 +354,12 @@ function KARMA.CheckAutoKick(ply)
       else
          ply:Kick(reason)
       end
+   end
+end
+
+function KARMA.CheckAutoKickAll()
+   for _, ply in ipairs(player.GetAll()) do
+      KARMA.CheckAutoKick(ply)
    end
 end
 


### PR DESCRIPTION
Fixes players with low karma being able to keep playing by leaving the server before the round ends and rejoining.