### PR TITLE
Clamp DListView_Column resize to width restraints

### DIFF
--- a/garrysmod/lua/vgui/dlistview_column.lua
+++ b/garrysmod/lua/vgui/dlistview_column.lua
@@ -126,7 +126,8 @@ function PANEL:PerformLayout()
 end
 
 function PANEL:ResizeColumn( iSize )
-
+	iSize = math.Clamp( iSize, self:GetMinWidth(), self:GetMaxWidth() )
+	
 	self:GetParent():OnRequestResize( self, iSize )
 
 end


### PR DESCRIPTION
w/o this it'll resize neighboring columns when you've already hit the limit