### PR TITLE
Add IsTableColor

### DIFF
--- a/garrysmod/lua/includes/util/color.lua
+++ b/garrysmod/lua/includes/util/color.lua
@@ -36,6 +36,17 @@ function IsColor( obj )
 
 end
 
+local function IsColorComponent( v )
+	return isnumber( v ) and v >= 0 and v <= 255 and math.floor( v ) == v
+end
+
+function IsTableColor( obj, alpha )
+	return istable( obj ) and
+		IsColorComponent( obj.r ) and
+		IsColorComponent( obj.g ) and
+		IsColorComponent( obj.b ) and
+		( not alpha or IsColorComponent( obj.a ) )
+end
 
 --[[---------------------------------------------------------
 	Returns color as a string


### PR DESCRIPTION
Checks if the table can be interpreted as an rgb(a) color since engine functions that return a color do not set the metatable. The alternative would be to add a Lua override to every function which returns a color setting the metatable, however, this does not scale for custom module functions.