### PR TITLE
Fixed Addons and Dupes not updating.

### DIFF
--- a/garrysmod/html/js/menu/control.Addons.js
+++ b/garrysmod/html/js/menu/control.Addons.js
@@ -422,3 +422,10 @@ function UpdateAddonDisabledState( noaddons, noworkshop )
 	Scope.Disabled = noworkshop;
 	UpdateDigest( Scope, 50 );
 }
+
+function UpdateAddons()
+{
+	if ( !Scope ) return;
+
+	Scope.SwitchWithTag( 'subscribed', 0, '' );
+}

--- a/garrysmod/html/js/menu/control.Addons.js
+++ b/garrysmod/html/js/menu/control.Addons.js
@@ -422,10 +422,3 @@ function UpdateAddonDisabledState( noaddons, noworkshop )
 	Scope.Disabled = noworkshop;
 	UpdateDigest( Scope, 50 );
 }
-
-function UpdateAddons()
-{
-	if ( !Scope ) return;
-
-	Scope.SwitchWithTag( 'subscribed', 0, '' );
-}

--- a/garrysmod/html/js/menu/control.Dupes.js
+++ b/garrysmod/html/js/menu/control.Dupes.js
@@ -108,3 +108,10 @@ function OnGameSaved()
 {
 	Scope.Switch( 'local', 0 );
 }
+
+function UpdateDupes()
+{
+	if ( !Scope ) return;
+
+	Scope.SwitchWithTag( 'subscribed_ugc', 0, '' );
+}

--- a/garrysmod/html/js/menu/control.Dupes.js
+++ b/garrysmod/html/js/menu/control.Dupes.js
@@ -108,10 +108,3 @@ function OnGameSaved()
 {
 	Scope.Switch( 'local', 0 );
 }
-
-function UpdateDupes()
-{
-	if ( !Scope ) return;
-
-	Scope.SwitchWithTag( 'subscribed_ugc', 0, '' );
-}

--- a/garrysmod/html/js/menu/control.Menu.js
+++ b/garrysmod/html/js/menu/control.Menu.js
@@ -323,6 +323,13 @@ function UpdateVersion( version, netVersion, branch )
 	UpdateDigest( gScope, 100 );
 }
 
+function UpdateCurrentCategory()
+{
+	if ( !Scope ) return;
+
+	Scope.Switch( Scope.Category, 0 );
+}
+
 function SetProblemCount( num, severity )
 {
 	gScope.ProblemCount		= num;

--- a/garrysmod/lua/menu/mainmenu.lua
+++ b/garrysmod/lua/menu/mainmenu.lua
@@ -97,7 +97,6 @@ function PANEL:RefreshContent()
 
 	self:RefreshGamemodes()
 	self:RefreshAddons()
-	self:RefreshDupes()
 
 end
 
@@ -113,13 +112,7 @@ end
 
 function PANEL:RefreshAddons()
 
-	self:Call( "UpdateAddons()" )
-
-end
-
-function PANEL:RefreshDupes()
-
-	self:Call( "UpdateDupes()" )
+	self:Call( "UpdateCurrentCategory()" )
 
 end
 

--- a/garrysmod/lua/menu/mainmenu.lua
+++ b/garrysmod/lua/menu/mainmenu.lua
@@ -97,6 +97,7 @@ function PANEL:RefreshContent()
 
 	self:RefreshGamemodes()
 	self:RefreshAddons()
+	self:RefreshDupes()
 
 end
 
@@ -112,7 +113,13 @@ end
 
 function PANEL:RefreshAddons()
 
-	-- TODO
+	self:Call( "UpdateAddons()" )
+
+end
+
+function PANEL:RefreshDupes()
+
+	self:Call( "UpdateDupes()" )
 
 end
 


### PR DESCRIPTION
This fixes the Addons list not updating and the Dupes list opening a Blank page, when the game content changed.  
This also adds the function `MainMenuPanel:RefreshDupes()` and makes `MainMenuPanel:RefreshAddons()` functional