### PR TITLE
TTT: Spectate previous player when left clicking

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/player.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player.lua
@@ -316,20 +316,13 @@ function GM:KeyPress(ply, key)
       ply:ResetViewRoll()
 
       if key == IN_ATTACK then
-         -- snap to random guy
-         ply:Spectate(OBS_MODE_ROAMING)
-         ply:SetEyeAngles(angle_zero) -- After exiting propspec, this could be set to awkward values
-         ply:SpectateEntity(nil)
+        -- spectate either the previous guy or a random guy in chase
+        local target = util.GetPreviousAlivePlayer(ply:GetObserverTarget())
 
-         local alive = util.GetAlivePlayers()
-
-         if #alive < 1 then return end
-
-         local target = table.Random(alive)
-         if IsValid(target) then
-            ply:SetPos(target:EyePos())
-            ply:SetEyeAngles(target:EyeAngles())
-         end
+        if IsValid(target) then
+           ply:Spectate(ply.spec_mode or OBS_MODE_CHASE)
+           ply:SpectateEntity(target)
+        end
       elseif key == IN_ATTACK2 then
          -- spectate either the next guy or a random guy in chase
          local target = util.GetNextAlivePlayer(ply:GetObserverTarget())

--- a/garrysmod/gamemodes/terrortown/gamemode/util.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/util.lua
@@ -87,6 +87,34 @@ function util.GetNextAlivePlayer(ply)
    return choice
 end
 
+function util.GetPreviousAlivePlayer(ply)
+    local alive = util.GetAlivePlayers()
+
+    if #alive < 1 then return nil end
+
+    local nxt = nil
+    local choice = nil
+    local p = nil
+
+    if IsValid(ply) then
+       for i = #alive, 1, -1 do
+          p = alive[i]
+
+          if nxt == ply then
+             choice = p
+          end
+
+          nxt = p
+       end
+    end
+
+    if not IsValid(choice) then
+       choice = alive[#alive - 1]
+    end
+
+    return choice
+end
+
 -- Uppercases the first character only
 function string.Capitalize(str)
    return string.upper(string.sub(str, 1, 1)) .. string.sub(str, 2)


### PR DESCRIPTION
Current behaviour when left clicking is spectating a random player:

```lua
-- snap to random guy
ply:Spectate(OBS_MODE_ROAMING)
ply:SetEyeAngles(angle_zero) -- After exiting propspec, this could be set to awkward values
ply:SpectateEntity(nil)

local alive = util.GetAlivePlayers()

if #alive < 1 then return end

local target = table.Random(alive)
if IsValid(target) then
   ply:SetPos(target:EyePos())
   ply:SetEyeAngles(target:EyeAngles())
end
```
I feel like it is more intuitive for it to spectate the previous player, as right click spectates the next player.