### PR TITLE
Expose RealFrameTime() to the menu state

### DIFF
--- a/garrysmod/lua/includes/extensions/util.lua
+++ b/garrysmod/lua/includes/extensions/util.lua
@@ -395,3 +395,24 @@ function util.IsBinaryModuleInstalled( name )
 
 	return false
 end
+
+if ( SERVER ) then return end
+
+--[[---------------------------------------------------------
+	Get the real frame time, instead of the
+		host_timescale linked frametime. This is for things
+		like GUI effects. NOT FOR REAL IN GAME STUFF(!!!)
+-----------------------------------------------------------]]
+local FrameTime = 0
+local LastQuery = 0
+
+function RealFrameTime() return FrameTime end
+
+local function RealFrameTimeThink()
+
+	FrameTime = math.Clamp( SysTime() - LastQuery, 0, 0.1 )
+	LastQuery = SysTime()
+
+end
+
+hook.Add( "Think", "RealFrameTime", RealFrameTimeThink ) -- Think is called after every frame on the client.

--- a/garrysmod/lua/includes/util/client.lua
+++ b/garrysmod/lua/includes/util/client.lua
@@ -1,23 +1,4 @@
 
---[[---------------------------------------------------------
-	Get the real frame time, instead of the
-		host_timescale linked frametime. This is for things
-		like GUI effects. NOT FOR REAL IN GAME STUFF(!!!)
------------------------------------------------------------]]
-local FrameTime = 0
-local LastQuery = 0
-
-function RealFrameTime() return FrameTime end
-
-local function RealFrameTimeThink()
-
-	FrameTime = math.Clamp( SysTime() - LastQuery, 0, 0.1 )
-	LastQuery = SysTime()
-
-end
-
-hook.Add( "Think", "RealFrameTime", RealFrameTimeThink ) -- Think is called after every frame on the client.
-
 local function RenderSpawnIcon_Prop( model, pos, middle, size )
 
 	if ( size < 900 ) then


### PR DESCRIPTION
This one is simple and more of a fix than anything. notification.AddLegacy() is available to both client and menu state and utilizes this function, but errors on the menu state because RealFrameTime() isn't exposed to that state.