### PR TITLE
Add `util.IsBinaryModuleInstalled`

### DIFF
--- a/garrysmod/lua/includes/extensions/util.lua
+++ b/garrysmod/lua/includes/extensions/util.lua
@@ -379,8 +379,10 @@ do
 	]
 	local fmt = "lua/bin/gm" .. (CLIENT && "cl" || "sv") .. "_%s_%s.dll"
 	function util.IsBinaryModuleInstalled( name )
-		if ( !isstring( name ) || #name == 0 ) then
-			return false
+		if ( !isstring( name ) ) then
+			error( "bad argument #1 to 'IsBinaryModuleInstalled' (string expected, got " .. type( name ) .. ")" )
+		elseif ( #name == 0 ) then
+			error( "bad argument #1 to 'IsBinaryModuleInstalled' (string cannot be empty)" )
 		end
 
 		if ( file.Exists( string.format( fmt, name, suffix ), "GAME" ) ) then

--- a/garrysmod/lua/includes/extensions/util.lua
+++ b/garrysmod/lua/includes/extensions/util.lua
@@ -370,30 +370,28 @@ end
 	Name: IsBinaryModuleInstalled( name )
 	Desc: Returns whether a binary module with the given name is present on disk
 -----------------------------------------------------------]]
-do
-	local suffix = ({"osx64","osx","linux64","linux","win64","win32"})[
-		( system.IsWindows() && 4 || 0 )
-		+ ( system.IsLinux() && 2 || 0 )
-		+ ( jit.arch == "x86" && 1 || 0 )
-		+ 1
-	]
-	local fmt = "lua/bin/gm" .. (CLIENT && "cl" || "sv") .. "_%s_%s.dll"
-	function util.IsBinaryModuleInstalled( name )
-		if ( !isstring( name ) ) then
-			error( "bad argument #1 to 'IsBinaryModuleInstalled' (string expected, got " .. type( name ) .. ")" )
-		elseif ( #name == 0 ) then
-			error( "bad argument #1 to 'IsBinaryModuleInstalled' (string cannot be empty)" )
-		end
-
-		if ( file.Exists( string.format( fmt, name, suffix ), "GAME" ) ) then
-			return true
-		end
-
-		-- Edge case - on Linux 32-bit x86-64 branch, linux32 is also supported as a suffix
-		if ( jit.versionnum != 20004 && jit.arch == "x86" && system.IsLinux() ) then
-			return file.Exists( string.format( fmt, name, "linux32" ), "GAME" )
-		end
-
-		return false
+local suffix = ({"osx64","osx","linux64","linux","win64","win32"})[
+	( system.IsWindows() && 4 || 0 )
+	+ ( system.IsLinux() && 2 || 0 )
+	+ ( jit.arch == "x86" && 1 || 0 )
+	+ 1
+]
+local fmt = "lua/bin/gm" .. (CLIENT && "cl" || "sv") .. "_%s_%s.dll"
+function util.IsBinaryModuleInstalled( name )
+	if ( !isstring( name ) ) then
+		error( "bad argument #1 to 'IsBinaryModuleInstalled' (string expected, got " .. type( name ) .. ")" )
+	elseif ( #name == 0 ) then
+		error( "bad argument #1 to 'IsBinaryModuleInstalled' (string cannot be empty)" )
 	end
+
+	if ( file.Exists( string.format( fmt, name, suffix ), "GAME" ) ) then
+		return true
+	end
+
+	-- Edge case - on Linux 32-bit x86-64 branch, linux32 is also supported as a suffix
+	if ( jit.versionnum != 20004 && jit.arch == "x86" && system.IsLinux() ) then
+		return file.Exists( string.format( fmt, name, "linux32" ), "GAME" )
+	end
+
+	return false
 end

--- a/garrysmod/lua/includes/extensions/util.lua
+++ b/garrysmod/lua/includes/extensions/util.lua
@@ -367,7 +367,7 @@ function util.RemovePData( steamid, name )
 end
 
 --[[---------------------------------------------------------
-	Name: BinaryModuleInstalled( name )
+	Name: IsBinaryModuleInstalled( name )
 	Desc: Returns whether a binary module with the given name is present on disk
 -----------------------------------------------------------]]
 do
@@ -378,7 +378,7 @@ do
 		+ 1
 	]
 	local fmt = "lua/bin/gm" .. (CLIENT && "cl" || "sv") .. "_%s_%s.dll"
-	function util.BinaryModuleInstalled( name )
+	function util.IsBinaryModuleInstalled( name )
 		if ( !isstring( name ) || #name == 0 ) then
 			return false
 		end

--- a/garrysmod/lua/includes/extensions/util.lua
+++ b/garrysmod/lua/includes/extensions/util.lua
@@ -365,3 +365,33 @@ function util.RemovePData( steamid, name )
 	sql.Query( "DELETE FROM playerpdata WHERE infoid = " .. SQLStr( name ) )
 
 end
+
+--[[---------------------------------------------------------
+	Name: BinaryModuleInstalled( name )
+	Desc: Returns whether a binary module with the given name is present on disk
+-----------------------------------------------------------]]
+do
+	local suffix = ({"osx64","osx","linux64","linux","win64","win32"})[
+		( system.IsWindows() && 4 || 0 )
+		+ ( system.IsLinux() && 2 || 0 )
+		+ ( jit.arch == "x86" && 1 || 0 )
+		+ 1
+	]
+	local fmt = "lua/bin/gm" .. (CLIENT && "cl" || "sv") .. "_%s_%s.dll"
+	function util.BinaryModuleInstalled( name )
+		if ( !isstring( name ) || #name == 0 ) then
+			return false
+		end
+
+		if ( file.Exists( string.format( fmt, name, suffix ), "GAME" ) ) then
+			return true
+		end
+
+		-- Edge case - on Linux 32-bit x86-64 branch, linux32 is also supported as a suffix
+		if ( jit.versionnum != 20004 && jit.arch == "x86" && system.IsLinux() ) then
+			return file.Exists( string.format( fmt, name, "linux32" ), "GAME" )
+		end
+
+		return false
+	end
+end


### PR DESCRIPTION
Improvement on #1868 (sorry Down nothing personal just wanted a separate PR) with edge case fix for Linux 32-bit x86-64 branch and a more code golf form of generating the format string of the module path. Also I changed the name to make it a bit more explicit.