### PR TITLE
Make TTT notification sound default off and add a setting for it.

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_help.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_help.lua
@@ -102,6 +102,8 @@ function HELPSCRN:Show()
    cb:SetTooltip(GetTranslation("set_wswitch_tip"))
 
    cb = dgui:CheckBox(GetTranslation("set_cues"), "ttt_cl_soundcues")
+   
+   cb = dgui:CheckBox(GetTranslation("set_msg_cue"), "ttt_cl_msg_soundcue")
 
    dsettings:AddItem(dgui)
 

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_msgstack.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_msgstack.lua
@@ -64,7 +64,7 @@ function MSTACK:AddColoredBgMessage(text, bg_clr)
    self:AddMessageEx(item)
 end
 
-local ttt_msg_soundcue = CreateClientConVar("ttt_cl_msg_soundcue", "1", true)
+local ttt_msg_soundcue = CreateClientConVar("ttt_cl_msg_soundcue", "0", true)
 
 -- Internal
 function MSTACK:AddMessageEx(item)

--- a/garrysmod/gamemodes/terrortown/gamemode/lang/english.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/lang/english.lua
@@ -257,6 +257,7 @@ L.set_fastswmenu_tip  = "When fast weapons switch is enabled, the menu switcher 
 L.set_wswitch         = "Disable weapon switch menu auto-closing"
 L.set_wswitch_tip     = "By default the weapon switcher automatically closes a few seconds after you last scroll. Enable this to make it stay up."
 L.set_cues            = "Play sound cue when a round begins or ends"
+L.set_msg_cue         = "Play sound cue when a notification appears"
 
 
 L.set_title_play    = "Gameplay settings"


### PR DESCRIPTION
This partially reverts part of a pervious PR. That for some reason defaulted on an annoying notification sound that has not existed in 12 to 13 years. It also did not provide a setting to disable it a side from a convar.

This PR defaults it off and adds an F1 setting.