### PR TITLE
Fix an obscure usergroup bug with `IsUserGroup`

### DIFF
--- a/garrysmod/lua/includes/extensions/player_auth.lua
+++ b/garrysmod/lua/includes/extensions/player_auth.lua
@@ -33,7 +33,7 @@ function meta:IsUserGroup( name )
 
 	if ( not self:IsValid() ) then return false end
 
-	return self:GetNWString( "UserGroup" ) == name
+	return self:GetUserGroup() == name
 
 end
 


### PR DESCRIPTION
On servers that remove the `PlayerAuthSpawn` hook which sets your usergroup to `user` if you don't have one, `PLAYER:IsUserGroup("user")` will return false despite `PLAYER:GetUserGroup()` returning `user` _if_ the server doesn't call `PLAYER:SetUserGroup("user")` at initial spawn.

Namely FAdmin (literally every DarkRP server) is vulnerable to this, unless ULX is installed alongside.