### PR TITLE
terrortown: use `IsValid()` to check `wep.AmmoEnt` in `DropActiveAmmo()`

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
@@ -248,7 +248,7 @@ local function DropActiveAmmo(ply)
    local wep = ply:GetActiveWeapon()
    if not IsValid(wep) then return end
 
-   if not wep.AmmoEnt then return end
+   if not IsValid(wep.AmmoEnt) then return end
 
    local amt = wep:Clip1()
    if amt < 1 or amt <= (wep.Primary.ClipSize * 0.25) then


### PR DESCRIPTION
While most of the TTT code uses the global `IsValid()` to check validity of entities, a less accurate `if not wep.AmmoEnt` check is currently used in `weaponry.lua`.

Changing this check to use `IsValid()` produces more accurate results and prevents issues when porting other SWEP bases to TTT.