### PR TITLE
Added support for Color's with table sanitization

### DIFF
--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -282,7 +282,7 @@ function table.Sanitise( t, done )
 
 	for k, v in pairs ( t ) do
 
-		if ( istable( v ) and !done[ v ] ) then
+		if ( istable( v ) and not IsColor( v ) and !done[ v ] ) then
 
 			done[ v ] = true
 			tbl[ k ] = table.Sanitise( v, done )
@@ -303,6 +303,15 @@ function table.Sanitise( t, done )
 				if y == 0 then y = nil end
 				if r == 0 then r = nil end
 				tbl[ k ] = { __type = "Angle", p = p, y = y, r = r }
+
+			elseif ( IsColor( v ) ) then
+
+				local r, g, b, a = v.r, v.g, v.b, v.a
+				if r == 255 then r = nil end
+				if g == 255 then g = nil end
+				if b == 255 then b = nil end
+				if a == 255 then a = nil end
+				tbl[ k ] = { __type = "Color", r = r, g = g, b = b, a = a }
 
 			elseif ( isbool( v ) ) then
 
@@ -333,7 +342,7 @@ function table.DeSanitise( t, done )
 
 	for k, v in pairs ( t ) do
 
-		if ( istable( v ) and !done[ v ] ) then
+		if ( istable( v ) and not IsColor(v) and !done[ v ] ) then
 
 			done[ v ] = true
 
@@ -341,11 +350,15 @@ function table.DeSanitise( t, done )
 
 				if ( v.__type == "Vector" ) then
 
-					tbl[ k ] = Vector( v.x, v.y, v.z )
+					tbl[ k ] = Vector( v.x or 0, v.y, v.z )
 
 				elseif ( v.__type == "Angle" ) then
 
-					tbl[ k ] = Angle( v.p, v.y, v.r )
+					tbl[ k ] = Angle( v.p or 0, v.y, v.r )
+
+				elseif ( v.__type == "Color" ) then
+
+					tbl[ k ] = Color( v.r or 255, v.g or 255, v.b or 255, v.a or 255 )
 
 				elseif ( v.__type == "Bool" ) then
 


### PR DESCRIPTION
# Added support for Color's with table sanitization
Also added 0's to the first argument of these, due to the fact that if the first argument of a angle/? is set to NIL, then ALL the values will be 0.
This is probably due to the check where it tries to convert a string/function/? to a angle/?
This is quite important because if you had Angle(0,1,2) and you sanitised it, the sanitisation replaces all 0's with nil, and your angle will break since the first value is 0 (nil now):

and
```lua
tbl[ k ] = Angle( v.p or 0, v.y, v.r )
```

Have also made the nilled values of Color to 255 instead of 0, as 255 is going to be the most common number in a Color, especially in the alpha channel, and will save on data