### PR TITLE
Fix NPC vs. NPC Deathnotice Icons

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/cl_deathnotice.lua
+++ b/garrysmod/gamemodes/base/gamemode/cl_deathnotice.lua
@@ -119,9 +119,9 @@ local function RecvNPCKilledNPC()
 
 	local victim	= "#" .. net.ReadString()
 	local inflictor	= net.ReadString()
-	local attacker	= "#" .. net.ReadString()
+	local attacker	= net.ReadString()
 
-	GAMEMODE:AddDeathNotice( attacker, -1, ( inflictor != "worldspawn" && inflictor || attacker ), victim, -1 )
+	GAMEMODE:AddDeathNotice( "#" .. attacker, -1, ( inflictor != "worldspawn" && inflictor || attacker ), victim, -1 )
 
 end
 net.Receive( "NPCKilledNPC", RecvNPCKilledNPC )

--- a/garrysmod/gamemodes/base/gamemode/cl_deathnotice.lua
+++ b/garrysmod/gamemodes/base/gamemode/cl_deathnotice.lua
@@ -121,7 +121,7 @@ local function RecvNPCKilledNPC()
 	local inflictor	= net.ReadString()
 	local attacker	= "#" .. net.ReadString()
 
-	GAMEMODE:AddDeathNotice( attacker, -1, inflictor, victim, -1 )
+	GAMEMODE:AddDeathNotice( attacker, -1, ( inflictor != "worldspawn" && inflictor || attacker ), victim, -1 )
 
 end
 net.Receive( "NPCKilledNPC", RecvNPCKilledNPC )


### PR DESCRIPTION
Shows NPC killicons for NPC vs NPC kills that don't have an inflictor instead of just the worldspawn icon, matching the behavior for NPC vs Player deaths