### PR TITLE
Reduce player __index calls in animations

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/animations.lua
+++ b/garrysmod/gamemodes/base/gamemode/animations.lua
@@ -1,47 +1,47 @@
 
-function GM:HandlePlayerJumping( ply, velocity )
+function GM:HandlePlayerJumping( ply, velocity, plyTable )
 
 	if ( ply:GetMoveType() == MOVETYPE_NOCLIP ) then
-		ply.m_bJumping = false
+		plyTable.m_bJumping = false
 		return
 	end
 
 	-- airwalk more like hl2mp, we airwalk until we have 0 velocity, then it's the jump animation
 	-- underwater we're alright we airwalking
-	if ( !ply.m_bJumping && !ply:OnGround() && ply:WaterLevel() <= 0 ) then
+	if ( !plyTable.m_bJumping && !ply:OnGround() && ply:WaterLevel() <= 0 ) then
 
-		if ( !ply.m_fGroundTime ) then
+		if ( !plyTable.m_fGroundTime ) then
 
-			ply.m_fGroundTime = CurTime()
+			plyTable.m_fGroundTime = CurTime()
 
-		elseif ( CurTime() - ply.m_fGroundTime ) > 0 && velocity:Length2DSqr() < 0.25 then
+		elseif ( CurTime() - plyTable.m_fGroundTime ) > 0 && velocity:Length2DSqr() < 0.25 then
 
-			ply.m_bJumping = true
-			ply.m_bFirstJumpFrame = false
-			ply.m_flJumpStartTime = 0
+			plyTable.m_bJumping = true
+			plyTable.m_bFirstJumpFrame = false
+			plyTable.m_flJumpStartTime = 0
 
 		end
 	end
 
-	if ply.m_bJumping then
+	if plyTable.m_bJumping then
 
-		if ply.m_bFirstJumpFrame then
+		if plyTable.m_bFirstJumpFrame then
 
-			ply.m_bFirstJumpFrame = false
+			plyTable.m_bFirstJumpFrame = false
 			ply:AnimRestartMainSequence()
 
 		end
 
-		if ( ply:WaterLevel() >= 2 ) || ( ( CurTime() - ply.m_flJumpStartTime ) > 0.2 && ply:OnGround() ) then
+		if ( ply:WaterLevel() >= 2 ) || ( ( CurTime() - plyTable.m_flJumpStartTime ) > 0.2 && ply:OnGround() ) then
 
-			ply.m_bJumping = false
-			ply.m_fGroundTime = nil
+			plyTable.m_bJumping = false
+			plyTable.m_fGroundTime = nil
 			ply:AnimRestartMainSequence()
 
 		end
 
-		if ply.m_bJumping then
-			ply.CalcIdeal = ACT_MP_JUMP
+		if plyTable.m_bJumping then
+			plyTable.CalcIdeal = ACT_MP_JUMP
 			return true
 		end
 	end
@@ -50,27 +50,27 @@ function GM:HandlePlayerJumping( ply, velocity )
 
 end
 
-function GM:HandlePlayerDucking( ply, velocity )
+function GM:HandlePlayerDucking( ply, velocity, plyTable )
 
 	if ( !ply:IsFlagSet( FL_ANIMDUCKING ) ) then return false end
 
 	if ( velocity:Length2DSqr() > 0.25 ) then
-		ply.CalcIdeal = ACT_MP_CROUCHWALK
+		plyTable.CalcIdeal = ACT_MP_CROUCHWALK
 	else
-		ply.CalcIdeal = ACT_MP_CROUCH_IDLE
+		plyTable.CalcIdeal = ACT_MP_CROUCH_IDLE
 	end
 
 	return true
 
 end
 
-function GM:HandlePlayerNoClipping( ply, velocity )
+function GM:HandlePlayerNoClipping( ply, velocity, plyTable )
 
 	if ( ply:GetMoveType() != MOVETYPE_NOCLIP || ply:InVehicle() ) then
 
