### PR TITLE
Update texturize.lua

### DIFF
--- a/garrysmod/lua/postprocess/texturize.lua
+++ b/garrysmod/lua/postprocess/texturize.lua
@@ -45,7 +45,7 @@ list.Set( "PostProcess", "#texturize_pp", {
 		for k, textr in pairs( list.Get( "TexturizeMaterials" ) ) do
 
 			spawnmenu.CreateContentIcon( "postprocess", content, {
-				name = "#texturize_pp",
+				name = string.gsub(k, "^%a", string.upper(string.sub(k, 1, 1))),
 				icon = textr.Icon,
 				convars = {
 					pp_texturize = {


### PR DESCRIPTION
Make the texturize effect spawnmenu icons display the texture's name instead of them all being "Texturize"

Necessary for large collections of Post Processing screen space texture effects. 

Capitalizes them too to follow main UI style.
