### PR TITLE
Make hint text more useful if the command key is unbound

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/cl_hints.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/cl_hints.lua
@@ -73,8 +73,8 @@ function GM:UnprocessHint( name )
 end
 
 -- Show opening menu hint if they haven't opened the menu within 30 seconds
-GM:AddHint( "OpeningMenu", 10 )
+GM:AddHint( "OpeningMenu", 30 )
 
 -- Tell them that they can turn off hints as they fully load in
-GM:AddHint( "Annoy1", 5 )
-GM:AddHint( "Annoy2", 7 )
+GM:AddHint( "Annoy1", 10 )
+GM:AddHint( "Annoy2", 13 )

--- a/garrysmod/gamemodes/sandbox/gamemode/cl_hints.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/cl_hints.lua
@@ -1,73 +1,80 @@
 
-local cl_showhints = CreateClientConVar( "cl_showhints", "1", true, false )
+local cl_showhints = CreateConVar( "cl_showhints", "1",
+	bit.bor( FCVAR_ARCHIVE, FCVAR_USERINFO ), "Show hints called thru SANDBOX:AddHint", 0, 1 )
 
--- A list of hints we've already done so we don't repeat ourselves`
-local ProcessedHints = {}
+-- A list of hints we've already done so we don't repeat ourselves
+GM.ProcessedHints = {}
 
---
--- Throw's a Hint to the screen
---
-local function ThrowHint( GM, name, force, length )
+local function ThrowHint( GM, name, length, sound )
 
 	if ( !cl_showhints:GetBool() ) then return end
 
 	local text = language.GetPhrase( "Hint_" .. name )
+	local startpos, endpos, bind = text:find( "%%([^%%]+)%%" )
 
-	local s, e, group = string.find( text, "%%([^%%]+)%%" )
-	while ( s ) do
-		local key = input.LookupBinding( group )
-		if ( !key ) then
-			if ( !force ) then return end
-			key = "<NOT BOUND>"
-		end
+	if ( startpos ~= nil ) then
+		local buffer = {}
+		local bufferlen = 1
+		local nextstartpos = 1
+		
+		repeat
+			local key = input.LookupBinding( bind )
 
-		text = string.gsub( text, "%%([^%%]+)%%", "'" .. key:upper() .. "'" )
-		s, e, group = string.find( text, "%%([^%%]+)%%" )
+			if ( key ~= nil ) then
+				key = key:upper()
+			else
+				key = bind .. " (command not bound to a key)"
+			end
+
+			-- Add the unaltered string + the translated key to the string buffer
+			buffer[ bufferlen ] = text:sub( nextstartpos, startpos - 1 )
+			buffer[ bufferlen + 1 ] = key
+			bufferlen = bufferlen + 2
+
+			nextstartpos = endpos + 1
+			startpos, endpos, bind = text:find( "%%([^%%]+)%%", nextstartpos )
+		until ( startpos == nil )
+		
+		text = table.concat( buffer, "", 1, bufferlen - 1 )
 	end
 
 	if ( length == nil ) then length = 20 end
 	GM:AddNotify( text, NOTIFY_HINT, length )
 
-	surface.PlaySound( "ambient/water/drip" .. math.random( 1, 4 ) .. ".wav" )
+	if ( sound == nil ) then sound = "ambient/water/drip" .. math.random( 1, 4 ) .. ".wav" end
+	surface.PlaySound( sound )
 
 end
 
+function GM:AddHint( name, delay, length, sound )
 
---
--- Adds a hint to the queue
---
-function GM:AddHint( name, delay, force, length )
-
-	if ( ProcessedHints[ name ] ) then return end
+	if ( self.ProcessedHints[ name ] ) then return end
 
 	if ( !engine.IsPlayingDemo() ) then
-		timer.Create( "HintSystem_" .. name, delay, 1, function()
-			ThrowHint( self, name, force, length )
+		timer.Create( "GMOD_HintSystem_" .. name, delay, 1, function()
+			ThrowHint( self, name, length, sound )
 		end )
 	end
 
-	ProcessedHints[ name ] = true
+	self.ProcessedHints[ name ] = true
 
 end
 
---
--- Removes a hint from the queue
---
 function GM:SuppressHint( name )
 
-	timer.Remove( "HintSystem_" .. name )
+	timer.Remove( "GMOD_HintSystem_" .. name )
 
 end
 
 function GM:UnprocessHint( name )
 
-	ProcessedHints[ name ] = nil
+	self.ProcessedHints[ name ] = nil
 
 end
 
 -- Show opening menu hint if they haven't opened the menu within 30 seconds
-GM:AddHint( "OpeningMenu", 30 )
+GM:AddHint( "OpeningMenu", 10 )
 
--- Tell them that they can turn off hints as they load in
-GM:AddHint( "Annoy1", 10 )
-GM:AddHint( "Annoy2", 12 )
+-- Tell them that they can turn off hints as they fully load in
+GM:AddHint( "Annoy1", 5 )
+GM:AddHint( "Annoy2", 7 )


### PR DESCRIPTION
Additionally
- Add ``number length`` and ``string sound`` arguments to ``GM:AddHint`` that default to ``20`` and ``"ambient/water/drip" .. math.random( 1, 4 ) .. ".wav"`` respectively
- Add ``GM:UnprocessHint( string name )``
- Make ``ProcessedHints`` a gamemode table var rather than a local
- Add helptext to ``cl_showhints``
- Adjust ``Annoy#`` hint times to account for the full-load time discrepancy
- Change ``HintTimer_`` hook prefix to ``GMOD_HintTimer_``
- Various optimizations