### PR TITLE
use snd_musicvolume instead of volume for loading screens

### DIFF
--- a/garrysmod/lua/menu/loading.lua
+++ b/garrysmod/lua/menu/loading.lua
@@ -273,6 +273,6 @@ function GameDetails( servername, serverurl, mapname, maxplayers, steamid, gamem
 
 	pnlLoading.JavascriptRun = string.format( 'if ( window.GameDetails ) GameDetails( "%s", "%s", "%s", %i, "%s", "%s", %.2f, "%s", "%s" );',
 		servername:JavascriptSafe(), serverurl:JavascriptSafe(), mapname:JavascriptSafe(), maxplayers, steamid:JavascriptSafe(), g_GameMode:JavascriptSafe(),
-		GetConVarNumber( "volume" ), GetConVarString( "gmod_language" ), niceGamemode:JavascriptSafe() )
+		GetConVarNumber( "snd_musicvolume" ), GetConVarString( "gmod_language" ), niceGamemode:JavascriptSafe() )
 
 end


### PR DESCRIPTION
Simple PR to follow "Music Volume" (`snd_musicvolume`) instead of "Game Volume" (`volume`).

In https://github.com/Facepunch/garrysmod/pull/1427#issuecomment-342980787 I asked whether the "Music Volume" slider can be used instead of the "Game Volume", but wasn't sure of the convar at the time. I see `snd_musicvolume` actually exists, but yet, it's not being used here.

This should also address https://github.com/Facepunch/garrysmod-requests/issues/1349

![image](https://user-images.githubusercontent.com/14265751/221372597-ed19eb16-d6bd-4c32-908a-d6e8453599ce.png)
