### PR TITLE
Fix TTTCanPickupAmmo hook not allowing false return

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/entities/base_ammo_ttt.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/base_ammo_ttt.lua
@@ -50,9 +50,11 @@ function ENT:PlayerCanPickup(ply)
    if ply == self:GetOwner() then return false end
 
    local result = hook.Call("TTTCanPickupAmmo", nil, ply, self)
-   if result then
+
+   if result != nil then
       return result
    end
+
 
    local ent = self
    local phys = ent:GetPhysicsObject()


### PR DESCRIPTION
If you attempted to return false when adding TTTCanPickupAmmo, it would still allow players to pick up ammo. Instead of checking if the hook returns true, it now checks if the hook returns anything.