### PR TITLE
Updated `cvars` library

### DIFF
--- a/garrysmod/lua/includes/modules/cvars.lua
+++ b/garrysmod/lua/includes/modules/cvars.lua
@@ -4,131 +4,131 @@ local type				= type
 local GetConVar			= GetConVar
 
 --[[---------------------------------------------------------
-    Name: cvar
-    Desc: Callbacks when cvars change
+	Name: cvar
+	Desc: Callbacks when cvars change
 -----------------------------------------------------------]]
 module( "cvars" )
 
 local ConVars = {}
 
 --[[---------------------------------------------------------
-    Name: GetConVarCallbacks
-    Desc: Returns a table of the given ConVars callbacks
+	Name: GetConVarCallbacks
+	Desc: Returns a table of the given ConVars callbacks
 -----------------------------------------------------------]]
 function GetConVarCallbacks( name, createIfNotFound )
 
-    local tab = ConVars[ name ]
-    if ( createIfNotFound and !tab ) then
-        tab = {}; ConVars[ name ] = tab
-    end
+	local tab = ConVars[ name ]
+	if ( createIfNotFound and !tab ) then
+		tab = {}; ConVars[ name ] = tab
+	end
 
-    return tab
+	return tab
 
 end
 
 --[[---------------------------------------------------------
-    Name: OnConVarChanged
-    Desc: Called by the engine
+	Name: OnConVarChanged
+	Desc: Called by the engine
 -----------------------------------------------------------]]
 function OnConVarChanged( name, old, new )
 
-    local tab = GetConVarCallbacks( name )
-    if ( !tab ) then return end
+	local tab = GetConVarCallbacks( name )
+	if ( !tab ) then return end
 
-    for i = 1, #tab do
-        local callback = tab[ i ]
-        if ( type( callback ) == "table" ) then
-            callback[ 1 ]( name, old, new )
-        else
-            callback( name, old, new )
-        end
-    end
+	for i = 1, #tab do
+		local callback = tab[ i ]
+		if ( type( callback ) == "table" ) then
+			callback[ 1 ]( name, old, new )
+		else
+			callback( name, old, new )
+		end
+	end
 
 end
 
 --[[---------------------------------------------------------
-    Name: AddChangeCallback
-    Desc: Adds a callback to be called when convar changes
+	Name: AddChangeCallback
+	Desc: Adds a callback to be called when convar changes
 -----------------------------------------------------------]]
 function AddChangeCallback( name, func, identifier )
 
-    local tab = GetConVarCallbacks( name, true )
+	local tab = GetConVarCallbacks( name, true )
 
-    if ( !identifier ) then
-        table.insert( tab, func )
-        return
-    end
+	if ( !identifier ) then
+		table.insert( tab, func )
+		return
+	end
 
-    for i = 1, #tab do
-        local callback = tab[ i ]
-        if ( type( callback ) == "table" and callback[ 2 ] == identifier ) then
-            callback[ 1 ] = func
-            return
-        end
-    end
+	for i = 1, #tab do
+		local callback = tab[ i ]
+		if ( type( callback ) == "table" and callback[ 2 ] == identifier ) then
+			callback[ 1 ] = func
+			return
+		end
+	end
 
-    table.insert( tab, { func, identifier } )
+	table.insert( tab, { func, identifier } )
 
 end
 
 --[[---------------------------------------------------------
-    Name: RemoveChangeCallback
-    Desc: Removes callback with identifier
+	Name: RemoveChangeCallback
+	Desc: Removes callback with identifier
 -----------------------------------------------------------]]
 function RemoveChangeCallback( name, identifier )
 
-    local tab = GetConVarCallbacks( name, true )
-    for i = 1, #tab do
-        local callback = tab[ i ]
-        if ( type( callback ) == "table" and callback[ 2 ] == identifier ) then
-            table.remove( tab, i )
-            break
-        end
-    end
+	local tab = GetConVarCallbacks( name, true )
+	for i = 1, #tab do
+		local callback = tab[ i ]
+		if ( type( callback ) == "table" and callback[ 2 ] == identifier ) then
+			table.remove( tab, i )
+			break
+		end
+	end
 
 end
 
 --[[---------------------------------------------------------
-    Name: String
-    Desc: Retrieves console variable as a string
+	Name: String
+	Desc: Retrieves console variable as a string
 -----------------------------------------------------------]]
 function String( name, default )
 
-    local convar = GetConVar( name )
-    if ( convar ~= nil ) then
-        return convar:GetString()
-    end
+	local convar = GetConVar( name )
+	if ( convar ~= nil ) then
+		return convar:GetString()
+	end
 
-    return default
+	return default
 
 end
 
 --[[---------------------------------------------------------
-    Name: Number
-    Desc: Retrieves console variable as a number
+	Name: Number
+	Desc: Retrieves console variable as a number
 -----------------------------------------------------------]]
 function Number( name, default )
 