-		if ( ply.m_bWasNoclipping ) then
+		if ( plyTable.m_bWasNoclipping ) then
 
-			ply.m_bWasNoclipping = nil
+			plyTable.m_bWasNoclipping = nil
 			ply:AnimResetGestureSlot( GESTURE_SLOT_CUSTOM )
 			if ( CLIENT ) then ply:SetIK( true ) end
 
@@ -80,7 +80,7 @@ function GM:HandlePlayerNoClipping( ply, velocity )
 
 	end
 
-	if ( !ply.m_bWasNoclipping ) then
+	if ( !plyTable.m_bWasNoclipping ) then
 
 		ply:AnimRestartGesture( GESTURE_SLOT_CUSTOM, ACT_GMOD_NOCLIP_LAYER, false )
 		if ( CLIENT ) then ply:SetIK( false ) end
@@ -91,26 +91,26 @@ function GM:HandlePlayerNoClipping( ply, velocity )
 
 end
 
-function GM:HandlePlayerVaulting( ply, velocity )
+function GM:HandlePlayerVaulting( ply, velocity, plyTable )
 
 	if ( velocity:LengthSqr() < 1000000 ) then return end
 	if ( ply:IsOnGround() ) then return end
 
-	ply.CalcIdeal = ACT_MP_SWIM
+	plyTable.CalcIdeal = ACT_MP_SWIM
 
 	return true
 
 end
 
-function GM:HandlePlayerSwimming( ply, velocity )
+function GM:HandlePlayerSwimming( ply, velocity, plyTable )
 
 	if ( ply:WaterLevel() < 2 || ply:IsOnGround() ) then
-		ply.m_bInSwim = false
+		plyTable.m_bInSwim = false
 		return false
 	end
 
-	ply.CalcIdeal = ACT_MP_SWIM
-	ply.m_bInSwim = true
+	plyTable.CalcIdeal = ACT_MP_SWIM
+	plyTable.m_bInSwim = true
 
 	return true
 
@@ -126,7 +126,7 @@ function GM:HandlePlayerLanding( ply, velocity, WasOnGround )
 
 end
 
-function GM:HandlePlayerDriving( ply )
+function GM:HandlePlayerDriving( ply, plyTable )
 
 	-- The player must have a parent to be in a vehicle. If there's no parent, we are in the exit anim, so don't do sitting in 3rd person anymore
 	if ( !ply:InVehicle() || !IsValid( ply:GetParent() ) ) then return false end
@@ -146,32 +146,32 @@ function GM:HandlePlayerDriving( ply )
 	if ( isfunction( pVehicle.HandleAnimation ) ) then
 		local seq = pVehicle:HandleAnimation( ply )
 		if ( seq != nil ) then
-			ply.CalcSeqOverride = seq
+			plyTable.CalcSeqOverride = seq
 		end
 	end
 
-	if ( ply.CalcSeqOverride == -1 ) then -- pVehicle.HandleAnimation did not give us an animation
+	if ( plyTable.CalcSeqOverride == -1 ) then -- pVehicle.HandleAnimation did not give us an animation
 		local class = pVehicle:GetClass()
 		if ( class == "prop_vehicle_jeep" ) then
-			ply.CalcSeqOverride = ply:LookupSequence( "drive_jeep" )
+			plyTable.CalcSeqOverride = ply:LookupSequence( "drive_jeep" )
 		elseif ( class == "prop_vehicle_airboat" ) then
-			ply.CalcSeqOverride = ply:LookupSequence( "drive_airboat" )
+			plyTable.CalcSeqOverride = ply:LookupSequence( "drive_airboat" )
 		elseif ( class == "prop_vehicle_prisoner_pod" && pVehicle:GetModel() == "models/vehicles/prisoner_pod_inner.mdl" ) then
 			-- HACK!!
