### PR TITLE
Add the ability to override Tooltip's delay per panel

### DIFF
--- a/garrysmod/lua/includes/extensions/client/panel.lua
+++ b/garrysmod/lua/includes/extensions/client/panel.lua
@@ -289,6 +289,13 @@ function meta:GetTooltipPanel()
 end
 
 --[[---------------------------------------------------------
+	Name: GetTooltipDelay
+-----------------------------------------------------------]]
+function meta:GetTooltipDelay()
+	return self.numTooltipDelay
+end
+
+--[[---------------------------------------------------------
 	Name: SetTooltip
 -----------------------------------------------------------]]
 function meta:SetTooltip( tooltip )
@@ -308,6 +315,13 @@ meta.SetToolTipPanel = meta.SetTooltipPanel
 -- Override which panel will be created instead of DTooltip
 function meta:SetTooltipPanelOverride( panel )
 	self.pnlTooltipPanelOverride = panel
+end
+
+--[[---------------------------------------------------------
+	Name: SetTooltipDelay
+-----------------------------------------------------------]]
+function meta:SetTooltipDelay( delay )
+	self.numTooltipDelay = delay
 end
 
 --[[---------------------------------------------------------

--- a/garrysmod/lua/vgui/dtooltip.lua
+++ b/garrysmod/lua/vgui/dtooltip.lua
@@ -99,7 +99,7 @@ end
 function PANEL:OpenForPanel( panel )
 
 	self.TargetPanel = panel
-	self.OpenDelay = isnumber(panel.numTooltipDelay) and panel.numTooltipDelay or tooltip_delay:GetFloat()
+	self.OpenDelay = isnumber( panel.numTooltipDelay ) and panel.numTooltipDelay or tooltip_delay:GetFloat()
 	self:PositionTooltip()
 
 	-- Use the parent panel's skin

--- a/garrysmod/lua/vgui/dtooltip.lua
+++ b/garrysmod/lua/vgui/dtooltip.lua
@@ -1,6 +1,7 @@
 
 --
 -- The delay before a tooltip appears
+-- Can be overridden with PANEL:SetTooltipDelay
 --
 local tooltip_delay = CreateClientConVar( "tooltip_delay", "0.5", true, false )
 
@@ -98,15 +99,16 @@ end
 function PANEL:OpenForPanel( panel )
 
 	self.TargetPanel = panel
+	self.OpenDelay = isnumber(panel.numTooltipDelay) and panel.numTooltipDelay or tooltip_delay:GetFloat()
 	self:PositionTooltip()
 
 	-- Use the parent panel's skin
 	self:SetSkin( panel:GetSkin().Name )
 
-	if ( tooltip_delay:GetFloat() > 0 ) then
+	if ( self.OpenDelay > 0 ) then
 
 		self:SetVisible( false )
-		timer.Simple( tooltip_delay:GetFloat(), function()
+		timer.Simple( self.OpenDelay, function()
 
 			if ( !IsValid( self ) ) then return end
 			if ( !IsValid( panel ) ) then return end


### PR DESCRIPTION
Adds the following methods to Panel:
```lua
Panel:SetTooltipDelay( delay )
Panel:GetTooltipDelay()
```
Internally this sets the `numTooltipDelay` value on the affected panel.  
DToolTip's will also have the `OpenDelay` value, which is determined by the above functions, and defaults to the existing convar value.