### PR TITLE
Add sequential parameter to net.Read/WriteTable

### DIFF
--- a/garrysmod/lua/includes/extensions/net.lua
+++ b/garrysmod/lua/includes/extensions/net.lua
@@ -115,7 +115,7 @@ function net.WriteTable( tab, seq )
 
 		for i = 1, len do
 
-			net.WriteType( tab[i] )
+			net.WriteType( tab[ i ] )
 
 		end
 		
@@ -141,9 +141,9 @@ function net.ReadTable( seq )
 
 	if ( seq ) then
 
-		for i = 1, net.ReadUInt(32) do
+		for i = 1, net.ReadUInt( 32 ) do
 
-			tab[i] = net.ReadType()
+			tab[ i ] = net.ReadType()
 
 		end
 

--- a/garrysmod/lua/includes/extensions/net.lua
+++ b/garrysmod/lua/includes/extensions/net.lua
@@ -152,7 +152,7 @@ function net.ReadTable( seq )
 		while true do
 
 			local k = net.ReadType()
-			if ( k == nil ) then return tab end
+			if ( k == nil ) then break end
 
 			tab[ k ] = net.ReadType()
 

--- a/garrysmod/lua/includes/extensions/net.lua
+++ b/garrysmod/lua/includes/extensions/net.lua
@@ -106,32 +106,61 @@ end
 -- item indivdually and in a specific order
 -- because it adds type information before each var
 --
-function net.WriteTable( tab )
+function net.WriteTable( tab, seq )
 
-	for k, v in pairs( tab ) do
+	if ( seq ) then
 
-		net.WriteType( k )
-		net.WriteType( v )
+		local len = #tab
+		net.WriteUInt( len, 32 )
+
+		for i = 1, len do
+
+			net.WriteType( tab[i] )
+
+		end
+		
+	else
+
+		for k, v in pairs( tab ) do
+	
+			net.WriteType( k )
+			net.WriteType( v )
+	
+		end
+	
+		-- End of table
+		net.WriteType( nil )
 
 	end
-
-	-- End of table
-	net.WriteType( nil )
 
 end
 
-function net.ReadTable()
+function net.ReadTable( seq )
 
 	local tab = {}
 
-	while true do
+	if ( seq ) then
 
-		local k = net.ReadType()
-		if ( k == nil ) then return tab end
+		for i = 1, net.ReadUInt(32) do
 
-		tab[ k ] = net.ReadType()
+			tab[i] = net.ReadType()
+
+		end
+
+	else
+
+		while true do
+
+			local k = net.ReadType()
+			if ( k == nil ) then return tab end
+
+			tab[ k ] = net.ReadType()
+
+		end
 
 	end
+	
+	return tab
 
 end
 


### PR DESCRIPTION
Writing a bunch of useless keys when networking a sequential table is a waste of bits. This will allow people to network sequential tables without networking all that useless data.

Using a table of 100 Colors;
`11208` bits are networked when writing as a non-sequential table.
`4032` bits for a sequential table.