-			ply.CalcSeqOverride = ply:LookupSequence( "drive_pd" )
+			plyTable.CalcSeqOverride = ply:LookupSequence( "drive_pd" )
 		else
-			ply.CalcSeqOverride = ply:LookupSequence( "sit_rollercoaster" )
+			plyTable.CalcSeqOverride = ply:LookupSequence( "sit_rollercoaster" )
 		end
 	end
 
-	local use_anims = ( ply.CalcSeqOverride == ply:LookupSequence( "sit_rollercoaster" ) || ply.CalcSeqOverride == ply:LookupSequence( "sit" ) )
+	local use_anims = ( plyTable.CalcSeqOverride == ply:LookupSequence( "sit_rollercoaster" ) || plyTable.CalcSeqOverride == ply:LookupSequence( "sit" ) )
 	if ( use_anims && ply:GetAllowWeaponsInVehicle() && IsValid( ply:GetActiveWeapon() ) ) then
 		local holdtype = ply:GetActiveWeapon():GetHoldType()
 		if ( holdtype == "smg" ) then holdtype = "smg1" end
 
 		local seqid = ply:LookupSequence( "sit_" .. holdtype )
 		if ( seqid != -1 ) then
-			ply.CalcSeqOverride = seqid
+			plyTable.CalcSeqOverride = seqid
 		end
 	end
 
@@ -222,7 +222,8 @@ function GM:UpdateAnimation( ply, velocity, maxseqgroundspeed )
 			ply:SetPoseParameter( "vehicle_steer", steer )
 
 		end
-		GAMEMODE:GrabEarAnimation( ply )
+		local plyTable = ply:GetTable()
+		GAMEMODE:GrabEarAnimation( ply, plyTable )
 		GAMEMODE:MouthMoveAnimation( ply )
 	end
 
@@ -232,23 +233,23 @@ end
 -- If you don't want the player to grab his ear in your gamemode then
 -- just override this.
 --
-function GM:GrabEarAnimation( ply )
+function GM:GrabEarAnimation( ply, plyTable )
 
-	ply.ChatGestureWeight = ply.ChatGestureWeight || 0
+	plyTable.ChatGestureWeight = plyTable.ChatGestureWeight || 0
 
 	-- Don't show this when we're playing a taunt!
 	if ( ply:IsPlayingTaunt() ) then return end
 
 	if ( ply:IsTyping() ) then
-		ply.ChatGestureWeight = math.Approach( ply.ChatGestureWeight, 1, FrameTime() * 5.0 )
+		plyTable.ChatGestureWeight = math.Approach( plyTable.ChatGestureWeight, 1, FrameTime() * 5.0 )
 	else
-		ply.ChatGestureWeight = math.Approach( ply.ChatGestureWeight, 0, FrameTime() * 5.0 )
+		plyTable.ChatGestureWeight = math.Approach( plyTable.ChatGestureWeight, 0, FrameTime() * 5.0 )
 	end
 
-	if ( ply.ChatGestureWeight > 0 ) then
+	if ( plyTable.ChatGestureWeight > 0 ) then
 
 		ply:AnimRestartGesture( GESTURE_SLOT_VCD, ACT_GMOD_IN_CHAT, true )
-		ply:AnimSetGestureWeight( GESTURE_SLOT_VCD, ply.ChatGestureWeight )
+		ply:AnimSetGestureWeight( GESTURE_SLOT_VCD, plyTable.ChatGestureWeight )
 
 	end
 
@@ -278,28 +279,28 @@ function GM:MouthMoveAnimation( ply )
 end
 
 function GM:CalcMainActivity( ply, velocity )
+	local plyTable = ply:GetTable()
+	plyTable.CalcIdeal = ACT_MP_STAND_IDLE
+	plyTable.CalcSeqOverride = -1
 
-	ply.CalcIdeal = ACT_MP_STAND_IDLE
-	ply.CalcSeqOverride = -1
+	self:HandlePlayerLanding( ply, velocity, plyTable.m_bWasOnGround )
 
