### PR TITLE
Fix markup alignment inconsistency

### DIFF
--- a/garrysmod/lua/includes/modules/markup.lua
+++ b/garrysmod/lua/includes/modules/markup.lua
@@ -251,9 +251,9 @@ function MarkupObject:Draw( xOffset, yOffset, halign, valign, alphaoverride, tex
 			local lineWidth = self.lineWidths[ blk.offset.y ]
 			if ( lineWidth ) then
 				if ( textAlign == TEXT_ALIGN_CENTER ) then
-					surface.SetTextPos( x + ( ( self:GetMaxWidth() - lineWidth ) / 2 ), y )
+					surface.SetTextPos( x + ( ( self.totalWidth - lineWidth ) / 2 ), y )
 				elseif ( textAlign == TEXT_ALIGN_RIGHT ) then
-					surface.SetTextPos( x + ( self:GetMaxWidth() - lineWidth ), y )
+					surface.SetTextPos( x + ( self.totalWidth - lineWidth ), y )
 				end
 			end
 		end


### PR DESCRIPTION
## tl;dr
Changed text position calculation, so it is aligned as expected while using center or right text alignment.

## Description
Currently, markup object is aligned according to it's size (`self.totalWidth`) but text is aligned according to maximum size (`self.maxWidth`). This results in misaligned text while using center or right alignment. 
![offcentered](https://user-images.githubusercontent.com/30143339/205938056-4adb99bc-36c9-46b6-98f0-fec11bcdca5c.png)
_Image of current markup behavior with `halign` and `textAlign` both set to `TEXT_ALIGN_CENTER` (white line - center of frame, green box - size of markup object, red box - max size of markup object)._

As visible on the image, the markup object itself is aligned correctly, but the text is off-centered. The same problem occurs while using right alignment, making the text aligned to the right side of the red box.

![correct](https://user-images.githubusercontent.com/30143339/205939637-a22a06f2-f4ae-4754-8b4f-a4eaa7b0adb6.png)
_Image of changed markup behavior with `halign` and `textAlign` both set to `TEXT_ALIGN_CENTER` (white line - center of frame, green box - size of markup object, red box - max size of markup object)._

Now the text is also aligned according to actual size, resulting in text aligned perfectly in the center of the frame, and it also works correctly with `TEXT_ALIGN_RIGHT`.

## Possible backward compatibility issues
Some developers may have corrected misaligned markup on their own, so changing this will cause the markup text to be 'corrected twice' and making it off-centered for them. However, in my opinion, current behavior is wrong and should be changed to work as expected - centering both markup object and text should produce a perfectly centered result.