### PR TITLE
Adds a player mic volume slider to the TTT scoreboard

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -648,6 +648,9 @@ function BeginRound()
    -- Remove their ragdolls
    ents.TTT.RemoveRagdolls(true)
 
+   -- Check for low-karma players that weren't banned on round end
+   if KARMA.cv.autokick:GetBool() then KARMA.CheckAutoKickAll() end
+
    if CheckForAbort() then return end
 
    -- Select traitors & co. This is where things really start so we can't abort

--- a/garrysmod/gamemodes/terrortown/gamemode/karma.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/karma.lua
@@ -259,9 +259,7 @@ function KARMA.RoundEnd()
       KARMA.RememberAll()
 
       if config.autokick:GetBool() then
-         for _, ply in ipairs(player.GetAll()) do
-            KARMA.CheckAutoKick(ply)
-         end
+         KARMA.CheckAutoKickAll()
       end
    end
 end
@@ -356,6 +354,12 @@ function KARMA.CheckAutoKick(ply)
       else
          ply:Kick(reason)
       end
+   end
+end
+
+function KARMA.CheckAutoKickAll()
+   for _, ply in ipairs(player.GetAll()) do
+      KARMA.CheckAutoKick(ply)
    end
 end
 

--- a/garrysmod/gamemodes/terrortown/gamemode/lang/english.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/lang/english.lua
@@ -1081,3 +1081,6 @@ L.binoc_zoom_level = "LEVEL"
 L.binoc_body = "BODY DETECTED"
 
 L.idle_popup_title = "Idle"
+
+--- 2021-06-07
+L.sb_playervolume = "Player Volume"

--- a/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -171,6 +171,12 @@ function PANEL:SetPlayer(ply)
                            end
                         end
 
+   self.voice.DoRightClick = function()
+      if IsValid(ply) and ply != LocalPlayer() then
+         self:ShowMicVolumeSlider()
+      end
+   end
+
    self:UpdatePlayerData()
 end
 
@@ -312,6 +318,99 @@ function PANEL:DoRightClick()
    if close then menu:Remove() return end
 
    menu:Open()
+end
+
+
+function PANEL:ShowMicVolumeSlider()
+	local width = 300
+	local height = 50
+	local padding = 10
+
+	local sliderHeight = 16
+	local sliderDisplayHeight = 8
+
+	local x = math.max(gui.MouseX() - width, 0)
+	local y = math.min(gui.MouseY(), ScrH() - height)
+
+	local currentPlayerVolume = self:GetPlayer():GetVoiceVolumeScale()
+	currentPlayerVolume = currentPlayerVolume != nil and currentPlayerVolume or 1
+
+
+	-- Frame for the slider
+	local frame = vgui.Create("DFrame")
+	frame:SetPos(x, y)
+	frame:SetSize(width, height)
+	frame:MakePopup()
+	frame:SetTitle("")
+	frame:ShowCloseButton(false)
+	frame:SetDraggable(false)
+	frame:SetSizable(false)
+	frame.Paint = function(self, w, h)
+		draw.RoundedBox(5, 0, 0, w, h, Color(24, 25, 28, 255))
+	end
+
+	-- Automatically close after 10 seconds (something may have gone wrong)
+	timer.Simple(10, function() if IsValid(frame) then frame:Close() end end)
+
+
+	-- "Player volume"
+	local label = vgui.Create("DLabel", frame)
+	label:SetPos(padding, padding)
+	label:SetFont("cool_small")
+	label:SetSize(width - padding * 2, 20)
+	label:SetColor(Color(255, 255, 255, 255))
+	label:SetText(LANG.GetTranslation("sb_playervolume"))
+
+
+	-- Slider
+	local slider = vgui.Create("DSlider", frame)
+	slider:SetHeight(sliderHeight)
+	slider:Dock(TOP)
+	slider:DockMargin(padding, 0, padding, 0)
+	slider:SetSlideX(currentPlayerVolume)
+	slider:SetLockY(0.5)
+	slider.TranslateValues = function(slider, x, y)
+      if IsValid(self:GetPlayer()) then self:GetPlayer():SetVoiceVolumeScale(x) end
+		return x, y
+	end
+
+	-- Close the slider panel once the player has selected a volume
+	slider.OnMouseReleased = function(panel, mcode) frame:Close() end
+	slider.Knob.OnMouseReleased = function(panel, mcode) frame:Close() end
+
+
+	-- Slider rendering
+	-- Render slider bar
+	slider.Paint = function(self, w, h)
+		local volumePercent = slider:GetSlideX()
+
+		-- Filled in box
+		draw.RoundedBox(5, 0, sliderDisplayHeight / 2, w * volumePercent, sliderDisplayHeight, Color(200, 46, 46, 255))
+
+		-- Grey box
+		draw.RoundedBox(5, w * volumePercent, sliderDisplayHeight / 2, w * (1 - volumePercent), sliderDisplayHeight, Color(79, 84, 92, 255))
+	end
+
+	-- Render slider "knob" & text
+	slider.Knob.Paint = function(self, w, h)
+		if slider:IsEditing() then
+			local textValue = math.Round(slider:GetSlideX() * 100) .. "%"
+			local textPadding = 5
+
+			-- The position of the text and size of rounded box are not relative to the text size. May cause problems if font size changes
+			draw.RoundedBox(
+				5, -- Radius
+				-sliderHeight * 0.5 - textPadding, -- X
+				-25, -- Y
+				sliderHeight * 2 + textPadding * 2, -- Width
+				sliderHeight + textPadding * 2, -- Height
+				Color(52, 54, 57, 255)
+			)
+			draw.DrawText(textValue, "cool_small", sliderHeight / 2, -20, Color(255, 255, 255, 255), TEXT_ALIGN_CENTER)
+		end
+		
+		draw.RoundedBox(100, 0, 0, sliderHeight, sliderHeight, Color(255, 255, 255, 255))
+	end
 end
 
 vgui.Register( "TTTScorePlayerRow", PANEL, "DButton" )

