### PR TITLE
Flash the window if the game is ready (and not focused)

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/base/gamemode/cl_init.lua
@@ -23,6 +23,9 @@ end
 	Desc: Called as soon as all map entities have been spawned
 -----------------------------------------------------------]]
 function GM:InitPostEntity()
+
+	if ( !system.HasFocus() ) then system.FlashWindow() end
+
 end
 
 --[[---------------------------------------------------------


### PR DESCRIPTION
This is a small QoL feature that will alert players when they've fully loaded into a server.

Typically players tab out of the game before joining a server - this would give them a "heads up" that the game is (nearly) ready to play.

**Note**: `system.FlashWindow()` only works on Windows, but appears to have no negative side effects when run on Linux, OSX.