-	self:HandlePlayerLanding( ply, velocity, ply.m_bWasOnGround )
-
-	if !( self:HandlePlayerNoClipping( ply, velocity ) ||
-		self:HandlePlayerDriving( ply ) ||
-		self:HandlePlayerVaulting( ply, velocity ) ||
-		self:HandlePlayerJumping( ply, velocity ) ||
-		self:HandlePlayerSwimming( ply, velocity ) ||
-		self:HandlePlayerDucking( ply, velocity ) ) then
+	if !( self:HandlePlayerNoClipping( ply, velocity, plyTable ) ||
+		self:HandlePlayerDriving( ply, plyTable ) ||
+		self:HandlePlayerVaulting( ply, velocity, plyTable ) ||
+		self:HandlePlayerJumping( ply, velocity, plyTable ) ||
+		self:HandlePlayerSwimming( ply, velocity, plyTable ) ||
+		self:HandlePlayerDucking( ply, velocity, plyTable ) ) then
 
 		local len2d = velocity:Length2DSqr()
-		if ( len2d > 22500 ) then ply.CalcIdeal = ACT_MP_RUN elseif ( len2d > 0.25 ) then ply.CalcIdeal = ACT_MP_WALK end
+		if ( len2d > 22500 ) then plyTable.CalcIdeal = ACT_MP_RUN elseif ( len2d > 0.25 ) then plyTable.CalcIdeal = ACT_MP_WALK end
 
 	end
 
-	ply.m_bWasOnGround = ply:IsOnGround()
-	ply.m_bWasNoclipping = ( ply:GetMoveType() == MOVETYPE_NOCLIP && !ply:InVehicle() )
+	plyTable.m_bWasOnGround = ply:IsOnGround()
+	plyTable.m_bWasNoclipping = ( ply:GetMoveType() == MOVETYPE_NOCLIP && !ply:InVehicle() )
 
-	return ply.CalcIdeal, ply.CalcSeqOverride
+	return plyTable.CalcIdeal, plyTable.CalcSeqOverride
 
 end
 

--- a/garrysmod/gamemodes/base/gamemode/animations.lua
+++ b/garrysmod/gamemodes/base/gamemode/animations.lua
@@ -1,8 +1,7 @@
 
 function GM:HandlePlayerJumping( ply, velocity, plyTable )
-	if !plyTable then
-		plyTable = ply:GetTable()
-	end
+
+	if ( !plyTable ) then plyTable = ply:GetTable() end
 
 	if ( ply:GetMoveType() == MOVETYPE_NOCLIP ) then
 		plyTable.m_bJumping = false
@@ -17,7 +16,7 @@ function GM:HandlePlayerJumping( ply, velocity, plyTable )
 
 			plyTable.m_fGroundTime = CurTime()
 
-		elseif ( CurTime() - plyTable.m_fGroundTime ) > 0 && velocity:Length2DSqr() < 0.25 then
+		elseif ( ( CurTime() - plyTable.m_fGroundTime ) > 0 && velocity:Length2DSqr() < 0.25 ) then
 
 			plyTable.m_bJumping = true
 			plyTable.m_bFirstJumpFrame = false
@@ -26,16 +25,16 @@ function GM:HandlePlayerJumping( ply, velocity, plyTable )
 		end
 	end
 
-	if plyTable.m_bJumping then
+	if ( plyTable.m_bJumping ) then
 
-		if plyTable.m_bFirstJumpFrame then
+		if ( plyTable.m_bFirstJumpFrame ) then
 
 			plyTable.m_bFirstJumpFrame = false
 			ply:AnimRestartMainSequence()
 
 		end
 
