### PR TITLE
use table argument for string.Interpolate

### DIFF
--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -369,10 +369,6 @@ end
 
 function string.Interpolate( str, lookuptable )
 
-	return ( string.gsub( str, "{([_%a][_%w]*)}", function( key )
-
-		return tostring( lookuptable[ key ] or "{" .. key .. "}" )
-
-	end ) )
+	return ( string.gsub( str, "{([_%a][_%w]*)}", lookuptable) )
 
 end


### PR DESCRIPTION
Using table argument is actually faster.
Here's the proof (Format - string.format; Interpolate is string.Interpolate in current version, and interpolate2 string.Interpolate in this pull request) https://media.discordapp.net/attachments/1033513273548611705/1065740111842639983/image.png?width=175&height=67