### PR TITLE
Add canvas IsValid check to dragndrop

### DIFF
--- a/garrysmod/lua/includes/extensions/client/panel/dragdrop.lua
+++ b/garrysmod/lua/includes/extensions/client/panel/dragdrop.lua
@@ -403,7 +403,7 @@ function meta:OnStartDragging()
 
 		local canvas = self:GetSelectionCanvas()
 
-		if ( !self:IsSelected() ) then
+		if ( IsValid( canvas ) && !self:IsSelected() ) then
 			canvas:UnselectAll()
 		end
 


### PR DESCRIPTION
Prevent errors when the selection canvas is struggling before we call any functions on an invalid panel.