### PR TITLE
Add SafeIndex, SafeCallMetaFunction, SafeCopy, and SafeSerialize

### DIFF
--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -458,3 +458,113 @@ function GetConVarString( name )
 	local c = GetConVar( name )
 	return ( c and c:GetString() ) or ""
 end
+
+
+--[[---------------------------------------------------------
+	Safe functions
+-----------------------------------------------------------]]
+
+local type = type
+local pcall = pcall
+local rawget = rawget
+local TypeID = TypeID
+local istable = istable
+local tostring = tostring
+local string_format = string.format
+local debug_getmetatable = debug.getmetatable
+
+local fSafeIndex
+
+do
+	local function IndexPassThru( success, err, ... )
+		if ( success ) then return true, err, ... end
+		return false, string_format( "\"__index\" function errored (%s)", err )
+	end
+
+	fSafeIndex = function( var, key )
+		local index = var
+		local index_type
+		
+		-- If var is a table
+		-- skip all of the extra checks verifying if a non-table can be indexed
+		if ( istable( var ) ) then goto TableIndex end
+		
+			local meta = debug_getmetatable( var )
+			if ( meta == nil ) then return false, "no metatable" end
+			
+			index = rawget( meta, "__index" )
+			if ( index == nil ) then return false, "no \"__index\" key defined" end
+		
+			index_type = TypeID( index )
+			if ( index_type == TYPE_FUNCTION ) then return IndexPassThru( pcall( index, var, key ) ) end
+			if ( index_type != TYPE_TABLE ) then return false, string_format( "expected \"__index\" key to be a table or function, got %s", type( index ) ) end
+		
+		::TableIndex::
+		
+		-- To prevent cyclic references
+		local metas = { [ meta ] = true }
+		
+		-- Repeat the same process for __index sub-tables
+		-- but not having __index present or it being the wrong type is no longer halting
+		repeat
+			-- Try raw indexing first
+			local out = rawget( index, key )
+			if ( out != nil ) then return true, out end
+			
+			-- Then check the metatable
+			local meta = debug_getmetatable( index )
+			if ( meta == nil ) then return true, nil end
+			if ( metas[ meta ] ) then return false, "cyclic \"__index\" reference" end
+			metas[ meta ] = true
+			
+			index = rawget( meta, "__index" )
+			if ( index == nil ) then return true, nil end
+			
+			index_type = TypeID( index )
+			if ( index_type == TYPE_FUNCTION ) then return IndexPassThru( pcall( index, var, key ) ) end
+		until ( index_type != TYPE_TABLE )
+		
+		return true, nil
+	end
+	
+	SafeIndex = fSafeIndex
+end
+
+do
+	local DefaultMappings = {
+		[TYPE_BOOL] = function( b )
+			if ( b ) return "1" end
+			return "0"
+		end,
+		[TYPE_NUMBER] = tostring,
+		[TYPE_STRING] = tostring
+	}
+
+	function SafeSerialize( var, funcname, mappings )
+		if ( funcname == nil ) then funcname = "Serialize" end
+		if ( mappings == nil ) then mappings = DefaultMappings end
+		
+		local func = mappings[ TypeID( var ) ]
+		if ( func != nil ) then return true, func( var ) end
+		
+		-- Skip indexing var itself by indexing its metatable directly
+		-- If var is a table and has a Serialize method present, it is probably not an object instance
+		-- but rather a metatable, ex. SafeSerialze( FindMetaTable("Vector") )
+		-- This prevents calling Serialize incorrectly on either a binded object or metatable
+		local meta = debug_getmetatable( var )
+		if ( meta == nil ) then return false, "no metatable" end
+		
+		local success
+		success, func = fSafeIndex( meta, funcname )
+		if ( !success ) then return false, string_format( "failed to index the metatable (%s)", func ) end
+		if ( func == nil ) then return false, string_format( "no \"%s\" function", funcname ) end
+		if ( !isfunction( func ) ) then return false, string_format( "expected \"%s\" to be a function, got %s", funcname, type( func ) ) end
+		
+		local success, out = pcall( func, var )
+		if ( !success ) then return false, string_format( "\"%s\" function errored (%s)", funcname, out ) end
+		if ( !isstring( out ) ) then return false, "expected \"%s\" function to return a string, got " .. type( out ) end
+		
+		return true, out
+	end
+end
+

--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -487,8 +487,7 @@ do
 		
 		-- If var is a table
 		-- skip all of the extra checks verifying if a non-table can be indexed
-		if ( istable( var ) ) then goto TableIndex end
-		
+		if ( not istable( var ) ) then
 			local meta = debug_getmetatable( var )
 			if ( meta == nil ) then return false, "no metatable" end
 			
@@ -498,8 +497,7 @@ do
 			index_type = TypeID( index )
 			if ( index_type == TYPE_FUNCTION ) then return IndexPassThru( pcall( index, var, key ) ) end
 			if ( index_type != TYPE_TABLE ) then return false, string_format( "expected \"__index\" key to be a table or function, got %s", type( index ) ) end
-		
-		::TableIndex::
+		end
 		
 		-- To prevent cyclic references
 		local metas = { [ meta ] = true }

--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -560,7 +560,7 @@ do
 		
 		local success, out = pcall( func, var )
 		if ( !success ) then return false, string_format( "\"%s\" function errored (%s)", funcname, out ) end
-		if ( !isstring( out ) ) then return false, "expected \"%s\" function to return a string, got " .. type( out ) end
+		if ( !isstring( out ) ) then return false, string_format( "expected \"%s\" function to return a string, got %s", funcname, type( out ) ) end
 		
 		return true, out
 	end


### PR DESCRIPTION
Adds:
- `bool success, ... rets SafeIndex(any var, any key)` - attempts to index the var with the given key. Returns true and the ret(s) if the index could occur without error even if it returns nil. If false is returned, also returns an error as the second argument.
- `bool success, any ret SafeCallMetaFunction(any var, any funcname, table mappings = nil)`
- `bool success, any ret SafeCopy(any var, any funcname, table mappings = {/*See impl*/})`
- `bool success, string serial SafeSerialize(any var, any funcname = "Serialize", table mappings = {/*See impl*/})` - attempts to run var:Serialize(). The mappings table can be used to call a custom function instead of Serialize on a per-type basis - this allows bools, strings, and numbers to be serialized. Returns true and the string result of the function if successful, or false and the error if failed.

See https://github.com/Facepunch/garrysmod/pull/1849 for use cases.