### PR TITLE
[Net] Reduced net.Write&Read Entity from 16 bits to 13 bits

### DIFF
--- a/garrysmod/lua/includes/extensions/net.lua
+++ b/garrysmod/lua/includes/extensions/net.lua
@@ -51,16 +51,16 @@ end
 function net.WriteEntity( ent )
 
 	if ( !IsValid( ent ) ) then
-		net.WriteUInt( 0, 16 )
+		net.WriteUInt( 0, 13 )
 	else
-		net.WriteUInt( ent:EntIndex(), 16 )
+		net.WriteUInt( ent:EntIndex(), 13 )
 	end
 
 end
 
 function net.ReadEntity()
 
-	local i = net.ReadUInt( 16 )
+	local i = net.ReadUInt( 13 )
 	if ( !i ) then return end
 
 	return Entity( i )


### PR DESCRIPTION
## net.WriteEntity and net.ReadEntity
Reduced the amount of bits from 16 bits to 13 bits because EntIndex doesn't seem to return a value above, 8127 and a range from 0-8191 should be enough.