### PR TITLE
Correction of a typing error in the comments

### DIFF
--- a/garrysmod/lua/includes/extensions/math.lua
+++ b/garrysmod/lua/includes/extensions/math.lua
@@ -149,7 +149,7 @@ function math.BSplinePoint( tDiff, tPoints, tMax )
 
 end
 
--- Round to the nearest interger
+-- Round to the nearest integer
 function math.Round( num, idp )
 
 	local mult = 10 ^ ( idp or 0 )


### PR DESCRIPTION
This is a problem of huge importance: it was written "interger" instead of "integer" in the math.lua file.
The game will surely be better with this fix ;)