### PR TITLE
Fix Malformed CSS Comments

### DIFF
--- a/garrysmod/html/css/creations/Creations.css
+++ b/garrysmod/html/css/creations/Creations.css
@@ -110,7 +110,7 @@ DIV.gridicon
 	width: 300px;
 	float: left;
 	margin: 3px;
-	//border-radius: 2px;
+	/*border-radius: 2px;*/
 	background-position:center; 
 }
 

--- a/garrysmod/html/css/menu/Menu.css
+++ b/garrysmod/html/css/menu/Menu.css
@@ -145,7 +145,7 @@ DIV.gridicon
 	width: 300px;
 	float: left;
 	margin: 3px;
-	//border-radius: 2px;
+	/*border-radius: 2px;*/
 	background-position:center;
 }
 


### PR DESCRIPTION
The correct syntax for CSS comments is `/* */`, as specified by the [W3C CSS2.1 specification](https://www.w3.org/TR/CSS21/syndata.html#comments). This is consistent with the commenting style used in other CSS files.