### PR TITLE
TTT: Fix ironsight position in singleplayer.

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -489,7 +489,7 @@ function SWEP:Initialize()
 end
 
 function SWEP:CalcViewModel()
-   if (not CLIENT) or (not IsFirstTimePredicted()) then return end
+   if (not CLIENT) or (not IsFirstTimePredicted() and not game.SinglePlayer()) then return end
    self.bIron = self:GetIronsights()
    self.fIronTime = self:GetIronsightsTime()
    self.fCurrentTime = CurTime()


### PR DESCRIPTION
CalcViewModel will always return early in singleplayer because of IsFirstTimePredicted always returning false.
This currently causes weapons to stay in place when aiming down sights in singleplayer.