### PR TITLE
Fix error due to derma_icon_browser

### DIFF
--- a/garrysmod/lua/send.txt
+++ b/garrysmod/lua/send.txt
@@ -83,6 +83,7 @@ lua\derma\derma_menus.lua
 lua\derma\derma_animation.lua
 lua\derma\derma_utils.lua
 lua\derma\derma_gwen.lua
+lua\derma\derma_icon_browser.lua
 lua\drive\drive_base.lua
 lua\drive\drive_noclip.lua
 lua\drive\drive_sandbox.lua


### PR DESCRIPTION
derma_icon_browser which was added in the latest patch was not added to send.txt, resulting in a file not found error

![image](https://user-images.githubusercontent.com/35779365/232953517-fab2c56c-a4fe-4933-9a3c-3e1434e99d7c.png)