-		if ( ply:WaterLevel() >= 2 ) || ( ( CurTime() - plyTable.m_flJumpStartTime ) > 0.2 && ply:OnGround() ) then
+		if ( ( ply:WaterLevel() >= 2 ) || ( ( CurTime() - plyTable.m_flJumpStartTime ) > 0.2 && ply:OnGround() ) ) then
 
 			plyTable.m_bJumping = false
 			plyTable.m_fGroundTime = nil
@@ -43,7 +42,7 @@ function GM:HandlePlayerJumping( ply, velocity, plyTable )
 
 		end
 
-		if plyTable.m_bJumping then
+		if ( plyTable.m_bJumping ) then
 			plyTable.CalcIdeal = ACT_MP_JUMP
 			return true
 		end
@@ -54,9 +53,8 @@ function GM:HandlePlayerJumping( ply, velocity, plyTable )
 end
 
 function GM:HandlePlayerDucking( ply, velocity, plyTable )
-	if !plyTable then
-		plyTable = ply:GetTable()
-	end
+
+	if ( !plyTable ) then plyTable = ply:GetTable() end
 
 	if ( !ply:IsFlagSet( FL_ANIMDUCKING ) ) then return false end
 
@@ -71,9 +69,8 @@ function GM:HandlePlayerDucking( ply, velocity, plyTable )
 end
 
 function GM:HandlePlayerNoClipping( ply, velocity, plyTable )
-	if !plyTable then
-		plyTable = ply:GetTable()
-	end
+
+	if ( !plyTable ) then plyTable = ply:GetTable() end
 
 	if ( ply:GetMoveType() != MOVETYPE_NOCLIP || ply:InVehicle() ) then
 
@@ -101,9 +98,8 @@ function GM:HandlePlayerNoClipping( ply, velocity, plyTable )
 end
 
 function GM:HandlePlayerVaulting( ply, velocity, plyTable )
-	if !plyTable then
-		plyTable = ply:GetTable()
-	end
+
+	if ( !plyTable ) then plyTable = ply:GetTable() end
 
 	if ( velocity:LengthSqr() < 1000000 ) then return end
 	if ( ply:IsOnGround() ) then return end
@@ -115,9 +111,8 @@ function GM:HandlePlayerVaulting( ply, velocity, plyTable )
 end
 
 function GM:HandlePlayerSwimming( ply, velocity, plyTable )
-	if !plyTable then
-		plyTable = ply:GetTable()
-	end
+
+	if ( !plyTable ) then plyTable = ply:GetTable() end
 
 	if ( ply:WaterLevel() < 2 || ply:IsOnGround() ) then
 		plyTable.m_bInSwim = false
@@ -142,9 +137,8 @@ function GM:HandlePlayerLanding( ply, velocity, WasOnGround )
 end
 
 function GM:HandlePlayerDriving( ply, plyTable )
-	if !plyTable then
-		plyTable = ply:GetTable()
-	end
+
+	if ( !plyTable ) then plyTable = ply:GetTable() end
 
 	-- The player must have a parent to be in a vehicle. If there's no parent, we are in the exit anim, so don't do sitting in 3rd person anymore
 	if ( !ply:InVehicle() || !IsValid( ply:GetParent() ) ) then return false end
@@ -194,6 +188,7 @@ function GM:HandlePlayerDriving( ply, plyTable )
 	end
 
 	return true
