### PR TITLE
Server browser should not penalise servers below a ping threshold

### DIFF
--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -339,7 +339,7 @@ function FormatVersion( ver )
 // Calculates the default server ranking
 function CalculateRank( server )
 {
-	var recommended = server.ping;
+	var recommended = Math.max(server.ping, 50);
 
 	if ( server.players == 0 ) recommended += 75; // Server is empty
 	if ( server.players >= server.maxplayers ) recommended += 100; // Server is full, can't join it


### PR DESCRIPTION
This PR reverts the change of [this commit](https://github.com/Facepunch/garrysmod/commit/8f307ab1a0f524b1658a3d537b34c986b98d73f9#diff-d633516491f4e0d5fe18d67f9a15cce8e86d31b3392c0c816c793d0f49b3f05a) and slightly improves the previous behaviour.

I do not see any reason this change was done in the first place.

Without the minimum threshold at which ping starts to matter, even anycast locations within the same continent will make a huge difference. This change is likely the reason why you cannot even realistically run a popular server in the US without having anycast. At the very least, the change made it significantly worse.
For example, a difference of 40ms due to anycast will currently make a server with just 8 players appear higher than a server with 100 players, which is absurd.

This PR also slightly improves the behaviour introduced prior to the mentioned commit. The ping penalty will now gradually come in starting at 50ms (the exact threshold can possibly be debated), rather than making a massive difference going from 60 to 61ms.
