### PR TITLE
Add VSH to getmaps.lua

### DIFF
--- a/garrysmod/lua/menu/getmaps.lua
+++ b/garrysmod/lua/menu/getmaps.lua
@@ -146,6 +146,7 @@ local function UpdateMaps()
 	MapNames[ "tr_" ] = "Team Fortress 2"
 	MapNames[ "trade_" ] = "Team Fortress 2"
 	MapNames[ "pass_" ] = "Team Fortress 2"
+	MapNames[ "vsh_" ] = "Team Fortress 2"
 
 	MapNames[ "zpa_" ] = "Zombie Panic! Source"
 	MapNames[ "zpl_" ] = "Zombie Panic! Source"


### PR DESCRIPTION
Versus Saxton Hale is now an official Team Fortress 2 gamemode; as such, this pull request reclassifies the (like, 4) new VSH maps to correctly be in the Team Fortress 2 section.