-    local convar = GetConVar( name )
-    if ( convar ~= nil ) then
-        return convar:GetFloat()
-    end
+	local convar = GetConVar( name )
+	if ( convar ~= nil ) then
+		return convar:GetFloat()
+	end
 
-    return default
+	return default
 
 end
 
 --[[---------------------------------------------------------
-    Name: Bool
-    Desc: Retrieves console variable as a boolean
+	Name: Bool
+	Desc: Retrieves console variable as a boolean
 -----------------------------------------------------------]]
 function Bool( name, default )
 
-    local convar = GetConVar( name )
-    if ( convar ~= nil ) then
-        return convar:GetBool()
-    end
+	local convar = GetConVar( name )
+	if ( convar ~= nil ) then
+		return convar:GetBool()
+	end
 
-    return default
+	return default
 
 end

--- a/garrysmod/lua/includes/modules/cvars.lua
+++ b/garrysmod/lua/includes/modules/cvars.lua
@@ -2,6 +2,7 @@
 local table				= table
 local type				= type
 local istable 			= istable
+local isstring			= isstring
 local assert			= assert
 local format			= string.format
 local GetConVar			= GetConVar
@@ -57,7 +58,7 @@ end
 function AddChangeCallback( name, func, identifier )
 
 	if ( identifier ) then
-		assert( type( identifier ) == "string", format( "bad argument #%i (string expected, got %s)", 2, type( identifier ) ) )
+		assert( isstring( identifier ), format( "bad argument #%i (string expected, got %s)", 3, type( identifier ) ) )
 	end
 
 	local tab = GetConVarCallbacks( name, true )
@@ -86,7 +87,7 @@ end
 function RemoveChangeCallback( name, identifier )
 
 	if ( identifier ) then
-		assert( type( identifier ) == "string", format( "bad argument #%i (string expected, got %s)", 2, type( identifier ) ) )
+		assert( isstring( identifier ), format( "bad argument #%i (string expected, got %s)", 2, type( identifier ) ) )
 	end
 
 	local tab = GetConVarCallbacks( name, true )

--- a/garrysmod/lua/includes/modules/cvars.lua
+++ b/garrysmod/lua/includes/modules/cvars.lua
@@ -1,6 +1,9 @@
 
 local table				= table
 local type				= type
+local istable 			= istable
+local assert			= assert
+local format			= string.format
 local GetConVar			= GetConVar
 
 --[[---------------------------------------------------------
@@ -19,7 +22,8 @@ function GetConVarCallbacks( name, createIfNotFound )
 
 	local tab = ConVars[ name ]
 	if ( createIfNotFound and !tab ) then
-		tab = {}; ConVars[ name ] = tab
+		tab = {}
+		ConVars[ name ] = tab
 	end
 
 	return tab
@@ -37,7 +41,7 @@ function OnConVarChanged( name, old, new )
 
 	for i = 1, #tab do
 		local callback = tab[ i ]
-		if ( type( callback ) == "table" ) then
+		if ( istable( callback ) ) then
 			callback[ 1 ]( name, old, new )
 		else
 			callback( name, old, new )
@@ -52,6 +56,10 @@ end
 -----------------------------------------------------------]]
 function AddChangeCallback( name, func, identifier )
 
+	if ( identifier ) then
+		assert( type( identifier ) == "string", format( "bad argument #%i (string expected, got %s)", 2, type( identifier ) ) )
+	end
+
 	local tab = GetConVarCallbacks( name, true )
 
 	if ( !identifier ) then
@@ -61,7 +69,7 @@ function AddChangeCallback( name, func, identifier )
 
 	for i = 1, #tab do
 		local callback = tab[ i ]
-		if ( type( callback ) == "table" and callback[ 2 ] == identifier ) then
+		if ( istable( callback ) and callback[ 2 ] == identifier ) then
 			callback[ 1 ] = func
 			return
 		end
@@ -77,10 +85,14 @@ end
 -----------------------------------------------------------]]
 function RemoveChangeCallback( name, identifier )
 
+	if ( identifier ) then
+		assert( type( identifier ) == "string", format( "bad argument #%i (string expected, got %s)", 2, type( identifier ) ) )
+	end
+
 	local tab = GetConVarCallbacks( name, true )
 	for i = 1, #tab do
 		local callback = tab[ i ]
-		if ( type( callback ) == "table" and callback[ 2 ] == identifier ) then
+		if ( istable( callback ) and callback[ 2 ] == identifier ) then
 			table.remove( tab, i )
 			break
 		end


### PR DESCRIPTION
I updated the outdated `cvars` library code, corrected the comments, replaced depricated functions with actual ones, and improved it by removing unnecessary checks.

I also formatted the entire code according to [CONTRIBUTING.md](https://github.com/Facepunch/garrysmod/blob/master/CONTRIBUTING.md)
All tabs were replaced by 4 spaces, function argument names were fixed, and a few small changes were made.