### PR TITLE
Add a check for a nil parameter

### DIFF
--- a/garrysmod/lua/includes/modules/hook.lua
+++ b/garrysmod/lua/includes/modules/hook.lua
@@ -51,7 +51,7 @@ function Remove( event_name, name )
 
 	if ( !isstring( event_name ) ) then ErrorNoHaltWithStack( "bad argument #1 to 'Remove' (string expected, got " .. type( event_name ) .. ")" ) return end
 
-	local notValid = isnumber( name ) or isbool( name ) or isfunction( name ) or !name.IsValid or !IsValid( name )
+	local notValid = !name or isnumber( name ) or isbool( name ) or isfunction( name ) or !name.IsValid or !IsValid( name )
 	if ( !isstring( name ) and notValid ) then ErrorNoHaltWithStack( "bad argument #2 to 'Add' (string expected, got " .. type( name ) .. ")" ) return end
 
 	if ( !Hooks[ event_name ] ) then return end


### PR DESCRIPTION
If `name` is not passed to `hook.Remove`, the initialization of `notValid` indexes a nil value and raises a generic Lua error instead of one more readable by addon authors. This patch raises the correct error if the parameter is omitted.