### PR TITLE
Fix errors from GetInt() when text entry contents aren't numeric

### DIFF
--- a/garrysmod/lua/vgui/dtextentry.lua
+++ b/garrysmod/lua/vgui/dtextentry.lua
@@ -379,9 +379,9 @@ end
 function PANEL:GetInt()
 
 	local num = tonumber( self:GetText() )
-	if !num then return end
+	if ( !num ) then return nil end
 
-	return math.floor( num + 0.5 )
+	return math.Round( num )
 
 end
 

--- a/garrysmod/lua/vgui/dtextentry.lua
+++ b/garrysmod/lua/vgui/dtextentry.lua
@@ -378,7 +378,10 @@ end
 
 function PANEL:GetInt()
 
-	return math.floor( tonumber( self:GetText() ) + 0.5 )
+	local num = tonumber( self:GetText() )
+	if !num then return end
+
+	return math.floor( num + 0.5 )
 
 end
 


### PR DESCRIPTION
The expected behaviour of DTextEntry:GetInt() is to return nil if the contents of the text entry aren't numeric ([according to the wiki](https://wiki.facepunch.com/gmod/DTextEntry:GetInt)).
The current method doesn't do this, and instead will throw an error when attempting to call it under this circumstance. It seems to be a bug that was overlooked when pasting the DTextEntry:GetFloat() method (seen below GetInt()) and adapting it to allow returning integers.