### PR TITLE
Don't stop refreshing server list when joining a server

### DIFF
--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -159,7 +159,6 @@ function ControllerServers( $scope, $element, $rootScope, $location )
 			lua.Run( "RunConsoleCommand( \"password\", %s )", srv.password );
 
 		lua.Run( "JoinServer( %s )", srv.address );
-		$scope.DoStopRefresh();
 	}
 
 	$scope.SwitchType = function( type )


### PR DESCRIPTION
Canceling the server list refresh when connecting to a server may lead people to believe there's less servers than there really is. 

This is especially problematic after @willox's change to load populated servers first was reverted as servers can now take quite some time to load.