### PR TITLE
Fix tooltip height position miscalculation with newlines.

### DIFF
--- a/garrysmod/lua/vgui/dtooltip.lua
+++ b/garrysmod/lua/vgui/dtooltip.lua
@@ -80,7 +80,7 @@ function PANEL:PositionTooltip()
 
 	y = y - 50
 
-	y = math.min( y, ly - h )
+	y = math.min( y, ly - h - 10 )
 	if ( y < 2 ) then y = 2 end
 
 	-- Fixes being able to be drawn off screen

--- a/garrysmod/lua/vgui/dtooltip.lua
+++ b/garrysmod/lua/vgui/dtooltip.lua
@@ -80,7 +80,7 @@ function PANEL:PositionTooltip()
 
 	y = y - 50
 
-	y = math.min( y, ly - h * 1.5 )
+	y = math.min( y, ly - h )
 	if ( y < 2 ) then y = 2 end
 
 	-- Fixes being able to be drawn off screen


### PR DESCRIPTION
1.5 causes the whole tooltip to elevate .5 extra on each newline(\n) line this: 
![1.5](https://i.imgur.com/hwV33tK.png)

1.0 or just no multiplier "fixes" it like this: 
![1.0](https://i.imgur.com/eWTBFMq.png)