### PR TITLE
Only consider HUDShouldDraw's return if it's non-nil

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/base/gamemode/cl_init.lua
@@ -54,9 +54,16 @@ function GM:HUDShouldDraw( name )
 
 		local wep = ply:GetActiveWeapon()
 
-		if ( IsValid( wep ) && wep.HUDShouldDraw != nil ) then
+		if ( IsValid( wep ) ) then
 
-			return wep.HUDShouldDraw( wep, name )
+			local fShouldDraw = wep.HUDShouldDraw
+
+			if ( isfunction( fShouldDraw ) ) then
+
+				local ret = fShouldDraw( wep, name )
+				if ( ret != nil ) then return ret end
+
+			end
 
 		end
 


### PR DESCRIPTION
Fixes having to always return true in SWEP:HUDShouldDraw for an element to render unlike a HUDShouldDraw hook. Also now checks to make sure SWEP:HUDShouldDraw is a function before calling it.