--- a/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -322,95 +322,95 @@ end
 
 
 function PANEL:ShowMicVolumeSlider()
-	local width = 300
-	local height = 50
-	local padding = 10
+   local width = 300
+   local height = 50
+   local padding = 10
 
-	local sliderHeight = 16
-	local sliderDisplayHeight = 8
+   local sliderHeight = 16
+   local sliderDisplayHeight = 8
 
-	local x = math.max(gui.MouseX() - width, 0)
-	local y = math.min(gui.MouseY(), ScrH() - height)
+   local x = math.max(gui.MouseX() - width, 0)
+   local y = math.min(gui.MouseY(), ScrH() - height)
 
-	local currentPlayerVolume = self:GetPlayer():GetVoiceVolumeScale()
-	currentPlayerVolume = currentPlayerVolume != nil and currentPlayerVolume or 1
-
-
-	-- Frame for the slider
-	local frame = vgui.Create("DFrame")
-	frame:SetPos(x, y)
-	frame:SetSize(width, height)
-	frame:MakePopup()
-	frame:SetTitle("")
-	frame:ShowCloseButton(false)
-	frame:SetDraggable(false)
-	frame:SetSizable(false)
-	frame.Paint = function(self, w, h)
-		draw.RoundedBox(5, 0, 0, w, h, Color(24, 25, 28, 255))
-	end
-
-	-- Automatically close after 10 seconds (something may have gone wrong)
-	timer.Simple(10, function() if IsValid(frame) then frame:Close() end end)
+   local currentPlayerVolume = self:GetPlayer():GetVoiceVolumeScale()
+   currentPlayerVolume = currentPlayerVolume != nil and currentPlayerVolume or 1
 
 
-	-- "Player volume"
-	local label = vgui.Create("DLabel", frame)
-	label:SetPos(padding, padding)
-	label:SetFont("cool_small")
-	label:SetSize(width - padding * 2, 20)
-	label:SetColor(Color(255, 255, 255, 255))
-	label:SetText(LANG.GetTranslation("sb_playervolume"))
+   -- Frame for the slider
+   local frame = vgui.Create("DFrame")
+   frame:SetPos(x, y)
+   frame:SetSize(width, height)
+   frame:MakePopup()
+   frame:SetTitle("")
+   frame:ShowCloseButton(false)
+   frame:SetDraggable(false)
+   frame:SetSizable(false)
+   frame.Paint = function(self, w, h)
+      draw.RoundedBox(5, 0, 0, w, h, Color(24, 25, 28, 255))
+   end
+
+   -- Automatically close after 10 seconds (something may have gone wrong)
+   timer.Simple(10, function() if IsValid(frame) then frame:Close() end end)
 
 
-	-- Slider
-	local slider = vgui.Create("DSlider", frame)
-	slider:SetHeight(sliderHeight)
-	slider:Dock(TOP)
-	slider:DockMargin(padding, 0, padding, 0)
-	slider:SetSlideX(currentPlayerVolume)
-	slider:SetLockY(0.5)
-	slider.TranslateValues = function(slider, x, y)
+   -- "Player volume"
+   local label = vgui.Create("DLabel", frame)
+   label:SetPos(padding, padding)
+   label:SetFont("cool_small")
+   label:SetSize(width - padding * 2, 20)
+   label:SetColor(Color(255, 255, 255, 255))
+   label:SetText(LANG.GetTranslation("sb_playervolume"))
+
+
+   -- Slider
+   local slider = vgui.Create("DSlider", frame)
+   slider:SetHeight(sliderHeight)
+   slider:Dock(TOP)
+   slider:DockMargin(padding, 0, padding, 0)
+   slider:SetSlideX(currentPlayerVolume)
+   slider:SetLockY(0.5)
+   slider.TranslateValues = function(slider, x, y)
       if IsValid(self:GetPlayer()) then self:GetPlayer():SetVoiceVolumeScale(x) end
