### PR TITLE
Check "CanProperty" for serverside editvariable

### DIFF
--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -496,6 +496,7 @@ if ( SERVER ) then
 		if ( !IsValid( ent ) ) then return end
 		if ( !isfunction( ent.GetEditingData ) ) then return end
 		if ( ent.AdminOnly && !( client:IsAdmin() || game.SinglePlayer() ) ) then return end
+		if ( !gamemode.Call( "CanProperty", client, "edit_variable", ent ) ) then return end
 
 		local key = net.ReadString()
 


### PR DESCRIPTION
Currently, "CanProperty" is not checked server-side when using the "Edit Properties.." option in the context menu, meaning it cannot be blanket disabled by a sandbox derived gamemode.

Made change locally and tested on a dedicated server, now allows blocking "Edit Properties..." 