### PR TITLE
Added string.NiceNumber() to abbreviate large numbers

### DIFF
--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -268,6 +268,47 @@ function string.NiceSize( size )
 
 end
 
+--[[---------------------------------------------------------
+	Name: NiceNumber( num )
+	Desc: Abbreviates numbers and adds a suffix	
+	Examples: string.NiceNumber( 69420 ) ==> "69.42K"
+			string.NiceNumber( -123456789 ) ==> "-123.46M"
+-----------------------------------------------------------]]
+local nice_number_suffixes = {
+    "K","M","B","T","Qa",
+    "Qi","Sx","Sp","Oc","No",
+    "Dc","Ud","Dd","Td","Qad",
+    "Qid","Sxd","Spd","Ocd","Nod",
+    "Vg","Uvg","Dvg","Tvg","Qavg",
+    "Qivg","Sxvg","Spvg","Ocvg"
+}
+
+string.NiceNumber = function( num )
+    local suffixid, absNum, isNegative = nil, tonumber( num ), false
+    if not absNum then return num end
+    
+    isNegative = absNum < 0
+    absNum = math.abs( absNum )
+
+    if absNum == math.huge then
+        return string.format( "%sInfinity", isNegative and "-" or "" )
+    end
+
+    for i = 1, #nice_number_suffixes do
+        if absNum >= ( 10 ^ ( i * 3 ) ) then
+            suffixid = i
+        else
+            break
+        end
+    end
+
+    return suffixid and string.format( "%s%s%s",
+        isNegative and "-" or "",
+        math.Round( ( absNum / ( 10 ^ ( suffixid * 3 ) ) ), 2 ),
+        nice_number_suffixes[ suffixid ] 
+    ) or num
+end
+
 -- Note: These use Lua index numbering, not what you'd expect
 -- ie they start from 1, not 0.
 


### PR DESCRIPTION
Added string.NiceNumber() to abbreviate large numbers
Examples:
```lua
string.NiceNumber( 69420 ) --> "69.42K"
string.NiceNumber( -123456789 ) --> "-123.46M"
```