### PR TITLE
Refactor weapon_medkit

### DIFF
--- a/garrysmod/lua/weapons/weapon_medkit.lua
+++ b/garrysmod/lua/weapons/weapon_medkit.lua
@@ -108,7 +108,7 @@ end
 function SWEP:HealEntity( ent, amount )
 
 	-- Heal ent
-	self:SetClip1( math.min( self:GetClip1() - amount, 0 ) )
+	self:SetClip1( math.max( self:Clip1() - amount, 0 ) )
 	ent:SetHealth( ent:Health() + amount )
 
 	-- Do effects
@@ -121,10 +121,16 @@ function SWEP:HealEntity( ent, amount )
 		owner:SetAnimation( PLAYER_ATTACK1 )
 	end
 
-	local endtime = CurTime() + self:SequenceDuration()
+	local curtime = CurTime()
+
+	-- Set next regen time
+	self:SetNextAmmoRegen( curtime + self.AmmoRegenFrequency )
+
+	-- Set next idle time
+	local endtime = curtime + self:SequenceDuration()
 	self:SetNextIdle( endtime )
 
-	-- Setup next firing time
+	-- Set next firing time
 	endtime = endtime + self.HealCooldown
 	self:SetNextPrimaryFire( endtime )
 	self:SetNextSecondaryFire( endtime )

--- a/garrysmod/lua/weapons/weapon_medkit.lua
+++ b/garrysmod/lua/weapons/weapon_medkit.lua
@@ -195,7 +195,7 @@ if ( CLIENT ) then
 		local display = self.AmmoDisplay
 		display.PrimaryClip = self:Clip1()
 
-		return self.AmmoDisplay
+		return display
 
 	end
 end

--- a/garrysmod/lua/weapons/weapon_medkit.lua
+++ b/garrysmod/lua/weapons/weapon_medkit.lua
@@ -109,7 +109,7 @@ function SWEP:HealEntity( ent, amount )
 
 	-- Heal ent
 	self:TakePrimaryAmmo( amount )
-	ent:SetHealth( ent:GetHealth() + amount )
+	ent:SetHealth( ent:Health() + amount )
 
 	-- Do effects
 	self:EmitSound( self.HealSound )

--- a/garrysmod/lua/weapons/weapon_medkit.lua
+++ b/garrysmod/lua/weapons/weapon_medkit.lua
@@ -18,12 +18,12 @@ SWEP.UseHands = true
 SWEP.Primary.ClipSize = 100
 SWEP.Primary.DefaultClip = 100
 SWEP.Primary.Automatic = false
-SWEP.Primary.Ammo = "none"
+SWEP.Primary.Ammo = ""
 
 SWEP.Secondary.ClipSize = -1
 SWEP.Secondary.DefaultClip = -1
 SWEP.Secondary.Automatic = false
-SWEP.Secondary.Ammo = "none"
+SWEP.Secondary.Ammo = ""
 
 SWEP.HoldType = "slam"
 
@@ -108,7 +108,7 @@ end
 function SWEP:HealEntity( ent, amount )
 
 	-- Heal ent
-	self:TakePrimaryAmmo( amount )
+	self:SetClip1( math.min( self:GetClip1() - amount, 0 ) )
 	ent:SetHealth( ent:Health() + amount )
 
 	-- Do effects
@@ -169,9 +169,8 @@ function SWEP:Think()
 
 		if ( clip1 < maxammo ) then
 			self:SetClip1( math.min( clip1 + self.AmmoRegenAmount, maxammo ) )
+			self:SetNextAmmoRegen( curtime + self.AmmoRegenFrequency )
 		end
-
-		self:SetNextAmmoRegen( curtime + self.AmmoRegenFrequency )
 	end
 
 	if ( curtime >= self:GetNextIdle() ) then

--- a/garrysmod/lua/weapons/weapon_medkit.lua
+++ b/garrysmod/lua/weapons/weapon_medkit.lua
@@ -181,6 +181,9 @@ function SWEP:Think()
 
 end
 
+function SWEP:Reload()
+end
+
 if ( CLIENT ) then
 	function SWEP:CustomAmmoDisplay()
 

--- a/garrysmod/lua/weapons/weapon_medkit.lua
+++ b/garrysmod/lua/weapons/weapon_medkit.lua
@@ -68,19 +68,12 @@ function SWEP:PrimaryAttack()
 		owner:LagCompensation( true )
 	end
 
-	local startpos, endpos = owner:GetShootPos(), owner:GetAimVector()
-	endpos:Mul( self.HealRange )
-	endpos:Add( startpos )
-
-	local tr = {
+	local startpos = owner:GetShootPos()
+	local tr = util.TraceLine( {
 		start = startpos,
-		endpos = endpos,
-		filter = owner,
-		output = nil
-	}
-	tr.output = tr -- Reuse our trace data table for our return data
-
-	util.TraceLine( tr )
+		endpos = startpos + owner:GetAimVector() * 64,
+		filter = owner
+	} )
 
 	if ( isplayer ) then
 		owner:LagCompensation( false )
