### PR TITLE
Change deprecated MousePos function

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/cl_targetid.lua
+++ b/garrysmod/gamemodes/base/gamemode/cl_targetid.lua
@@ -23,7 +23,7 @@ function GM:HUDDrawTargetID()
 	surface.SetFont( font )
 	local w, h = surface.GetTextSize( text )
 	
-	local MouseX, MouseY = gui.MousePos()
+	local MouseX, MouseY = input.GetCursorPos()
 	
 	if ( MouseX == 0 && MouseY == 0 ) then
 	

--- a/garrysmod/gamemodes/sandbox/gamemode/editor_player.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/editor_player.lua
@@ -262,7 +262,7 @@ list.Set( "DesktopWindows", "PlayerEditor", {
 		-- Hold to rotate
 
 		function mdl:DragMousePress()
-			self.PressX, self.PressY = gui.MousePos()
+			self.PressX, self.PressY = input.GetCursorPos()
 			self.Pressed = true
 		end
 
@@ -272,10 +272,10 @@ list.Set( "DesktopWindows", "PlayerEditor", {
 			if ( self.bAnimated ) then self:RunAnimation() end
 
 			if ( self.Pressed ) then
-				local mx = gui.MousePos()
+				local mx = input.GetCursorPos()
 				self.Angles = self.Angles - Angle( 0, ( ( self.PressX or mx ) - mx ) / 2, 0 )
 
-				self.PressX, self.PressY = gui.MousePos()
+				self.PressX, self.PressY = input.GetCursorPos()
 			end
 
 			ent:SetAngles( self.Angles )

--- a/garrysmod/gamemodes/sandbox/gamemode/editor_player.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/editor_player.lua
@@ -272,10 +272,10 @@ list.Set( "DesktopWindows", "PlayerEditor", {
 			if ( self.bAnimated ) then self:RunAnimation() end
 
 			if ( self.Pressed ) then
-				local mx = input.GetCursorPos()
+				local mx, my = input.GetCursorPos()
 				self.Angles = self.Angles - Angle( 0, ( ( self.PressX or mx ) - mx ) / 2, 0 )
 
-				self.PressX, self.PressY = input.GetCursorPos()
+				self.PressX, self.PressY = mx, my
 			end
 
 			ent:SetAngles( self.Angles )

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/contextmenu.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/contextmenu.lua
@@ -152,10 +152,10 @@ function CreateContextMenu()
 	-- so feed clicks to the proper functions..
 	--
 	g_ContextMenu.OnMousePressed = function( p, code )
-		hook.Run( "GUIMousePressed", code, gui.ScreenToVector( gui.MousePos() ) )
+		hook.Run( "GUIMousePressed", code, gui.ScreenToVector( input.GetCursorPos() ) )
 	end
 	g_ContextMenu.OnMouseReleased = function( p, code )
-		hook.Run( "GUIMouseReleased", code, gui.ScreenToVector( gui.MousePos() ) )
+		hook.Run( "GUIMouseReleased", code, gui.ScreenToVector( input.GetCursorPos() ) )
 	end
 
 	hook.Run( "ContextMenuCreated", g_ContextMenu )

--- a/garrysmod/lua/includes/extensions/util/worldpicker.lua
+++ b/garrysmod/lua/includes/extensions/util/worldpicker.lua
@@ -41,7 +41,7 @@ hook.Add( "VGUIMousePressAllowed", "WorldPickerMouseDisable", function( code )
 
 	if ( !bDoing ) then return false end
 
-	local dir = gui.ScreenToVector( gui.MousePos() )
+	local dir = gui.ScreenToVector( input.GetCursorPos() )
 	local tr = util.TraceLine( {
 		start = LocalPlayer():GetShootPos(),
 		endpos = LocalPlayer():GetShootPos() + dir * 32768,

--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -425,7 +425,7 @@ if ( CLIENT ) then
 
 	function RememberCursorPosition()
 
-		local x, y = gui.MousePos()
+		local x, y = input.GetCursorPos()
 
 		-- If the cursor isn't visible it will return 0,0 ignore it.
 		if ( x == 0 && y == 0 ) then return end

--- a/garrysmod/lua/menu/motionsensor.lua
+++ b/garrysmod/lua/menu/motionsensor.lua
@@ -33,7 +33,7 @@ local function DrawColorBox()
 	-- fade the box down if we get close, so we can click on stuff that's under it.
 	--
 	if ( vgui.CursorVisible() ) then
-		local mx, my = gui.MousePos()
+		local mx, my = input.GetCursorPos()
 		local dist = Vector( mx, my, 0 ):Distance( Vector( x + w *0.5, y + h * 0.5, 0 ) )
 		alpha = math.Clamp( alpha - ( 512 - dist ), 10, 255 )
 	end

--- a/garrysmod/lua/postprocess/super_dof.lua
+++ b/garrysmod/lua/postprocess/super_dof.lua
@@ -282,7 +282,7 @@ function RenderSuperDoF( ViewOrigin, ViewAngles, ViewFOV )
 
 	if ( FocusGrabber ) then
 
-		local x, y = gui.MousePos()
+		local x, y = input.GetCursorPos()
 		local dir = util.AimVector( ViewAngles, ViewFOV, x, y, ScrW(), ScrH() )
 
 		local tr = util.TraceLine( util.GetPlayerTrace( LocalPlayer(), dir ) )


### PR DESCRIPTION
This switches the deprecated gui.MousePos function to input.GetCursorPos