### PR TITLE
Reply function in net.Receive

### DIFF
--- a/garrysmod/lua/includes/extensions/net.lua
+++ b/garrysmod/lua/includes/extensions/net.lua
@@ -27,9 +27,26 @@ function net.Incoming( len, client )
 
 	if ( !strName ) then return end
 
-	local func = net.Receivers[ strName:lower() ]
+	strName = strName:lower()
+	local func = net.Receivers[ strName ]
 	if ( !func ) then return end
 
+	local g = table.Copy(_G)
+
+	g["Reply"] = function(...)
+		local args = {...}
+
+		net.Start(strName)
+
+		if #args > 0 then
+			net.WriteType(args)
+		end
+
+		net[CLIENT and "SendToServer" or "Send"](client)
+	end
+
+	setfenv(func, g)
+	
 	--
 	-- len includes the 16 bit int which told us the message name
 	--


### PR DESCRIPTION
Example:
```lua.
if SERVER then
	util.AddNetworkString("network_string")

	net.Start("test1")
	net.Send(Entity(1))

	net.Receive("network_string", function(l, p)
		local args = net.ReadType()
		print("Print args")
		PrintTable(args)
	end)
else
	net.Receive("network_string", function(l, p)
                <your code there>
		Reply("MyArg1", {"MyArg2_1"}, 33^2)
	end)
end
```

My idea is good, but the implementation itself is so far-so bad.

[*] I would replace table.Copy(_G) with something else, but I have no idea what. You can't cache _G either, because table.Copy(_G) will be immutable at the moment of script activation, i.e. if a player adds a global function/variable, he won't be able to use it in net.Receive. So table.Copy(_G) is the only option for now.

[*] Also using net.*Type is a bad idea, and it should be replaced with something more optimized.

I hope someone will see my idea and continue it.