### PR TITLE
Add util.MakeColoredTextMessage

### DIFF
--- a/garrysmod/lua/includes/extensions/util.lua
+++ b/garrysmod/lua/includes/extensions/util.lua
@@ -365,3 +365,24 @@ function util.RemovePData( steamid, name )
 	sql.Query( "DELETE FROM playerpdata WHERE infoid = " .. SQLStr( name ) )
 
 end
+
+if ( SERVER ) then
+	function util.MakeColoredTextMessage( name )
+		util.AddNetworkString( name )
+
+		return function( filter )
+			net.Start( name )
+			net.Send( filter )
+		end
+	end
+else
+	function util.MakeColoredTextMessage( name, ... )
+		local func = function()
+			chat.AddText( ... )
+		end
+
+		net.Receive( name, func )
+
+		return func
+	end
+end


### PR DESCRIPTION
Usage
```Lua
-- Shared outright in a file
local HelloWorldMessage = util.MakeColoredTextMessage( "HelloWorldMessage", Color(255, 0, 255), "Hello World!" )

-- Inside of a serverside function
HelloWorldMessage(ply)
-- or
HelloWorldMessage(player.GetAll())

-- Or in a clientside function
HelloWorldMessage()
```

No more PrintMessage, no more serverside chat.AddText. Should have done this years ago. Not a great function name so I'm open to suggestions.