### PR TITLE
Fixed DGrid

### DIFF
--- a/garrysmod/lua/vgui/dgrid.lua
+++ b/garrysmod/lua/vgui/dgrid.lua
@@ -66,6 +66,8 @@ function PANEL:PerformLayout()
 
 	for k, panel in pairs( self.Items ) do
 
+		if ( !panel:IsVisible() ) then continue end
+
 		local x = ( i % self.m_iCols ) * self.m_iColWide
 		local y = math.floor( i / self.m_iCols ) * self.m_iRowHeight
 

--- a/garrysmod/lua/vgui/dgrid.lua
+++ b/garrysmod/lua/vgui/dgrid.lua
@@ -106,4 +106,13 @@ function PANEL:SortByMember( key, desc )
 
 end
 
+function PANEL:Clear()
+
+	for k, panel in ipairs( self:GetChildren() ) do
+		panel:Remove()
+	end
+	self.Items = {}
+
+end
+
 derma.DefineControl( "DGrid", "A really simple grid layout panel", PANEL, "Panel" )


### PR DESCRIPTION
1. Now `Panel:Clear()` works properly in DGrid.
2. Ignore invisible children in `DGrid:PerformLayout()` to avoid empty spaces.