@@ -189,13 +182,14 @@ end
 function SWEP:Reload()
 end
 
-if ( CLIENT ) then
-	function SWEP:CustomAmmoDisplay()
+-- The following code does not need to exist on the server, so bail
+if ( SERVER ) then return end
 
-		local display = self.AmmoDisplay
-		display.PrimaryClip = self:Clip1()
+function SWEP:CustomAmmoDisplay()
 
-		return display
+	local display = self.AmmoDisplay
+	display.PrimaryClip = self:Clip1()
 
-	end
+	return display
+
 end

--- a/garrysmod/lua/weapons/weapon_medkit.lua
+++ b/garrysmod/lua/weapons/weapon_medkit.lua
@@ -71,7 +71,7 @@ function SWEP:PrimaryAttack()
 	local startpos, endpos = owner:GetShootPos(), owner:GetAimVector()
 	endpos:Mul( self.HealRange )
 	endpos:Add( startpos )
-	
+
 	local tr = {
 		start = startpos,
 		endpos = endpos,
@@ -110,20 +110,20 @@ function SWEP:HealEntity( ent, amount )
 	-- Heal ent
 	self:TakePrimaryAmmo( amount )
 	ent:SetHealth( ent:GetHealth() + amount )
-	
+
 	-- Do effects
 	self:EmitSound( self.HealSound )
 	self:SendWeaponAnim( ACT_VM_PRIMARYATTACK )
-	
+
 	local owner = self:GetOwner()
-	
+
 	if ( owner:IsValid() ) then
 		owner:SetAnimation( PLAYER_ATTACK1 )
 	end
-	
+
 	local endtime = CurTime() + self:SequenceDuration()
 	self:SetNextIdle( endtime )
-	
+
 	-- Setup next firing time
 	endtime = endtime + self.HealCooldown
 	self:SetNextPrimaryFire( endtime )
@@ -135,7 +135,7 @@ function SWEP:HealFail( ent )
 
 	-- Do effects
 	self:EmitSound( self.DenySound )
-	
+
 	-- Setup next firing time
 	local endtime = CurTime() + self.DenyCooldown
 	self:SetNextPrimaryFire( endtime )
@@ -146,15 +146,15 @@ end
 function SWEP:DoHeal( ent )
 
 	if ( !self:CanHeal( ent ) ) then self:HealFail( ent ) return false end
-	
+
 	local health, maxhealth = ent:Health(), ent:GetMaxHealth()
 	if ( health >= maxhealth ) then self:HealFail( ent ) return false end
-	
+
 	local need = math.min( maxhealth - health, self.HealAmount )
 	if ( self:Clip1() < need ) then self:HealFail( ent ) return false end
-	
+
 	self:HealEntity( ent, need )
-	
+
 	return true
 
 end
@@ -162,18 +162,18 @@ end
 function SWEP:Think()
 
 	local curtime = CurTime()
-	
+
 	if ( curtime >= self:GetNextAmmoRegen() ) then
 		local clip1 = self:Clip1()
 		local maxammo = self.Primary.ClipSize
-	
+
 		if ( clip1 < maxammo ) then
 			self:SetClip1( math.min( clip1 + self.AmmoRegenAmount, maxammo ) )
 		end
-		
+
 		self:SetNextAmmoRegen( curtime + self.AmmoRegenFrequency )
 	end
-	
+
 	if ( curtime >= self:GetNextIdle() ) then
 		self:SendWeaponAnim( ACT_VM_IDLE )
 		self:SetNextIdle( curtime + self:SequenceDuration() )

--- a/garrysmod/lua/weapons/weapon_medkit.lua
+++ b/garrysmod/lua/weapons/weapon_medkit.lua
@@ -2,8 +2,8 @@
 AddCSLuaFile()
 
 SWEP.PrintName = "#GMOD_MedKit"
-SWEP.Author = "robotboy655 & MaxOfS2D"
-SWEP.Purpose = "Heal people with your primary attack, or yourself with the secondary."
+SWEP.Author = "robotboy655, MaxOfS2D, code_gs"
+SWEP.Purpose = "Heal other people with primary attack, heal yourself with secondary attack."
 
 SWEP.Slot = 5
 SWEP.SlotPos = 3
@@ -25,126 +25,169 @@ SWEP.Secondary.DefaultClip = -1
 SWEP.Secondary.Automatic = false
 SWEP.Secondary.Ammo = "none"
 
-SWEP.HealAmount = 20 -- Maximum heal amount per use
-SWEP.MaxAmmo = 100 -- Maxumum ammo
+SWEP.HoldType = "slam"
 
-local HealSound = Sound( "HealthKit.Touch" )
-local DenySound = Sound( "WallHealth.Deny" )
+SWEP.HealSound = Sound( "HealthKit.Touch" )
+SWEP.DenySound = Sound( "WallHealth.Deny" )
+
+SWEP.HealCooldown = 0.5
+SWEP.DenyCooldown = 1
+
+SWEP.HealAmount = 20 -- Maximum heal amount per use
+SWEP.HealRange = 64
+
+SWEP.AmmoRegenFrequency = 1 -- Number of seconds before each ammo regen
+SWEP.AmmoRegenAmount = 2 -- Amount of ammo refilled every AmmoRegenFrequency seconds
 
 function SWEP:Initialize()
 
-	self:SetHoldType( "slam" )
+	self:SetHoldType( self.HoldType )
 
-	if ( CLIENT ) then return end
+	if ( CLIENT ) then
+		self.AmmoDisplay = {
+			Draw = true,
+			PrimaryClip = 0
+		}
+	end
 
-	timer.Create( "medkit_ammo" .. self:EntIndex(), 1, 0, function()
-		if ( self:Clip1() < self.MaxAmmo ) then self:SetClip1( math.min( self:Clip1() + 2, self.MaxAmmo ) ) end
-	end )
+end
+
+function SWEP:SetupDataTables()
+
+	self:NetworkVar( "Float", 0, "NextAmmoRegen" )
+	self:NetworkVar( "Float", 1, "NextIdle" )
 
 end
 
 function SWEP:PrimaryAttack()
 
-	if ( CLIENT ) then return end
-
 	local owner = self:GetOwner()
+	local isplayer = SERVER and owner:IsPlayer()
 
-	if ( owner:IsPlayer() ) then
+	if ( isplayer ) then
 		owner:LagCompensation( true )
 	end
 
-	local tr = util.TraceLine( {
-		start = owner:GetShootPos(),
-		endpos = owner:GetShootPos() + owner:GetAimVector() * 64,
-		filter = owner
-	} )
+	local startpos, endpos = owner:GetShootPos(), owner:GetAimVector()
+	endpos:Mul( self.HealRange )
+	endpos:Add( startpos )
+	
+	local tr = {
+		start = startpos,
+		endpos = endpos,
+		filter = owner,
+		output = nil
+	}
+	tr.output = tr -- Reuse our trace data table for our return data
 
-	if ( owner:IsPlayer() ) then
+	util.TraceLine( tr )
+
+	if ( isplayer ) then
 		owner:LagCompensation( false )
 	end
 
-	local ent = tr.Entity
-
-	local need = self.HealAmount
-	if ( IsValid( ent ) ) then need = math.min( ent:GetMaxHealth() - ent:Health(), self.HealAmount ) end
-
-	if ( IsValid( ent ) && self:Clip1() >= need && ( ent:IsPlayer() or ent:IsNPC() ) && ent:Health() < ent:GetMaxHealth() ) then
-
-		self:TakePrimaryAmmo( need )
-
-		ent:SetHealth( math.min( ent:GetMaxHealth(), ent:Health() + need ) )
-		ent:EmitSound( HealSound )
-
-		self:SendWeaponAnim( ACT_VM_PRIMARYATTACK )
-
-		self:SetNextPrimaryFire( CurTime() + self:SequenceDuration() + 0.5 )
-		owner:SetAnimation( PLAYER_ATTACK1 )
-
-		-- Even though the viewmodel has looping IDLE anim at all times, we need this to make fire animation work in multiplayer
-		timer.Create( "weapon_idle" .. self:EntIndex(), self:SequenceDuration(), 1, function() if ( IsValid( self ) ) then self:SendWeaponAnim( ACT_VM_IDLE ) end end )
-
-	else
-
-		owner:EmitSound( DenySound )
-		self:SetNextPrimaryFire( CurTime() + 1 )
-
-	end
+	self:DoHeal( tr.Entity )
 
 end
 
 function SWEP:SecondaryAttack()
 
-	if ( CLIENT ) then return end
+	self:DoHeal( self:GetOwner() )
 
-	local ent = self:GetOwner()
+end
 
-	local need = self.HealAmount
-	if ( IsValid( ent ) ) then need = math.min( ent:GetMaxHealth() - ent:Health(), self.HealAmount ) end
+-- Basic black/whitelist function
+-- Checking if the entity's health is below its max is done in SWEP:DoHeal
+function SWEP:CanHeal( ent )
 
-	if ( IsValid( ent ) && self:Clip1() >= need && ent:Health() < ent:GetMaxHealth() ) then
+	-- ent may be NULL here, but these functions return false for it
+	return ent:IsPlayer() or ent:IsNPC()
 
-		self:TakePrimaryAmmo( need )
+end
 
-		ent:SetHealth( math.min( ent:GetMaxHealth(), ent:Health() + need ) )
-		ent:EmitSound( HealSound )
+function SWEP:HealEntity( ent, amount )
 
-		self:SendWeaponAnim( ACT_VM_PRIMARYATTACK )
-
-		self:SetNextSecondaryFire( CurTime() + self:SequenceDuration() + 0.5 )
-		ent:SetAnimation( PLAYER_ATTACK1 )
-
-		timer.Create( "weapon_idle" .. self:EntIndex(), self:SequenceDuration(), 1, function() if ( IsValid( self ) ) then self:SendWeaponAnim( ACT_VM_IDLE ) end end )
-
-	else
-
-		ent:EmitSound( DenySound )
-		self:SetNextSecondaryFire( CurTime() + 1 )
-
+	-- Heal ent
+	self:TakePrimaryAmmo( amount )
+	ent:SetHealth( ent:GetHealth() + amount )
+	
+	-- Do effects
+	self:EmitSound( self.HealSound )
+	self:SendWeaponAnim( ACT_VM_PRIMARYATTACK )
+	
+	local owner = self:GetOwner()
+	
+	if ( owner:IsValid() ) then
+		owner:SetAnimation( PLAYER_ATTACK1 )
 	end
+	
+	local endtime = CurTime() + self:SequenceDuration()
+	self:SetNextIdle( endtime )
+	
+	-- Setup next firing time
+	endtime = endtime + self.HealCooldown
+	self:SetNextPrimaryFire( endtime )
+	self:SetNextSecondaryFire( endtime )
 
 end
 
-function SWEP:OnRemove()
+function SWEP:HealFail( ent )
 
-	timer.Stop( "medkit_ammo" .. self:EntIndex() )
-	timer.Stop( "weapon_idle" .. self:EntIndex() )
+	-- Do effects
+	self:EmitSound( self.DenySound )
+	
+	-- Setup next firing time
+	local endtime = CurTime() + self.DenyCooldown
+	self:SetNextPrimaryFire( endtime )
+	self:SetNextSecondaryFire( endtime )
 
 end
 
-function SWEP:Holster()
+function SWEP:DoHeal( ent )
 
-	timer.Stop( "weapon_idle" .. self:EntIndex() )
-
+	if ( !self:CanHeal( ent ) ) then self:HealFail( ent ) return false end
+	
+	local health, maxhealth = ent:Health(), ent:GetMaxHealth()
+	if ( health >= maxhealth ) then self:HealFail( ent ) return false end
+	
+	local need = math.min( maxhealth - health, self.HealAmount )
+	if ( self:Clip1() < need ) then self:HealFail( ent ) return false end
+	
+	self:HealEntity( ent, need )
+	
 	return true
 
 end
 
-function SWEP:CustomAmmoDisplay()
+function SWEP:Think()
 
-	self.AmmoDisplay = self.AmmoDisplay or {}
-	self.AmmoDisplay.Draw = true
-	self.AmmoDisplay.PrimaryClip = self:Clip1()
+	local curtime = CurTime()
+	
+	if ( curtime >= self:GetNextAmmoRegen() ) then
+		local clip1 = self:Clip1()
+		local maxammo = self.Primary.ClipSize
+	
+		if ( clip1 < maxammo ) then
+			self:SetClip1( math.min( clip1 + self.AmmoRegenAmount, maxammo ) )
+		end
+		
+		self:SetNextAmmoRegen( curtime + self.AmmoRegenFrequency )
+	end
+	
+	if ( curtime >= self:GetNextIdle() ) then
+		self:SendWeaponAnim( ACT_VM_IDLE )
+		self:SetNextIdle( curtime + self:SequenceDuration() )
+	end
 
-	return self.AmmoDisplay
+end
 
+if ( CLIENT ) then
+	function SWEP:CustomAmmoDisplay()
+
+		local display = self.AmmoDisplay
+		display.PrimaryClip = self:Clip1()
+
+		return self.AmmoDisplay
+
+	end
 end


### PR DESCRIPTION
- Converted the ammo/idle timers to predicted netvars like weapon_fists
- Divided up the Primary/SecondaryAttack functions into SWEP:CanHeal(entity), SWEP:DoHeal(entity), SWEP:HealEntity(entity), and SWEP:HealFail(entity)
- Changed many constants to class variables to promote addon SWEP modification instead of copying and modifying the code
- Heal success/failures now punishes both primary and secondary fire no matter which heal type it is to prevent being able to interrupt the medpack animation with the opposite heal type attack
- Regen time is now tied to when the last heal was performed or when the medkit was deployed instead of being arbitrarily tied to a timer's creation time
- Removed SWEP.MaxAmmo as SWEP.Primary.ClipSize was already serving its purpose
- General optimisations/cleanup

Supersedes https://github.com/Facepunch/garrysmod/pull/1942. 