### PR TITLE
TTT: Fix wrong argument in SortByMember

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_cse_proj.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_cse_proj.lua
@@ -174,7 +174,7 @@ function ENT:Explode(tr)
 
       local corpses = self:GetNearbyCorpses()
       if #corpses > self.MaxScenesPerPulse then
-         table.SortByMember(corpses, "dist", function(a, b) return a > b end)
+         table.SortByMember(corpses, "dist", true)
       end
 
       local e = EffectData()


### PR DESCRIPTION
This can cause confusion because the function is never called, but the table sorts itself in the correct order.