### PR TITLE
Send achievements through net. instead of :SendLua

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/entities/gmod_balloon.lua
+++ b/garrysmod/gamemodes/sandbox/entities/entities/gmod_balloon.lua
@@ -71,7 +71,7 @@ function ENT:OnTakeDamage( dmginfo )
 
 	local attacker = dmginfo:GetAttacker()
 	if ( IsValid( attacker ) && attacker:IsPlayer() ) then
-		attacker:SendLua( "achievements.BalloonPopped()" )
+        attacker:SendAchievement( "BalloonPopped" )
 	end
 
 	self:Remove()

--- a/garrysmod/gamemodes/sandbox/entities/entities/gmod_balloon.lua
+++ b/garrysmod/gamemodes/sandbox/entities/entities/gmod_balloon.lua
@@ -71,7 +71,7 @@ function ENT:OnTakeDamage( dmginfo )
 
 	local attacker = dmginfo:GetAttacker()
 	if ( IsValid( attacker ) && attacker:IsPlayer() ) then
-        attacker:SendAchievement( "BalloonPopped" )
+		attacker:SendAchievement( "BalloonPopped" )
 	end
 
 	self:Remove()

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/remover.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/remover.lua
@@ -44,7 +44,7 @@ function TOOL:LeftClick( trace )
 	if ( DoRemoveEntity( trace.Entity ) ) then
 
 		if ( !CLIENT ) then
-			self:GetOwner():SendLua( "achievements.Remover()" )
+			self:GetOwner():SendAchievement( "Remover" )
 		end
 
 		return true
@@ -79,7 +79,7 @@ function TOOL:RightClick( trace )
 
 	end
 
-	self:GetOwner():SendLua( string.format( "for i=1,%i do achievements.Remover() end", Count ) )
+	self:SendAchievement( "Remover", Count )
 
 	return true
 

--- a/garrysmod/gamemodes/sandbox/gamemode/commands.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/commands.lua
@@ -341,7 +341,7 @@ function DoPlayerEntitySpawn( ply, entity_name, model, iSkin, strBody )
 
 		-- Set new position
 		ent:SetPos( vFlushPoint )
-		ply:SendLua( "achievements.SpawnedProp()" )
+		ply:SendAchievement( "SpawnedProp" )
 
 	else
 
@@ -352,7 +352,7 @@ function DoPlayerEntitySpawn( ply, entity_name, model, iSkin, strBody )
 			phys:SetPos( phys:GetPos() + VecOffset )
 		end
 
-		ply:SendLua( "achievements.SpawnedRagdoll()" )
+		ply:SendAchievement( "SpawnedRagdoll" )
 
 	end
 
@@ -562,7 +562,7 @@ function Spawn_NPC( ply, NPCClassName, WeaponName, tr )
 	-- And cleanup
 	ply:AddCleanup( "npcs", SpawnedNPC )
 
-	ply:SendLua( "achievements.SpawnedNPC()" )
+	ply:SendAchievement( "SpawnedNPC" )
 
 end
 concommand.Add( "gmod_spawnnpc", function( ply, cmd, args ) Spawn_NPC( ply, args[ 1 ], args[ 2 ] ) end )

--- a/garrysmod/gamemodes/sandbox/gamemode/player_extension.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/player_extension.lua
@@ -103,6 +103,7 @@ function meta:AddCleanup( type, ent )
 end
 
 if ( SERVER ) then
+	util.AddNetworkString( "SendAchievement" )
 
 	function meta:GetTool( mode )
 
@@ -136,7 +137,31 @@ if ( SERVER ) then
 
 	end
 
+
+	function meta:SendAchievement( achievement, count )
+		count = count or 1
+
+		net.Start( 'SendAchievement' )
+		net.WriteString( achievement )
+		net.WriteUInt( count, 16 )
+		net.Send( self )
+
+	end
 else
+
+	net.Receive( 'SendAchievement', function( len )
+
+		local achievement = net.ReadString()
+		local count = net.ReadUInt( 16 )
+
+		local func = achievements[ achievement ]
+		if !achievement then return end
+
+		for _ = 1, count do
+			func()
+		end
+
+	end )
 
 	function meta:GetTool( mode )
 

--- a/garrysmod/lua/autorun/properties/remove.lua
+++ b/garrysmod/lua/autorun/properties/remove.lua
@@ -50,7 +50,7 @@ properties.Add( "remove", {
 		ed:SetEntity( ent )
 		util.Effect( "entity_remove", ed, true, true )
 
-		ply:SendLua( "achievements.Remover()" )
+		ply:SendAchievement( "Remover" )
 
 	end
 

--- a/garrysmod/lua/entities/sent_ball.lua
+++ b/garrysmod/lua/entities/sent_ball.lua
@@ -148,7 +148,7 @@ function ENT:Use( activator, caller )
 		-- Give the collecting player some free health
 		local health = activator:Health()
 		activator:SetHealth( health + 5 )
-		activator:SendLua( "achievements.EatBall()" )
+		activator:SendAchievement( "EatBall" )
 
 	end
 


### PR DESCRIPTION
I've noticed that pretty much all achievements are currently being send through SendLua which is suboptimal, my proposal is to send it through the net library instead so there's less bandwith being used.

I'm open for suggestions and improvements as this might not be the best way to do it. I've considered sending the int of achievements instead of using the achievement string but those aren't easily available on serverside so i went with this.

It's hard to test how much SendLua really sends over so i am not 100% sure if this can be considered an improvement, although in the best case sending (for SendLua) `achievements.SpawnedProp()` is 26 bytes while with this method it'd be 14 bytes of data.