### PR TITLE
Fix mistake in russian.lua

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/lang/russian.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/lang/russian.lua
@@ -499,7 +499,7 @@ L.dna_menu_scan   = "Поиск"
 L.dna_menu_repeat = "Автоповтор"
 L.dna_menu_ready  = "ГОТОВ"
 L.dna_menu_charge = "ЗАРЯДКА"
-L.dna_menu_select = "ВЫБЕРЕТЕ ОБРАЗЕЦ"
+L.dna_menu_select = "ВЫБЕРИТЕ ОБРАЗЕЦ"
 
 L.dna_help_primary   = "{primaryfire}: собрать образец ДНК."
 L.dna_help_secondary = "{secondaryfire}: открыть меню управления."


### PR DESCRIPTION
Incorrect form

> ВЫБЕРЕТЕ ОБРАЗЕЦ

Correct

> ВЫБЕРИТЕ ОБРАЗЕЦ

The word “выберите” expresses a wish, request, or order. In this context, the verb form of the imperative plural is used.

https://russkiiyazyk.ru/orfografiya/pravopisanie/kak-pravilno-pishetsya-slovo-vyiberete-ili-vyiberite.html