### PR TITLE
Additional check for TableInherit function

### DIFF
--- a/garrysmod/lua/includes/modules/scripted_ents.lua
+++ b/garrysmod/lua/includes/modules/scripted_ents.lua
@@ -25,7 +25,7 @@ local function TableInherit( t, base )
 
 		if ( t[ k ] == nil ) then
 			t[ k ] = v
-		elseif ( k != "BaseClass" && istable( t[ k ] ) ) then
+		elseif ( k != "BaseClass" && istable( t[ k ] ) && istable( v ) ) then
 			TableInherit( t[ k ], v )
 		end
 


### PR DESCRIPTION
If you write argument in base entity like a string and then overwrite it like table you will catch error like 

```
[ERROR] lua/includes/modules/scripted_ents.lua:25: bad argument #1 to 'pairs' (table expected, got string)
  1. pairs - [C]:-1
   2. TableInherit - lua/includes/modules/scripted_ents.lua:25
    3. TableInherit - lua/includes/modules/scripted_ents.lua:30
     4. Get - lua/includes/modules/scripted_ents.lua:184
      5. unknown - lua/includes/modules/scripted_ents.lua:151
 ```