### PR TITLE
Allow suppressing or overriding halo rendering

### DIFF
--- a/garrysmod/lua/includes/modules/halo.lua
+++ b/garrysmod/lua/includes/modules/halo.lua
@@ -144,9 +144,13 @@ function Render( entry )
 	render.SetStencilReferenceValue( 0 )
 end
 
+function GetTable()
+	return List	
+end
+
 hook.Add( "PostDrawEffects", "RenderHalos", function()
 
-	hook.Run( "PreDrawHalos" )
+	if hook.Run( "PreDrawHalos" ) == false then return end
 
 	if ( #List == 0 ) then return end
 

--- a/garrysmod/lua/includes/modules/halo.lua
+++ b/garrysmod/lua/includes/modules/halo.lua
@@ -150,7 +150,7 @@ end
 
 hook.Add( "PostDrawEffects", "RenderHalos", function()
 
-	if hook.Run( "PreDrawHalos" ) == false then return end
+	if ( hook.Run( "PreDrawHalos" ) == false ) then return end
 
 	if ( #List == 0 ) then return end
 


### PR DESCRIPTION
May be used to reimplement halos without having to override the library or for situations where halos may be clashing with aesthetics or rendering (better to hide halos temporarily than have them glow through areas or force people to hook the halo library).