### PR TITLE
Add SlowWalkSpeed to player_manager / GM.SetPlayerSpeed / Default player classes

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/player_class/player_default.lua
+++ b/garrysmod/gamemodes/base/gamemode/player_class/player_default.lua
@@ -7,6 +7,7 @@ local PLAYER = {}
 
 PLAYER.DisplayName			= "Default Class"
 
+PLAYER.SlowWalkSpeed		= 200		-- How fast to move when slow-walking (+WALK)
 PLAYER.WalkSpeed			= 400		-- How fast to move when not running
 PLAYER.RunSpeed				= 600		-- How fast to move when running
 PLAYER.CrouchedWalkSpeed	= 0.3		-- Multiply move speed by this when crouching

--- a/garrysmod/gamemodes/base/gamemode/player_shd.lua
+++ b/garrysmod/gamemodes/base/gamemode/player_shd.lua
@@ -14,8 +14,9 @@ end
 	Name: gamemode:SetPlayerSpeed( )
 	Desc: Sets the player's run/walk speed
 -----------------------------------------------------------]]
-function GM:SetPlayerSpeed( ply, walk, run )
+function GM:SetPlayerSpeed( ply, walk, run, slowWalk )
 
+	ply:SetSlowWalkSpeed( slowWalk )
 	ply:SetWalkSpeed( walk )
 	ply:SetRunSpeed( run )
 

--- a/garrysmod/gamemodes/sandbox/gamemode/player_class/player_sandbox.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/player_class/player_sandbox.lua
@@ -24,6 +24,7 @@ PLAYER.TauntCam = TauntCamera()
 --
 -- See gamemodes/base/player_class/player_default.lua for all overridable variables
 --
+PLAYER.SlowWalkSpeed		= 100
 PLAYER.WalkSpeed 			= 200
 PLAYER.RunSpeed				= 400
 

--- a/garrysmod/lua/includes/modules/player_manager.lua
+++ b/garrysmod/lua/includes/modules/player_manager.lua
@@ -423,6 +423,7 @@ function OnPlayerSpawn( ply, transiton )
 	local class = LookupPlayerClass( ply )
 	if ( !class ) then return end
 
+	ply:SetSlowWalkSpeed( class.SlowWalkSpeed )
 	ply:SetWalkSpeed( class.WalkSpeed )
 	ply:SetRunSpeed( class.RunSpeed )
 	ply:SetCrouchedWalkSpeed( class.CrouchedWalkSpeed )


### PR DESCRIPTION
Following up on https://github.com/Facepunch/garrysmod-requests/issues/1231, this pull request brings support for `PLAYER.SetSlowWalkSpeed` to:

- `player_manager.OnPlayerSpawn`
- `GM.SetPlayerSpeed`
- The `player_default` and `player_sandbox` player classes

Please let me know if I'm missing anything or if there's any way this can be improved!