### PR TITLE
Prevent indexing IsValid from a number or boolean value

### DIFF
--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -224,6 +224,7 @@ end
 function IsValid( object )
 
 	if ( !object ) then return false end
+	if ( isnumber(object) || isbool(object) ) then return false end
 
 	local isvalid = object.IsValid
 	if ( !isvalid ) then return false end


### PR DESCRIPTION
Here's an example of some hook code I recently had to use for a public addon for a DarkRP compatibility:
```lua
hook.Add("canDropPocketItem", "RRB:Home:canDropPocketItem", function(ply, item)
    if not IsValid(ply) or not IsValid(item) then return end
    -- ...
end)
```

However, this code seems to generate an error when "item" is a number (which can happen with DarkRP). Since there are no types in GLua, I can never be sure which value I'm going to check, and it would be a pain to constantly have to add checks to make sure it's an indexable type variable.

After analyzing the code, it soon becomes clear that this is due to the function trying to retrieve the IsValid function from the passed object. My patch therefore proposes to return false if a number or boolean is passed, rather than generating an error that stops execution.