### PR TITLE
Send the entity to send fewer bits than sending the class

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/cl_deathnotice.lua
+++ b/garrysmod/gamemodes/base/gamemode/cl_deathnotice.lua
@@ -49,13 +49,13 @@ end
 local function RecvPlayerKilledByPlayer()
 
 	local victim	= net.ReadEntity()
-	local inflictor	= net.ReadString()
+	local inflictor	= net.ReadEntity()
 	local attacker	= net.ReadEntity()
 
 	if ( !IsValid( attacker ) ) then return end
 	if ( !IsValid( victim ) ) then return end
 
-	GAMEMODE:AddDeathNotice( attacker:Name(), attacker:Team(), inflictor, victim:Name(), victim:Team() )
+	GAMEMODE:AddDeathNotice( attacker:Name(), attacker:Team(), inflictor:GetClass(), victim:Name(), victim:Team() )
 
 end
 net.Receive( "PlayerKilledByPlayer", RecvPlayerKilledByPlayer )
@@ -73,19 +73,20 @@ local function RecvPlayerKilled()
 
 	local victim	= net.ReadEntity()
 	if ( !IsValid( victim ) ) then return end
-	local inflictor	= net.ReadString()
-	local attacker	= "#" .. net.ReadString()
+	local inflictor	= net.ReadEntity()
+	local attacker	= net.ReadEntity()
 
-	GAMEMODE:AddDeathNotice( attacker, -1, inflictor, victim:Name(), victim:Team() )
+	GAMEMODE:AddDeathNotice( "#" .. attacker:GetClass(), -1, inflictor:GetClass(), victim:Name(), victim:Team() )
 
 end
 net.Receive( "PlayerKilled", RecvPlayerKilled )
 
 local function RecvPlayerKilledNPC()
 
-	local victimtype = net.ReadString()
+	local victimEntity = net.ReadEntity()
+	local victimtype = victimEntity:GetClass()
 	local victim	= "#" .. victimtype
-	local inflictor	= net.ReadString()
+	local inflictor	= net.ReadEntity()
 	local attacker	= net.ReadEntity()
 
 	--
@@ -93,7 +94,7 @@ local function RecvPlayerKilledNPC()
 	--
 	if ( !IsValid( attacker ) ) then return end
 
-	GAMEMODE:AddDeathNotice( attacker:Name(), attacker:Team(), inflictor, victim, -1 )
+	GAMEMODE:AddDeathNotice( attacker:Name(), attacker:Team(), inflictor:GetClass(), victim, -1 )
 
 	local bIsLocalPlayer = ( IsValid(attacker) && attacker == LocalPlayer() )
 
@@ -117,11 +118,13 @@ net.Receive( "PlayerKilledNPC", RecvPlayerKilledNPC )
 
 local function RecvNPCKilledNPC()
 
-	local victim	= "#" .. net.ReadString()
-	local inflictor	= net.ReadString()
-	local attacker	= "#" .. net.ReadString()
+	local victimEntity = net.ReadEntity()
+	local victim	= "#" .. victimEntity:GetClass()
+	local inflictor	= net.ReadEntity()
+	local attackerEntity = net.ReadEntity()
+	local attacker	= "#" .. attackerEntity:GetClass()
 
-	GAMEMODE:AddDeathNotice( attacker, -1, inflictor, victim, -1 )
+	GAMEMODE:AddDeathNotice( attacker, -1, inflictor:GetClass(), victim, -1 )
 
 end
 net.Receive( "NPCKilledNPC", RecvNPCKilledNPC )

--- a/garrysmod/gamemodes/base/gamemode/npc.lua
+++ b/garrysmod/gamemodes/base/gamemode/npc.lua
@@ -3,6 +3,8 @@
 util.AddNetworkString( "PlayerKilledNPC" )
 util.AddNetworkString( "NPCKilledNPC" )
 
