### PR TITLE
TTT: more translatability improvements and fixes

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_lang.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_lang.lua
@@ -337,7 +337,11 @@ local styledmessages = {
    chat_plain = {
       "body_call",
       "disg_turned_on",
-      "disg_turned_off"
+      "disg_turned_off",
+      "mute_all",
+      "mute_off",
+      "mute_specs",
+      "mute_living"
    },
 
    chat_warn = {

--- a/garrysmod/gamemodes/terrortown/gamemode/ent_replace.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/ent_replace.lua
@@ -28,37 +28,73 @@ local function ReplaceSingle(ent, newname)
    ent:Remove()
 end
 
-local hl2_ammo_replace = {
-   ["item_ammo_pistol"] = "item_ammo_pistol_ttt",
-   ["item_box_buckshot"] = "item_box_buckshot_ttt",
-   ["item_ammo_smg1"] = "item_ammo_smg1_ttt",
-   ["item_ammo_357"] = "item_ammo_357_ttt",
-   ["item_ammo_357_large"] = "item_ammo_357_ttt",
-   ["item_ammo_revolver"] = "item_ammo_revolver_ttt", -- zm
-   ["item_ammo_ar2"] = "item_ammo_pistol_ttt",
-   ["item_ammo_ar2_large"] = "item_ammo_smg1_ttt",
-   ["item_ammo_smg1_grenade"] = "weapon_zm_pistol",
-   ["item_battery"] = "item_ammo_357_ttt",
-   ["item_healthkit"] = "weapon_zm_shotgun",
-   ["item_suitcharger"] = "weapon_zm_mac10",
-   ["item_ammo_ar2_altfire"] = "weapon_zm_mac10",
-   ["item_rpg_round"] = "item_ammo_357_ttt",
-   ["item_ammo_crossbow"] = "item_box_buckshot_ttt",
-   ["item_healthvial"] = "weapon_zm_molotov",
-   ["item_healthcharger"] = "item_ammo_revolver_ttt",
-   ["item_ammo_crate"] = "weapon_ttt_confgrenade",
-   ["item_item_crate"] = "ttt_random_ammo"
-};
+local hl2_ents = {
+   item_ammo_pistol = true,
+   item_box_buckshot = true,
+   item_ammo_smg1 = true,
+   item_ammo_357 = true,
+   item_ammo_357_large = true,
+   item_ammo_revolver = true,
+   item_ammo_ar2 = true,
+   item_ammo_ar2_large = true,
+   item_ammo_smg1_grenade = true,
+   item_battery = true,
+   item_healthkit = true,
+   item_suitcharger = true,
+   item_ammo_ar2_altfire = true,
+   item_rpg_round = true,
+   item_ammo_crossbow = true,
+   item_healthvial = true,
+   item_healthcharger = true,
+   item_ammo_crate = true,
+   item_item_crate = true
+}
+
+local hl2_weapons = {
+   weapon_smg1 = true,
+   weapon_shotgun = true,
+   weapon_ar2 = true,
+   weapon_357 = true,
+   weapon_crossbow = true,
+   weapon_rpg = true,
+   weapon_slam = true,
+   weapon_frag = true,
+   weapon_crowbar = true
+}
+
+local ttt_ents = {
+   item_ammo_pistol_ttt = true,
+   item_box_buckshot_ttt = true,
+   item_ammo_smg1_ttt = true,
+   item_ammo_357_ttt = true,
+   item_ammo_revolver_ttt = true,
+   weapon_ttt_confgrenade = true,
+   weapon_ttt_smokegrenade = true,
+   weapon_zm_molotov = true,
+   ttt_random_ammo = true
+}
+
+local ttt_weapons = {
+   weapon_ttt_glock = true,
+   weapon_ttt_m16 = true,
+   weapon_zm_mac10 = true,
+   weapon_zm_pistol = true,
+   weapon_zm_rifle = true,
+   weapon_zm_shotgun = true,
+   weapon_zm_revolver = true,
+   weapon_zm_sledge = true
+}
 
 -- Replace an ammo entity with the TTT version
 -- Optional cls param is the classname, if the caller already has it handy
 local function ReplaceAmmoSingle(ent, cls)
    if cls == nil then cls = ent:GetClass() end
-
-   local rpl = hl2_ammo_replace[cls]
-   if rpl then
-      ReplaceSingle(ent, rpl)
-   end
+   
+   -- refactor that hardcoded stuff and add support for all of TTT's ents
+   -- and abuse of some table good practices
+   if !hl2_ents[cls] then return end
+   
+   ReplaceSingle(ent, ttt_ents[ math.random( #ttt_ents ) ])
 end
 
 local function ReplaceAmmo()
@@ -66,18 +102,6 @@ local function ReplaceAmmo()
       ReplaceAmmoSingle(ent)
    end
 end
-
-local hl2_weapon_replace = {
-   ["weapon_smg1"] = "weapon_zm_mac10",
-   ["weapon_shotgun"] = "weapon_zm_shotgun",
-   ["weapon_ar2"] = "weapon_ttt_m16",
-   ["weapon_357"] = "weapon_zm_rifle",
-   ["weapon_crossbow"] = "weapon_zm_pistol",
-   ["weapon_rpg"] = "weapon_zm_sledge",
-   ["weapon_slam"] = "item_ammo_pistol_ttt",
-   ["weapon_frag"] = "weapon_zm_revolver",
-   ["weapon_crowbar"] = "weapon_zm_molotov"
-};
 
 local function ReplaceWeaponSingle(ent, cls)
    -- Loadout weapons immune
@@ -87,10 +111,10 @@ local function ReplaceWeaponSingle(ent, cls)
    else
       if cls == nil then cls = ent:GetClass() end
 
-      local rpl = hl2_weapon_replace[cls]
-      if rpl then
-         ReplaceSingle(ent, rpl)
-      end
+      -- and also weapons
+      if !hl2_weapons[cls] then return end
+      
+      ReplaceSingle(ent, ttt_weapons[ math.random( #ttt_weapons ) ])
 
    end
 end

--- a/garrysmod/gamemodes/terrortown/gamemode/gamemsg.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/gamemsg.lua
@@ -235,7 +235,20 @@ local function TraitorGlobalVoice(ply, cmd, args)
 end
 concommand.Add("tvog", TraitorGlobalVoice)
 
+-- from shared.lua
+-- MUTE_NONE = 0
+-- MUTE_TERROR = 1
+-- MUTE_ALL = 2
+-- MUTE_SPEC = 1002
+local MuteModes = {
+   [0] = "mute_off",
+   [1] = "mute_living",
+   [2] = "mute_all",
+   [1002] = "mute_specs"
+}
+
 local function MuteTeam(ply, cmd, args)
+
    if not IsValid(ply) then return end
    if not (#args == 1 and tonumber(args[1])) then return end
    if not ply:IsSpec() then
@@ -246,13 +259,9 @@ local function MuteTeam(ply, cmd, args)
    local t = tonumber(args[1])
    ply.mute_team = t
 
-   if t == MUTE_ALL then
-      ply:ChatPrint("All muted.")
-   elseif t == MUTE_NONE or t == TEAM_UNASSIGNED or not team.Valid(t) then
-      ply:ChatPrint("None muted.")
-   else
-      ply:ChatPrint(team.GetName(t) .. " muted.")
-   end
+   -- We have actual translated messages for this now. 
+   -- So much for ifs and hardcodes. This is way better
+   LANG.Msg(ply, MuteModes[t])
 end
 concommand.Add("ttt_mute_team", MuteTeam)
 

--- a/garrysmod/gamemodes/terrortown/terrortown.txt
+++ b/garrysmod/gamemodes/terrortown/terrortown.txt
@@ -11,7 +11,7 @@
 		1
 		{
 			"name"		"ttt_debug_preventwin"
-			"text"		"Prevent Winning"
+			"text"		"prevent_winning"
 			"type"		"CheckBox"
 			"default"	"0"
 		}
@@ -19,7 +19,7 @@
 		2
 		{
 			"name"		"ttt_haste"
-			"text"		"Haste Mode"
+			"text"		"haste_mode"
 			"type"		"CheckBox"
 			"default"	"1"
 		}
@@ -27,7 +27,7 @@
 		5
 		{
 			"name"		"ttt_time_limit_minutes"
-			"text"		"Map Time Limit"
+			"text"		"map_time_limit"
 			"type"		"Numeric"
 			"default"	"75"
 		}
@@ -35,7 +35,7 @@
 		6
 		{
 			"name"		"ttt_firstpreptime"
-			"text"		"Initial Waiting Time"
+			"text"		"initial_waiting_time"
 			"type"		"Numeric"
 			"default"	"60"
 		}
@@ -43,7 +43,7 @@
 		7
 		{
 			"name"		"ttt_preptime_seconds"
-			"text"		"Preparing Time"
+			"text"		"preparing_time"
 			"type"		"Numeric"
 			"default"	"30"
 		}
@@ -51,7 +51,7 @@
 		8
 		{
 			"name"		"ttt_posttime_seconds"
-			"text"		"Postround Time"
+			"text"		"postround_time"
 			"type"		"Numeric"
 			"default"	"30"
 		}
@@ -59,7 +59,7 @@
 		9
 		{
 			"name"		"ttt_round_limit"
-			"text"		"Round Limit"
+			"text"		"round_limit"
 			"type"		"Numeric"
 			"default"	"6"
 		}
@@ -67,7 +67,7 @@
 		10
 		{
 			"name"		"ttt_roundtime_minutes"
-			"text"		"Round Time"
+			"text"		"round_time"
 			"type"		"Numeric"
 			"default"	"10"
 		}
@@ -75,7 +75,7 @@
 		11
 		{
 			"name"		"ttt_haste_starting_minutes"
-			"text"		"Haste Round Time"
+			"text"		"haste_round_time"
 			"type"		"Numeric"
 			"default"	"5"
 		}
@@ -83,7 +83,7 @@
 		12
 		{
 			"name"		"ttt_haste_minutes_per_death"
-			"text"		"Haste Kill Time Bonus"
+			"text"		"haste_kill_time_bonus"
 			"type"		"Numeric"
 			"default"	".5"
 		}
@@ -91,7 +91,7 @@
 		13
 		{
 			"name"		"ttt_postround_dm"
-			"text"		"Postround Deathmatch"
+			"text"		"postround_dm"
 			"type"		"CheckBox"
 			"default"	"0"
 		}
@@ -99,7 +99,7 @@
 		14
 		{
 			"name"		"ttt_traitor_max"
-			"text"		"Max Traitors"
+			"text"		"max_traitors"
 			"type"		"Numeric"
 			"default"	"32"
 		}
@@ -107,7 +107,7 @@
 		15
 		{
 			"name"		"ttt_traitor_pct"
-			"text"		"Traitor Ratio"
+			"text"		"traitor_ratio"
 			"type"		"Numeric"
 			"default"	"0.25"
 		}
@@ -115,7 +115,7 @@
 		16
 		{
 			"name"		"ttt_credits_starting"
-			"text"		"Traitor Credits"
+			"text"		"traitor_credits"
 			"type"		"Numeric"
 			"default"	"2"
 		}
@@ -123,7 +123,7 @@
 		17
 		{
 			"name"		"ttt_detective_max"
-			"text"		"Max Detectives"
+			"text"		"max_detectives"
 			"type"		"Numeric"
 			"default"	"32"
 		}
@@ -131,7 +131,7 @@
 		18
 		{
 			"name"		"ttt_detective_pct"
-			"text"		"Detective Ratio"
+			"text"		"detective_ratio"
 			"type"		"Numeric"
 			"default"	"0.125"
 		}
@@ -139,7 +139,7 @@
 		19
 		{
 			"name"		"ttt_det_credits_starting"
-			"text"		"Detective Credits"
+			"text"		"detective_credits"
 			"type"		"Numeric"
 			"default"	"1"
 		}
@@ -147,7 +147,7 @@
 		20
 		{
 			"name"		"ttt_detective_min_players"
-			"text"		"Min Detective Playercount"
+			"text"		"detective_min_players"
 			"type"		"Numeric"
 			"default"	"8"
 		}
@@ -155,7 +155,7 @@
 		21
 		{
 			"name"		"ttt_detective_karma_min"
-			"text"		"Min Detective Karma"
+			"text"		"detective_min_karma"
 			"type"		"Numeric"
 			"default"	"600"
 		}
@@ -163,7 +163,7 @@
 		22
 		{
 			"name"		"ttt_detective_hats"
-			"text"		"Detective Hats"
+			"text"		"detective_hats"
 			"type"		"CheckBox"
 			"default"	"1"
 		}
@@ -171,7 +171,7 @@
 		23
 		{
 			"name"		"ttt_allow_discomb_jump"
-			"text"		"Discombob Jumping"
+			"text"		"discombob_jumping"
 			"type"		"CheckBox"
 			"default"	"0"
 		}
@@ -179,7 +179,7 @@
 		24
 		{
 			"name"		"ttt_no_nade_throw_during_prep"
-			"text"		"No Preround Grenade Throwing"
+			"text"		"no_preround_grenade_throwing"
 			"type"		"CheckBox"
 			"default"	"1"
 		}
@@ -187,7 +187,7 @@
 		25
 		{
 			"name"		"ttt_teleport_telefrags"
-			"text"		"Teleporter Fragging"
+			"text"		"teleporter_fragging"
 			"type"		"CheckBox"
 			"default"	"1"
 		}
@@ -195,7 +195,7 @@
 		26
 		{
 			"name"		"ttt_ragdoll_pinning"
-			"text"		"Ragdoll Pinning"
+			"text"		"ragdoll_pinning"
 			"type"		"CheckBox"
 			"default"	"1"
 		}
@@ -203,7 +203,7 @@
 		27
 		{
 			"name"		"ttt_ragdoll_pinning_innocents"
-			"text"		"Innocent Pinning"
+			"text"		"innocent_pinning"
 			"type"		"CheckBox"
 			"default"	"0"
 		}
@@ -211,7 +211,7 @@
 		30
 		{
 			"name"		"ttt_namechange_kick"
-			"text"		"Kick for Changing Name"
+			"text"		"kick_for_changing_name"
 			"type"		"CheckBox"
 			"default"	"1"
 		}
@@ -219,7 +219,7 @@
 		31
 		{
 			"name"		"ttt_namechange_bantime"
-			"text"		"Name Change Ban Time"
+			"text"		"name_change_ban_time"
 			"type"		"Numeric"
 			"default"	"10"
 		}

--- a/garrysmod/resource/localization/en/main_menu.properties
+++ b/garrysmod/resource/localization/en/main_menu.properties
@@ -35,6 +35,34 @@ bone_manipulate_players=Allow to bone manipulate players
 bone_manipulate_others=Allow to bone manipulate everything
 limit_physgun=Limit the Physics Gun
 
+prevent_winning=Prevent Winning
+haste_mode=Haste Mode
+map_time_limit=Map Time Limit
+initial_waiting_time=Initial Waiting Time
+preparing_time=Preparing Time
+postround_time=Postround Time
+round_limit=Round Limit
+round_time=Round Time
+haste_round_time=Haste Round Time
+haste_kill_time_bonus=Haste Kill Time Bonus
+postround_dm=Postround Deathmatch
+max_traitors=Max Traitors
+traitor_ratio=Traitor Ratio
+traitor_credits=Traitor Credits
+max_detectives=Max Detectives
+detective_ratio=Detective Ratio
+detective_credits=Detective Credits
+detective_min_players=Min Detective Playercount
+detective_min_karma=Min Detective Karma
+detective_hats=Detective Hats
+discombob_jumping=Discombob Jumping
+no_preround_grenade_throwing=No Preround Grenade Throwing
+teleporter_fragging=Teleporter Fragging
+ragdoll_pinning=Ragdoll Pinning
+innocent_pinning=Innocent Pinning
+kick_for_changing_name=Kick for Changing Name
+name_change_ban_time=Name Change Ban Time
+
 persistent_mode_menu=Persistence file\: (empty=disabled)
 persistent_mode=Persistence file\:
 persistent_mode.help=If not empty, enables 'Make Persistent' option when you right click on props while holding C, allowing you to save them across sessions. Changing the filename will save existing persistent props, cleanup the whole map and load props from given file if it exists.


### PR DESCRIPTION
- Implement actual translations for TTT start new game menu

- Implement actual translations for mute states notifications on chat, thus removing its hardcodes

- Remove hardcodes and refactor hl2 ents replacements for maps with no spawnscripts

- Suggest new effect and sound for discombulator and remove its pulling function related to non-players (only push stuff away)

- This is a complement for c833b5892875a7c7c0a1fdf112d1d34653a4669d by @svdm, trying to fix Facepunch/garrysmod-issues#3544 (one of the pendencies from it)

PS: I'd also recommend transfering all of the TTT lang files to Crowdin, to improve the translatability for the translator's community. I've tested it the english lang file, and it works. Not as straightforward as the rest of the translation, it will involve respecting the syntax and stuff like that, but it could work pretty well.