### PR TITLE
Update Fistful of Frags map categories

### DIFF
--- a/garrysmod/lua/menu/getmaps.lua
+++ b/garrysmod/lua/menu/getmaps.lua
@@ -155,6 +155,7 @@ local function UpdateMaps()
 	MapNames[ "zph_" ] = "Zombie Panic! Source"
 
 	MapNames[ "fof_" ] = "Fistful of Frags"
+	MapNames[ "fofhr_" ] = "Fistful of Frags"
 	MapNames[ "cm_" ] = "Fistful of Frags"
 	MapNames[ "gt_" ] = "Fistful of Frags"
 	MapNames[ "tp_" ] = "Fistful of Frags"


### PR DESCRIPTION
This now makes the "other" tab once again empty with Fistful of Frags installed by adding the `fofhr_` map category, just like my previous update to the Team Fortress 2 map categories when Versus Saxton Hale was officially added.