### PR TITLE
Do not set ClassName in vgui.CreateFromTable

### DIFF
--- a/garrysmod/lua/includes/extensions/client/panel/scriptedpanels.lua
+++ b/garrysmod/lua/includes/extensions/client/panel/scriptedpanels.lua
@@ -59,7 +59,6 @@ function vgui.CreateFromTable( metatable, parent, name )
 
 	table.Merge( panel:GetTable(), metatable )
 	panel.BaseClass = PanelFactory[ metatable.Base ]
-	panel.ClassName = classname
 
 	-- Call the Init function if we have it
 	if ( panel.Init ) then


### PR DESCRIPTION
Panels created by this functions do not have their own class and are anonymous. The reference classname in the existing function does not exist and is nil.