### PR TITLE
Replace timer.Destroy (deprecated) with timer.Remove

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/save_load.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/save_load.lua
@@ -66,7 +66,7 @@ if ( SERVER ) then
 			timer.Create( "LoadGModSave_WaitForPlayer", 0.1, 0, function()
 				if ( !IsValid( Entity( 1 ) ) ) then return end
 
-				timer.Destroy( "LoadGModSave_WaitForPlayer" )
+				timer.Remove( "LoadGModSave_WaitForPlayer" )
 				LoadGModSave( savedata )
 			end )
 


### PR DESCRIPTION
timer.Destroy is deprecated, so timer.Remove should be used instead.