-		return x, y
-	end
+      return x, y
+   end
 
-	-- Close the slider panel once the player has selected a volume
-	slider.OnMouseReleased = function(panel, mcode) frame:Close() end
-	slider.Knob.OnMouseReleased = function(panel, mcode) frame:Close() end
+   -- Close the slider panel once the player has selected a volume
+   slider.OnMouseReleased = function(panel, mcode) frame:Close() end
+   slider.Knob.OnMouseReleased = function(panel, mcode) frame:Close() end
 
 
-	-- Slider rendering
-	-- Render slider bar
-	slider.Paint = function(self, w, h)
-		local volumePercent = slider:GetSlideX()
+   -- Slider rendering
+   -- Render slider bar
+   slider.Paint = function(self, w, h)
+      local volumePercent = slider:GetSlideX()
 
-		-- Filled in box
-		draw.RoundedBox(5, 0, sliderDisplayHeight / 2, w * volumePercent, sliderDisplayHeight, Color(200, 46, 46, 255))
+      -- Filled in box
+      draw.RoundedBox(5, 0, sliderDisplayHeight / 2, w * volumePercent, sliderDisplayHeight, Color(200, 46, 46, 255))
 
-		-- Grey box
-		draw.RoundedBox(5, w * volumePercent, sliderDisplayHeight / 2, w * (1 - volumePercent), sliderDisplayHeight, Color(79, 84, 92, 255))
-	end
+      -- Grey box
+      draw.RoundedBox(5, w * volumePercent, sliderDisplayHeight / 2, w * (1 - volumePercent), sliderDisplayHeight, Color(79, 84, 92, 255))
+   end
 
-	-- Render slider "knob" & text
-	slider.Knob.Paint = function(self, w, h)
-		if slider:IsEditing() then
-			local textValue = math.Round(slider:GetSlideX() * 100) .. "%"
-			local textPadding = 5
+   -- Render slider "knob" & text
+   slider.Knob.Paint = function(self, w, h)
+      if slider:IsEditing() then
+         local textValue = math.Round(slider:GetSlideX() * 100) .. "%"
+         local textPadding = 5
 
-			-- The position of the text and size of rounded box are not relative to the text size. May cause problems if font size changes
-			draw.RoundedBox(
-				5, -- Radius
-				-sliderHeight * 0.5 - textPadding, -- X
-				-25, -- Y
-				sliderHeight * 2 + textPadding * 2, -- Width
-				sliderHeight + textPadding * 2, -- Height
-				Color(52, 54, 57, 255)
-			)
-			draw.DrawText(textValue, "cool_small", sliderHeight / 2, -20, Color(255, 255, 255, 255), TEXT_ALIGN_CENTER)
-		end
-		
-		draw.RoundedBox(100, 0, 0, sliderHeight, sliderHeight, Color(255, 255, 255, 255))
-	end
+         -- The position of the text and size of rounded box are not relative to the text size. May cause problems if font size changes
+         draw.RoundedBox(
+            5, -- Radius
+            -sliderHeight * 0.5 - textPadding, -- X
+            -25, -- Y
+            sliderHeight * 2 + textPadding * 2, -- Width
+            sliderHeight + textPadding * 2, -- Height
+            Color(52, 54, 57, 255)
+         )
+         draw.DrawText(textValue, "cool_small", sliderHeight / 2, -20, Color(255, 255, 255, 255), TEXT_ALIGN_CENTER)
+      end
+      
+      draw.RoundedBox(100, 0, 0, sliderHeight, sliderHeight, Color(255, 255, 255, 255))
+   end
 end
 
 vgui.Register( "TTTScorePlayerRow", PANEL, "DButton" )


### PR DESCRIPTION
This PR adds a volume slider to adjust a player's microphone volume, using the new `Set/GetVoiceVolumeScale` functions, about to be introduced in the next GMod update (June 9th).

Players can right click on the mute/unmute button in the TTT scoreboard to get a slider, to adjust that player's mic volume.
![preview](https://i.imgur.com/j1KGqhx.png)


[Preview video - https://www.youtube.com/watch?v=0GzG5lA6EvM](https://www.youtube.com/watch?v=0GzG5lA6EvM)


# Translations
This adds a new message to the TTT language files.
Translations would be greatly appreciated, even if it is a simple phrase- "Player Volume"

* Thanks to Tiagoquix for the Brazilian Portuguese translation