### PR TITLE
Fixed XSS vulnerability in loading screen.

### DIFF
--- a/garrysmod/html/loading.html
+++ b/garrysmod/html/loading.html
@@ -47,9 +47,9 @@
 
 			function GameDetails( servername, serverurl, mapname, maxplayers, steamid, gamemode, volume, lang, gamemodeNice )
 			{
-				$("#serverName").html( servername );
-				$("#serverMap").html( mapname );
-				$("#serverGamemode").html( gamemodeNice );
+				$("#serverName").text( servername );
+				$("#serverMap").text( mapname );
+				$("#serverGamemode").text( gamemodeNice );
 				$("#mapimg").attr("src", "asset://mapimage/" + mapname );
 				$("body").css( "background-image", "url( 'asset://mapimage/" + mapname + "' )" );
 


### PR DESCRIPTION
Using the method `.text` rather than `.html`, since the method `.html` does not escape html entity characters.