### PR TITLE
TTT: fix effect_fn being permanent (causes physics crashes)

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
@@ -376,6 +376,9 @@ local rag_collide = CreateConVar("ttt_ragdoll_collide", "0")
 function CORPSE.Create(ply, attacker, dmginfo)
    if not IsValid(ply) then return end
 
+   local efn = ply.effect_fn
+   ply.effect_fn = nil
+
    local rag = ents.Create("prop_ragdoll")
    if not IsValid(rag) then return nil end
 
@@ -450,10 +453,9 @@ function CORPSE.Create(ply, attacker, dmginfo)
    end
 
    -- create advanced death effects (knives)
-   if ply.effect_fn then
+   if efn then
       -- next frame, after physics is happy for this ragdoll
-      local efn = ply.effect_fn
-      timer.Simple(0, function() efn(rag) end)
+      timer.Simple(0, function() if IsValid(rag) then efn(rag) end end)
    end
 
    hook.Run("TTTOnCorpseCreated", rag, ply)


### PR DESCRIPTION
this removes the "effect_fn" function from a player after use since it's supposed to be a temporary function that's used only once

i also added an IsValid check for the ragdoll since it might've become invalid after 1 tick

effect_fn being permanent is what causes knives to be randomly floating in the air even after many many rounds since someone last died to a knife

when someone dies to a knife, that player is forever TAINTED, all of their deaths in the following rounds will spawn a knife prop with a cursed offset that gets welded to their corpse

it's very hard to replicate but i've found that this bug eventually causes certain ragdolls to freak out, and eventually can cause a physics "crash" (server just hangs)