### PR TITLE
TTT `+zoom` fix

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_keys.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_keys.lua
@@ -60,7 +60,7 @@ function GM:PlayerBindPress(ply, bind, pressed)
          WSWITCH:SelectSlot(idx)
       end
       return true
-   elseif string.find(bind, "zoom") and pressed then
+   elseif bind == "+zoom" and pressed then
       -- open or close radio
       RADIO:ShowRadioCommands(not RADIO.Show)
       return true


### PR DESCRIPTION
This is stupidly written code that works because `-zoom` is never called, I discovered it by accident when trying to get `PlayerBindPress` to catch all the binds.

It works fine with my simpler solution as well.