+
 end
 
 --[[---------------------------------------------------------
@@ -240,8 +235,8 @@ function GM:UpdateAnimation( ply, velocity, maxseqgroundspeed )
 			ply:SetPoseParameter( "vehicle_steer", steer )
 
 		end
-		local plyTable = ply:GetTable()
-		GAMEMODE:GrabEarAnimation( ply, plyTable )
+
+		GAMEMODE:GrabEarAnimation( ply )
 		GAMEMODE:MouthMoveAnimation( ply )
 	end
 
@@ -252,9 +247,8 @@ end
 -- just override this.
 --
 function GM:GrabEarAnimation( ply, plyTable )
-	if !plyTable then
-		plyTable = ply:GetTable()
-	end
+
+	if ( !plyTable ) then plyTable = ply:GetTable() end
 
 	plyTable.ChatGestureWeight = plyTable.ChatGestureWeight || 0
 
@@ -300,6 +294,7 @@ function GM:MouthMoveAnimation( ply )
 end
 
 function GM:CalcMainActivity( ply, velocity )
+
 	local plyTable = ply:GetTable()
 	plyTable.CalcIdeal = ACT_MP_STAND_IDLE
 	plyTable.CalcSeqOverride = -1

--- a/garrysmod/gamemodes/base/gamemode/animations.lua
+++ b/garrysmod/gamemodes/base/gamemode/animations.lua
@@ -1,5 +1,8 @@
 
 function GM:HandlePlayerJumping( ply, velocity, plyTable )
+	if !plyTable then
+		plyTable = ply:GetTable()
+	end
 
 	if ( ply:GetMoveType() == MOVETYPE_NOCLIP ) then
 		plyTable.m_bJumping = false
@@ -51,6 +54,9 @@ function GM:HandlePlayerJumping( ply, velocity, plyTable )
 end
 
 function GM:HandlePlayerDucking( ply, velocity, plyTable )
+	if !plyTable then
+		plyTable = ply:GetTable()
+	end
 
 	if ( !ply:IsFlagSet( FL_ANIMDUCKING ) ) then return false end
 
@@ -65,6 +71,9 @@ function GM:HandlePlayerDucking( ply, velocity, plyTable )
 end
 
 function GM:HandlePlayerNoClipping( ply, velocity, plyTable )
+	if !plyTable then
+		plyTable = ply:GetTable()
+	end
 
 	if ( ply:GetMoveType() != MOVETYPE_NOCLIP || ply:InVehicle() ) then
 
@@ -92,6 +101,9 @@ function GM:HandlePlayerNoClipping( ply, velocity, plyTable )
 end
 
 function GM:HandlePlayerVaulting( ply, velocity, plyTable )
+	if !plyTable then
+		plyTable = ply:GetTable()
+	end
 
 	if ( velocity:LengthSqr() < 1000000 ) then return end
 	if ( ply:IsOnGround() ) then return end
@@ -103,6 +115,9 @@ function GM:HandlePlayerVaulting( ply, velocity, plyTable )
 end
 
 function GM:HandlePlayerSwimming( ply, velocity, plyTable )
+	if !plyTable then
+		plyTable = ply:GetTable()
+	end
 
 	if ( ply:WaterLevel() < 2 || ply:IsOnGround() ) then
 		plyTable.m_bInSwim = false
@@ -127,6 +142,9 @@ function GM:HandlePlayerLanding( ply, velocity, WasOnGround )
 end
 
 function GM:HandlePlayerDriving( ply, plyTable )
+	if !plyTable then
+		plyTable = ply:GetTable()
+	end
 
 	-- The player must have a parent to be in a vehicle. If there's no parent, we are in the exit anim, so don't do sitting in 3rd person anymore
 	if ( !ply:InVehicle() || !IsValid( ply:GetParent() ) ) then return false end
@@ -234,6 +252,9 @@ end
 -- just override this.
 --
 function GM:GrabEarAnimation( ply, plyTable )
+	if !plyTable then
+		plyTable = ply:GetTable()
+	end
 
 	plyTable.ChatGestureWeight = plyTable.ChatGestureWeight || 0
 


### PR DESCRIPTION
Calling ply. is quite expensive, however indexing the player:GetTable() is much much cheaper.

Example of a server with 64 bots, using fprofiler serverside:
![image](https://github.com/Facepunch/garrysmod/assets/69946827/427fd8d5-5894-4639-912f-26300ecc3387)
![image](https://github.com/Facepunch/garrysmod/assets/69946827/50db0382-fef1-4069-93ad-af9275a6c878)

I instantly noticed a significant performance increase going from ~40sv to ~60sv