### PR TITLE
Updates/Option to inherit bodygroups from player->hands in player_manager

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/player.lua
+++ b/garrysmod/gamemodes/base/gamemode/player.lua
@@ -293,7 +293,7 @@ function GM:PlayerSetHandsModel( pl, ent )
 	if ( info ) then
 		ent:SetModel( info.model )
 		ent:SetSkin( info.matchBodySkin and pl:GetSkin() or info.skin )
-		ent:SetBodyGroups( info.body )
+		ent:SetBodyGroups( info.matchBodyGroups and player_manager.GetBodyGroupsAsStr( pl ) or info.body )
 	end
 
 end

--- a/garrysmod/gamemodes/terrortown/gamemode/player.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player.lua
@@ -95,13 +95,13 @@ function GM:PlayerSpawn(ply)
 end
 
 function GM:PlayerSetHandsModel( pl, ent )
-   local simplemodel = player_manager.TranslateToPlayerModelName(pl:GetModel())
-   local info = player_manager.TranslatePlayerHands(simplemodel)
-   if info then
-      ent:SetModel(info.model)
-      ent:SetSkin(info.skin)
-      ent:SetBodyGroups(info.body)
-   end
+   local simplemodel = player_manager.TranslateToPlayerModelName( pl:GetModel() )
+	local info = player_manager.TranslatePlayerHands( simplemodel )
+	if info then
+		ent:SetModel( info.model )
+		ent:SetSkin( info.matchBodySkin and pl:GetSkin() or info.skin )
+		ent:SetBodyGroups( info.matchBodyGroups and player_manager.GetBodyGroupsAsStr( pl ) or info.body )
+	end
 end
 
 function GM:IsSpawnpointSuitable(ply, spwn, force, rigged)

--- a/garrysmod/gamemodes/terrortown/gamemode/player.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player.lua
@@ -96,12 +96,12 @@ end
 
 function GM:PlayerSetHandsModel( pl, ent )
    local simplemodel = player_manager.TranslateToPlayerModelName( pl:GetModel() )
-	local info = player_manager.TranslatePlayerHands( simplemodel )
-	if info then
-		ent:SetModel( info.model )
-		ent:SetSkin( info.matchBodySkin and pl:GetSkin() or info.skin )
-		ent:SetBodyGroups( info.matchBodyGroups and player_manager.GetBodyGroupsAsStr( pl ) or info.body )
-	end
+   local info = player_manager.TranslatePlayerHands( simplemodel )
+   if info then
+      ent:SetModel( info.model )
+      ent:SetSkin( info.matchBodySkin and pl:GetSkin() or info.skin )
+      ent:SetBodyGroups( info.matchBodyGroups and player_manager.GetBodyGroupsAsStr( pl ) or info.body )
+   end
 end
 
 function GM:IsSpawnpointSuitable(ply, spwn, force, rigged)

--- a/garrysmod/lua/includes/modules/player_manager.lua
+++ b/garrysmod/lua/includes/modules/player_manager.lua
@@ -24,12 +24,28 @@ function AddValidModel( name, model )
 
 end
 
+
+
+--[[---------------------------------------------------------
+	Helper function as GetBodyGroups is a table
+-----------------------------------------------------------]]
+function GetBodyGroupsAsStr( ply )
+    local bg = ply:GetBodyGroups()
+
+    local t1 = {}
+    for _, v in ipairs(bg) do 
+        table.insert(t1, v.num)
+    end
+
+    return table.concat(t1)
+end
+
 --
 -- Valid hands
 --
-function AddValidHands( name, model, skin, body, matchBodySkin )
+function AddValidHands( name, model, skin, body, matchBodySkin, matchBodyGroups )
 
-	HandNames[ name ] = { model = model, skin = skin or 0, body = body or "0000000", matchBodySkin = matchBodySkin or false }
+	HandNames[ name ] = { model = model, skin = skin or 0, body = body or "0000000", matchBodySkin = matchBodySkin or false, matchBodyGroups = matchBodyGroups or false }
 
 end
 
@@ -40,6 +56,9 @@ function AllValidModels( )
 	return ModelList
 end
 
+function AllHandNames( )
+	return HandNames
+end
 
 --[[---------------------------------------------------------
 	Translate the simple name of a model


### PR DESCRIPTION
- Adds player_manager.AllHandNames accessor for local hand names table
- Adds player_manager.GetBodyGroupsAsStr ( as GetBodyGroups returns a table and we need a string! ) 
- Adds matchBodyGroups support to player_manager.AddValidHands - just like matchBodySkin (default false)
- Updates GM:PlayerSetHandsModel for gamemodes base/terrortown to include inheriting bodygroups