### PR TITLE
Tool ghost entity improvements

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/balloon.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/balloon.lua
@@ -16,6 +16,8 @@ TOOL.Information = {
 
 cleanup.Register( "balloons" )
 
+local hitangle_offset = Angle( 90, 0, 0 )
+
 function TOOL:LeftClick( trace, attach )
 
 	if ( IsValid( trace.Entity ) && trace.Entity:IsPlayer() ) then return false end
@@ -84,8 +86,10 @@ function TOOL:LeftClick( trace, attach )
 	local Offset = CurPos - NearestPoint
 
 	local Pos = trace.HitPos + Offset
+	local Ang = trace.HitNormal:Angle() + hitangle_offset
 
 	balloon:SetPos( Pos )
+	balloon:SetAngles( Ang )
 
 	undo.Create( "Balloon" )
 		undo.AddEntity( balloon )
@@ -182,12 +186,13 @@ function TOOL:UpdateGhostBalloon( ent, ply )
 	local Offset = CurPos - NearestPoint
 
 	local pos = trace.HitPos + Offset
+	local ang = trace.HitNormal:Angle() + hitangle_offset
 
 	local modeltable = list.Get( "BalloonModels" )[ self:GetClientInfo( "model" ) ]
 	if ( modeltable.skin ) then ent:SetSkin( modeltable.skin ) end
 
 	ent:SetPos( pos )
-	ent:SetAngles( angle_zero )
+	ent:SetAngles( ang )
 
 	ent:SetNoDraw( false )
 
@@ -204,6 +209,11 @@ function TOOL:Think()
 		if ( IsValid( self.GhostEntity ) ) then self.GhostEntity.model = self:GetClientInfo( "model" ) end
 
 	end
+
+end
+
+-- DrawHUD is called every frame making it a better option than Think for updating the ghost balloon
+function TOOL:DrawHUD()
 
 	self:UpdateGhostBalloon( self.GhostEntity, self:GetOwner() )
 

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/button.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/button.lua
@@ -159,6 +159,10 @@ function TOOL:Think()
 		self:MakeGhostEntity( mdl, vector_origin, angle_zero )
 	end
 
+end
+
+function TOOL:DrawHUD()
+
 	self:UpdateGhostButton( self.GhostEntity, self:GetOwner() )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/dynamite.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/dynamite.lua
@@ -152,6 +152,10 @@ function TOOL:Think()
 		self:MakeGhostEntity( mdl, vector_origin, angle_zero )
 	end
 
+end
+
+function TOOL:DrawHUD()
+
 	self:UpdateGhostDynamite( self.GhostEntity, self:GetOwner() )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/emitter.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/emitter.lua
@@ -172,6 +172,10 @@ function TOOL:Think()
 		self:MakeGhostEntity( "models/props_lab/tpplug.mdl", vector_origin, angle_zero )
 	end
 
+end
+
+function TOOL:DrawHUD()
+
 	self:UpdateGhostEmitter( self.GhostEntity, self:GetOwner() )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/hoverball.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/hoverball.lua
@@ -206,6 +206,10 @@ function TOOL:Think()
 		self:MakeGhostEntity( mdl, vector_origin, angle_zero )
 	end
 
+end
+
+function TOOL:DrawHUD()
+
 	self:UpdateGhostHoverball( self.GhostEntity, self:GetOwner() )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/lamp.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/lamp.lua
@@ -229,6 +229,10 @@ function TOOL:Think()
 		self:MakeGhostEntity( mdl, vector_origin, angle_zero )
 	end
 
+end
+
+function TOOL:DrawHUD()
+
 	self:UpdateGhostLamp( self.GhostEntity, self:GetOwner() )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/light.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/light.lua
@@ -204,6 +204,10 @@ function TOOL:Think()
 		self:MakeGhostEntity( "models/maxofs2d/light_tubular.mdl", vector_origin, angle_zero )
 	end
 
+end
+
+function TOOL:DrawHUD()
+
 	self:UpdateGhostLight( self.GhostEntity, self:GetOwner() )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/thruster.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/thruster.lua
@@ -208,6 +208,10 @@ function TOOL:Think()
 		self:MakeGhostEntity( mdl, vector_origin, angle_zero )
 	end
 
+end
+
+function TOOL:DrawHUD()
+
 	self:UpdateGhostThruster( self.GhostEntity, self:GetOwner() )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/wheel.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/wheel.lua
@@ -234,6 +234,10 @@ function TOOL:Think()
 		self:MakeGhostEntity( mdl, vector_origin, angle_zero )
 	end
 
+end
+
+function TOOL:DrawHUD()
+
 	self:UpdateGhostWheel( self.GhostEntity, self:GetOwner() )
 
 end


### PR DESCRIPTION
I have fixed the jittering ghost entities for tools when you move them about, this happens because it's being updated in a TOOL:Think function, which isn't called at the client's FPS.
I have moved the update ghost entity function for each tool into a TOOL:DrawHUD function, which is called every frame.
I have also made balloons align with the surface normal, which feels more natural.

Before:
https://user-images.githubusercontent.com/53242610/121425487-5da8ec00-c96a-11eb-89f6-5ae62ad4ab38.mp4

After:
https://user-images.githubusercontent.com/53242610/121425559-731e1600-c96a-11eb-84ee-0a4c8ea8d8a1.mp4