### PR TITLE
Added killicon.AddTexture()

### DIFF
--- a/garrysmod/lua/includes/modules/killicon.lua
+++ b/garrysmod/lua/includes/modules/killicon.lua
@@ -36,6 +36,15 @@ function Add( name, material, color )
 
 end
 
+function AddTexture( name, texture, color )
+
+	Icons[name] = {}
+	Icons[name].type 		= TYPE_TEXTURE
+	Icons[name].texture		= texture
+	Icons[name].color 		= color
+
+end
+
 function AddAlias( name, alias )
 
 	Icons[name] = Icons[alias]


### PR DESCRIPTION
Adds the ability to add non-VMT based killicons by passing killicons directly into the killicon table, making the process for creating killicons much easier, and finally allowing for dynamically generated killicons and .png killicons. One image can now be used to populate spawn icon, select icon, and kill icon, much more easily.