### PR TITLE
[TTT] Prevent weapons disappearing during round cleanup

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -389,6 +389,10 @@ local function CleanUp()
    for k,v in ipairs(player.GetAll()) do
       if IsValid(v) then
          v:StripWeapons()
+            if v:IsTerror() then
+               -- don't let players pick up weapons until they respawn
+               v.prevent_pickup_until = CurTime() + 1
+            end
       end
    end
 

--- a/garrysmod/gamemodes/terrortown/gamemode/player.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player.lua
@@ -71,6 +71,8 @@ function GM:PlayerSpawn(ply)
    ply.spawn_nick = ply:Nick()
    ply.has_spawned = true
 
+   ply.prevent_pickup_until = nil
+
    -- let the client do things on spawn
    net.Start("TTT_PlayerSpawned")
       net.WriteBit(ply:IsSpec())

--- a/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
@@ -10,6 +10,8 @@ function GM:PlayerCanPickupWeapon(ply, wep)
    if not IsValid(wep) or not IsValid(ply) then return end
    if ply:IsSpec() then return false end
 
+   if ply.prevent_pickup_until and CurTime() <= ply.prevent_pickup_until then return false end
+
    -- Disallow picking up for ammo
    if ply:HasWeapon(wep:GetClass()) then
       return false


### PR DESCRIPTION
During round restarts, living players will be stripped of their weapons for 1 tick before they get respawned, during which they can pick up weapons that will immediately be lost as soon as they respawn.
This is the reason why a weapon will sometimes be missing from it's usual spawn point.
This fixes the issue by preventing players from picking up any weapon during the 1-tick period before respawning.

Credit goes to @wgetJane for the fix. 