### PR TITLE
Add more robust error checking to weapons/scripted_ents.Register

### DIFF
--- a/garrysmod/lua/includes/modules/scripted_ents.lua
+++ b/garrysmod/lua/includes/modules/scripted_ents.lua
@@ -131,29 +131,29 @@ function Register( t, name, forcename )
 
 	end
 
-	if ( t.Spawnable != true ) then return true end
+	if ( t.Spawnable == true ) then
+		local printname = t.PrintName
+		if ( !isstring( printname ) ) then printname = name end
 
-	local printname = t.PrintName
-	if ( !isstring( printname ) ) then printname = name end
+		local category = t.Category
+		if ( !isstring( category ) ) then category = "Other" end
 
-	local category = t.Category
-	if ( !isstring( category ) ) then category = "Other" end
+		list.Set( "SpawnableEntities", name, {
+			-- Required information
+			ClassName		= name,
+			PrintName		= printname,
+			Category		= category,
 
-	list.Set( "SpawnableEntities", name, {
-		-- Required information
-		ClassName		= name,
-		PrintName		= printname,
-		Category		= category,
-
-		-- Optional information
-		NormalOffset	= t.NormalOffset,
-		DropToFloor		= t.DropToFloor,
-		Author			= t.Author,
-		AdminOnly		= t.AdminOnly,
-		Information		= t.Information,
-		ScriptedEntityType = t.ScriptedEntityType,
-		IconOverride	= t.IconOverride
-	} )
+			-- Optional information
+			NormalOffset	= t.NormalOffset,
+			DropToFloor		= t.DropToFloor,
+			Author			= t.Author,
+			AdminOnly		= t.AdminOnly,
+			Information		= t.Information,
+			ScriptedEntityType = t.ScriptedEntityType,
+			IconOverride	= t.IconOverride
+		} )
+	end
 
 	return true
 

--- a/garrysmod/lua/includes/modules/weapons.lua
+++ b/garrysmod/lua/includes/modules/weapons.lua
@@ -61,6 +61,7 @@ function Register( t, name, forcename )
 	end
 
 	if ( !forcename && isstring( t.ClassName ) ) then name = t.ClassName end
+	t.ClassName = name
 
 	local old = WeaponList[ name ]
 	WeaponList[ name ] = t


### PR DESCRIPTION
Fixes https://github.com/Facepunch/garrysmod-issues/issues/5495 - unlike SWEPs, SENTs do not set a ClassName variable. While SWEPs really shouldn't either to prevent the same multi-registration issue, addons and [even base code](https://github.com/Facepunch/garrysmod/blob/3d0d965168a9e58ad669f90667f02bee13048cb0/garrysmod/gamemodes/sandbox/gamemode/commands.lua#L860-L863) relies on this key to be set on the data table. While the entire initial SWEP table could be copied, I don't want to break addons that may rely on that ClassName being set on their passed table (yet).

Also added a bunch of type checks to provide more premature errors in case the SENT/SWEP sets something invalid before its creation.

A third optional bool argument (defaulting to false) "forcename" has been added to both Register functions which allows the caller to ignore ClassName overrides.

Additionally, the ai and nextbot SENT bases were added to the default base table.

Lastly, X.Register now returns true if the registration was successful and false if the PreRegisterX hook blocked it.