### PR TITLE
PrintTable argument to ignore *nested* _G in all tables

### DIFF
--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -56,7 +56,7 @@ include( "util/color.lua" )
 --[[---------------------------------------------------------
 	Prints a table to the console
 -----------------------------------------------------------]]
-function PrintTable( t, indent, done )
+function PrintTable( t, indent, done, noNestedGlobal )
 	local Msg = Msg
 
 	done = done or {}
@@ -75,11 +75,11 @@ function PrintTable( t, indent, done )
 		local value = t[ key ]
 		Msg( string.rep( "\t", indent ) )
 
-		if  ( istable( value ) && !done[ value ] ) then
+		if  ( istable( value ) && !done[ value ] && !( value == _G && noNestedGlobal ) ) then
 
 			done[ value ] = true
 			Msg( key, ":\n" )
-			PrintTable ( value, indent + 2, done )
+			PrintTable ( value, indent + 2, done, noNestedGlobal )
 			done[ value ] = nil
 
 		else


### PR DESCRIPTION
Add option to not print the entire global table when nested in another table.
```lua
-- PrintTable( t, indent, done, noNestedGlobal )
PrintTable({1,2,3,_G}) -- will print everything like normal because noNestedGlobal isn't set
PrintTable(_G) -- will print everything like normal because noNestedGlobal isn't set (and _G._G wont get table-printed due to the "done" table anyways)
PrintTable({1,2,3,_G}, nil, nil, true) -- will print everything but will refer to a nested _G in "t" argument as "table: 0xXXXXXXXX"
PrintTable(_G, nil, nil, true) -- will print everything, _G will still be table-printed first time as is not nested in "t" argument (except for _G._G which wouldn't be table-printed due to the "done" table anyways, or any other nested _G's wont be table-printed)
```