+local worldspawn = Entity(0)
+
 --[[---------------------------------------------------------
    Name: gamemode:OnNPCKilled( entity, attacker, inflictor )
    Desc: The NPC has died
@@ -30,8 +32,8 @@ function GM:OnNPCKilled( ent, attacker, inflictor )
 	
 	end
 	
-	local InflictorClass = "worldspawn"
-	local AttackerClass = "worldspawn"
+	local InflictorClass = worldspawn
+	local AttackerClass = worldspawn
 	
 	if ( IsValid( inflictor ) ) then InflictorClass = inflictor:GetClass() end
 	if ( IsValid( attacker ) ) then
@@ -45,8 +47,8 @@ function GM:OnNPCKilled( ent, attacker, inflictor )
 
 			net.Start( "PlayerKilledNPC" )
 		
-				net.WriteString( ent:GetClass() )
-				net.WriteString( InflictorClass )
+				net.WriteEntity( ent )
+				net.WriteEntity( InflictorClass )
 				net.WriteEntity( attacker )
 		
 			net.Broadcast()
@@ -60,9 +62,9 @@ function GM:OnNPCKilled( ent, attacker, inflictor )
 
 	net.Start( "NPCKilledNPC" )
 	
-		net.WriteString( ent:GetClass() )
-		net.WriteString( InflictorClass )
-		net.WriteString( AttackerClass )
+		net.WriteEntity( ent )
+		net.WriteEntity( InflictorClass )
+		net.WriteEntity( AttackerClass )
 	
 	net.Broadcast()
 

--- a/garrysmod/gamemodes/base/gamemode/npc.lua
+++ b/garrysmod/gamemodes/base/gamemode/npc.lua
@@ -3,8 +3,6 @@
 util.AddNetworkString( "PlayerKilledNPC" )
 util.AddNetworkString( "NPCKilledNPC" )
 
-local worldspawn = Entity(0)
-
 --[[---------------------------------------------------------
    Name: gamemode:OnNPCKilled( entity, attacker, inflictor )
    Desc: The NPC has died
@@ -32,23 +30,24 @@ function GM:OnNPCKilled( ent, attacker, inflictor )
 	
 	end
 	
-	local InflictorClass = worldspawn
-	local AttackerClass = worldspawn
+	local world = game.GetWorld()
+	local InflictorEntity = world
+	local AttackerEntity = world
 	
-	if ( IsValid( inflictor ) ) then InflictorClass = inflictor:GetClass() end
+	if ( IsValid( inflictor ) ) then InflictorEntity = inflictor end
 	if ( IsValid( attacker ) ) then
 
-		AttackerClass = attacker:GetClass()
+		AttackerEntity = attacker
 
 		-- If there is no valid inflictor, use the attacker (i.e. manhacks)
-		if ( !IsValid( inflictor ) ) then InflictorClass = attacker:GetClass() end
+		if ( !IsValid( inflictor ) ) then InflictorEntity = attacker end
 
 		if ( attacker:IsPlayer() ) then
 
 			net.Start( "PlayerKilledNPC" )
 		
 				net.WriteEntity( ent )
-				net.WriteEntity( InflictorClass )
+				net.WriteEntity( InflictorEntity )
 				net.WriteEntity( attacker )
 		
 			net.Broadcast()
@@ -58,13 +57,13 @@ function GM:OnNPCKilled( ent, attacker, inflictor )
 
 	end
 
-	if ( ent:GetClass() == "npc_turret_floor" ) then AttackerClass = ent:GetClass() end
+	if ( ent:GetClass() == "npc_turret_floor" ) then AttackerEntity = ent end
 
 	net.Start( "NPCKilledNPC" )
 	
 		net.WriteEntity( ent )
-		net.WriteEntity( InflictorClass )
-		net.WriteEntity( AttackerClass )
+		net.WriteEntity( InflictorEntity )
+		net.WriteEntity( AttackerEntity )
 	
 	net.Broadcast()
 

--- a/garrysmod/gamemodes/base/gamemode/player.lua
+++ b/garrysmod/gamemodes/base/gamemode/player.lua
@@ -177,7 +177,7 @@ function GM:PlayerDeath( ply, inflictor, attacker )
 		net.Start( "PlayerKilledByPlayer" )
 
 			net.WriteEntity( ply )
-			net.WriteString( inflictor:GetClass() )
+			net.WriteEntity( inflictor )
 			net.WriteEntity( attacker )
 
 		net.Broadcast()
@@ -189,8 +189,8 @@ function GM:PlayerDeath( ply, inflictor, attacker )
 	net.Start( "PlayerKilled" )
 
 		net.WriteEntity( ply )
-		net.WriteString( inflictor:GetClass() )
-		net.WriteString( attacker:GetClass() )
+		net.WriteEntity( inflictor )
+		net.WriteEntity( attacker )
 
 	net.Broadcast()
 


### PR DESCRIPTION
Hi
I suggest sending an entity to send fewer bits than sending the class, which is the same as sending a string.
An entity corresponds to 13 bits whereas a string with two characters corresponds to a higher number of bits and we know that the class of an entity is not two characters long.