### PR TITLE
Crop DButton's image size if it's too big

### DIFF
--- a/garrysmod/lua/vgui/dbutton.lua
+++ b/garrysmod/lua/vgui/dbutton.lua
@@ -102,13 +102,20 @@ function PANEL:PerformLayout( w, h )
 	--
 	if ( IsValid( self.m_Image ) ) then
 
-		local ar = self.m_Image:GetWide()/self.m_Image:GetTall()
-		local tall = math.min(self.m_Image:GetTall(), self:GetTall()-4)
+		local targetSize = math.min( self:GetWide() - 4, self:GetTall() - 4 )
 
-		self.m_Image:SetWide(tall*ar)
-		self.m_Image:SetTall(tall)
-		
-		self.m_Image:SetPos( 4, ( self:GetTall() - self.m_Image:GetTall() ) * 0.5 )
+		local zoom = math.min( targetSize / self.m_Image:GetWide(), targetSize / self.m_Image:GetTall(), 1 )
+		local newSizeX = math.ceil( self.m_Image:GetWide() * zoom )
+		local newSizeY = math.ceil( self.m_Image:GetTall() * zoom )
+
+		self.m_Image:SetWide( newSizeX )
+		self.m_Image:SetTall( newSizeY )
+
+		if ( self:GetWide() < self:GetTall() ) then
+			self.m_Image:SetPos( 4, ( self:GetTall() - self.m_Image:GetTall() ) * 0.5 )
+		else
+			self.m_Image:SetPos( 2 + ( targetSize - self.m_Image:GetWide() ) * 0.5, ( self:GetTall() - self.m_Image:GetTall() ) * 0.5 )
+		end 
 
 		self:SetTextInset( self.m_Image:GetWide() + 16, 0 )
 

--- a/garrysmod/lua/vgui/dbutton.lua
+++ b/garrysmod/lua/vgui/dbutton.lua
@@ -102,8 +102,12 @@ function PANEL:PerformLayout( w, h )
 	--
 	if ( IsValid( self.m_Image ) ) then
 
-		self.m_Image:SetWide(math.min(self.m_Image:GetWide(), self:GetTall()-4))
-		self.m_Image:SetTall(math.min(self.m_Image:GetTall(), self:GetTall()-4))
+		local ar = self.m_Image:GetWide()/self.m_Image:GetTall()
+		local tall = math.min(self.m_Image:GetTall(), self:GetTall()-4)
+
+		self.m_Image:SetWide(tall*ar)
+		self.m_Image:SetTall(tall)
+		
 		self.m_Image:SetPos( 4, ( self:GetTall() - self.m_Image:GetTall() ) * 0.5 )
 
 		self:SetTextInset( self.m_Image:GetWide() + 16, 0 )

--- a/garrysmod/lua/vgui/dbutton.lua
+++ b/garrysmod/lua/vgui/dbutton.lua
@@ -102,6 +102,8 @@ function PANEL:PerformLayout( w, h )
 	--
 	if ( IsValid( self.m_Image ) ) then
 
+		self.m_Image:SetWide(math.min(self.m_Image:GetWide(), self:GetTall()-4))
+		self.m_Image:SetTall(math.min(self.m_Image:GetTall(), self:GetTall()-4))
 		self.m_Image:SetPos( 4, ( self:GetTall() - self.m_Image:GetTall() ) * 0.5 )
 
 		self:SetTextInset( self.m_Image:GetWide() + 16, 0 )


### PR DESCRIPTION
It will allow higher resolution icons to be used with lower sized DButtons. For example, on first pic 72x72 icons used with DButtons before changes and after

![pic1](https://user-images.githubusercontent.com/71833488/226166558-f892dfeb-b814-43e7-a920-7d6b9e7dcbd0.png) ![pic2](https://user-images.githubusercontent.com/71833488/226166567-2ac42e16-a367-41e2-ae84-9bcb15d96bca.png)