### PR TITLE
Fix Zombine spawn

### DIFF
--- a/garrysmod/lua/autorun/base_npcs.lua
+++ b/garrysmod/lua/autorun/base_npcs.lua
@@ -228,7 +228,7 @@ AddNPC( {
 	KeyValues = { SquadName = "zombies" }
 } )
 
-if ( IsMounted( "episodic" ) or IsMounted( "ep2" )) then
+if ( IsMounted( "episodic" ) or IsMounted( "ep2" ) ) then
 	AddNPC( {
 		Name = "Zombine",
 		Class = "npc_zombine",

--- a/garrysmod/lua/autorun/base_npcs.lua
+++ b/garrysmod/lua/autorun/base_npcs.lua
@@ -228,7 +228,7 @@ AddNPC( {
 	KeyValues = { SquadName = "zombies" }
 } )
 
-if ( IsMounted( "episodic" ) ) then
+if ( IsMounted( "episodic" ) or IsMounted( "ep2" )) then
 	AddNPC( {
 		Name = "Zombine",
 		Class = "npc_zombine",


### PR DESCRIPTION
fixes an issue where if ep2 is mounted but ep1 isnt, zombines wont spawn, despite working with just ep2