### PR TITLE
Reworked server browser ranking

### DIFF
--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -339,19 +339,19 @@ function FormatVersion( ver )
 // Calculates the default server ranking
 function CalculateRank( server )
 {
-	var recommended = server.ping;
+	// Add some fuzzines/discoverability to the server list
+	var recommended = server.fuzziness;
+
+	// Give more popular servers a higher ranking, starting at more than 2 players
+	recommended -= Math.max(Math.log2(Math.min(server.players, 96) + 1) - 2, 0) * 10;
+
+	// Penalise very high pings, anything below 60 ping makes little difference
+	recommended += Math.max(server.ping, 60) / 2;
 
 	if ( server.players == 0 ) recommended += 75; // Server is empty
 	if ( server.players >= server.maxplayers ) recommended += 100; // Server is full, can't join it
 	if ( server.pass ) recommended += 300; // Password protected, can't join it
 	if ( server.isAnon ) recommended += 1000; // Anonymous server
-
-	// The first few bunches of players reduce the impact of the server's ping on the ranking a little
-	if ( server.players >= 4 ) recommended -= 10;
-	if ( server.players >= 8 ) recommended -= 15;
-	if ( server.players >= 16 ) recommended -= 15;
-	if ( server.players >= 32 ) recommended -= 10;
-	if ( server.players >= 64 ) recommended -= 10;
 
 	return recommended;
 }
@@ -423,6 +423,7 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 		botplayers:		parseInt( botplayers ),
 		pass:			pass == "1",
 		lastplayed:		parseInt( lastplayed ),
+		fuzziness:		Math.random() * 15,
 		address:		address,
 		flag: 			loc.toLowerCase(),
 		category: 		gmcat || "",


### PR DESCRIPTION
The current server browser ranking suffers from a few pitfalls that this PR tries to address:

- Currently, small changes in player count (e.g. 63 vs 64 players) can make a huge difference in the server ranking due to how the categories work. This PR addresses the issue by making this change gradual. A server with 64 players now only has an insignificantly higher score than a 63 player server.
  - At similar ping, it is also currently impossible for servers in the lower player "category" to be above servers in the higher category, making it very hard for small servers to even get noticed in the "busy" gamemode categories.
- Currently, ping plays a massive role in server ranking and a ping difference of just 1ms might put you at the bottom of the 64/32/16 player category. This PR makes it so anything below 50ms is not penalized. Also, after 50ms, the ping difference comes in gradually rather than being a massive jump.

The problem with just doing these two changes is that it would result in servers being ordered almost exclusively by player count. To address this issue, this PR also adds fuzziness to the server list. Fuzziness is basically just a small random number defeating any strict ranking. Instead, the ranking is probabilistic, i.e. more popular servers are more likely to be near the top, but it is not guaranteed. An added benefit is that fuzziness also allows smaller servers to be above bigger ones, but only sometimes.
  - With the fuzziness, a 63 player server is essentially as likely to be above a 64 player server as in the reverse.
  - It is possible for a 30 player server to be above an 80 player server in the server ranking, but it is relatively unlikely
  - A server with a ping of 60 and a server with a ping of 62 will be ranked roughly in the same place probabilistically
  - A server with a ping of 120 will always be ranked after a server with a ping of 60

All the precise numbers used in the PR can of course be up for debate.


[Here's ](https://user-images.githubusercontent.com/1258762/235445764-5e7a60eb-5191-47ed-849d-c3a3130dad90.png)an image demonstrating the ping issue of the current ranking.

Here's two images of the ranking this this PR introduces in the TTT category:
[sample1](https://media.discordapp.net/attachments/589120351238225940/1101661921519861841/ttt_example.png?width=1223&height=904), [sample2](https://media.discordapp.net/attachments/589120351238225940/1101661921847033876/ttt_example2.png?width=1232&height=904), note that each time you refresh, the ranking will be slightly different.