### PR TITLE
Minor Fix: Prevent medkit timer spam

### DIFF
--- a/garrysmod/lua/weapons/weapon_medkit.lua
+++ b/garrysmod/lua/weapons/weapon_medkit.lua
@@ -126,8 +126,10 @@ end
 
 function SWEP:OnRemove()
 
-	timer.Stop( "medkit_ammo" .. self:EntIndex() )
-	timer.Stop( "weapon_idle" .. self:EntIndex() )
+	if ( CLIENT ) then return end
+
+	timer.Remove( "medkit_ammo" .. self:EntIndex() )
+	timer.Remove( "weapon_idle" .. self:EntIndex() )
 
 end
 


### PR DESCRIPTION
### The problem
Medkits currently create a new timer every time they're spawned.
In the `OnRemove` ent hook, the timers are `.Stop`'d, but not `.Remove`'d.
On servers where people die and respawn with a medkit frequently, this can lead to situations like this:
![image](https://user-images.githubusercontent.com/7936439/218034710-57552b16-3751-4b5e-b14e-309c8bf8eefd.png)

They're _probably_ fine, but.. why have 'em?

### This PR
I changed `timer.Stop` to `timer.Remove` in `OnRemove`, which will properly clean up medkit timers when they're removed.

I also returned early for `CLIENT` in `OnRemove` because the timers only exist on `SERVER`.