### PR TITLE
Add AddLegacyType & GetLegacyTypes

### DIFF
--- a/garrysmod/lua/includes/modules/notification.lua
+++ b/garrysmod/lua/includes/modules/notification.lua
@@ -84,6 +84,21 @@ function AddLegacy( text, type, length )
 
 end
 
+function AddLegacyType( legacyName, materialName )
+	if ( !isstring( legacyName ) ) then error( "bad argument #1 to 'AddLegacyType' (string expected, got " .. type( legacyName ) .. ")", 2 ) return end
+	if ( !isstring( materialName ) ) then error( "bad argument #2 to 'AddLegacyType' (string expected, got " .. type( materialName ) .. ")", 2 ) return end
+
+	local mat = Material( materialName )
+
+	if ( !mat || mat:IsError() ) then return end
+
+	NoticeMaterial[ legacyName ] = mat
+end
+
+function GetLegacyTypes()
+	return NoticeMaterial
+end
+
 -- This is ugly because it's ripped straight from the old notice system
 local function UpdateNotice( pnl, total_h )
 


### PR DESCRIPTION
The notice material types are hard-coded and we have such a small arsenal of these materials, it would be nice to have an easy way to add our own. This might be a useless addition, I'd like to see feedback on this.