### PR TITLE
Significantly improve the performance of SortedPairs

### DIFF
--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -532,21 +532,41 @@ local function toKeyValues( tbl )
 
 end
 
+local function getGeys( tbl )
+
+	local keys = {}
+
+	for k in pairs( tbl ) do
+		table.insert( keys, k )
+	end
+
+	return keys
+
+end
+
 --[[---------------------------------------------------------
 	A Pairs function
 		Sorted by TABLE KEY
 -----------------------------------------------------------]]
 function SortedPairs( pTable, Desc )
 
-	local sortedTbl = toKeyValues( pTable )
+	local keys = getGeys( pTable )
 
-	if ( Desc ) then
-		table.sort( sortedTbl, function( a, b ) return a.key > b.key end )
+	if Desc then
+		table.sort( keys, function( a, b )
+			return a > b
+		end )
 	else
-		table.sort( sortedTbl, function( a, b ) return a.key < b.key end )
+		table.sort( keys, function( a, b )
+			return a < b
+		end )
 	end
 
-	return keyValuePairs, { Index = 0, KeyValues = sortedTbl }
+	local i, key
+	return function()
+		i, key = next( keys, i )
+		return key, pTable[key]
+	end
 
 end
 


### PR DESCRIPTION
## 📜 Description
This `SortedPairs` refactor improves the performance of the function by between 185-240% _(*on a table with 5,000 entries)_ based on my testing.

This does technically introduce a regression (see the Considerations section).

## ✊ Motivation
I noticed the existing `SortedPairs` implementation has a lot of table indexing, which adds a bit of performance overhead.

I took a stab at refactoring it to improve the performance and was impressed by how much faster it was.

## 🤓 Explanation
Say we have the following table:
```lua
local tbl = {
    f   =  6,
    i   =  2,
    kpz = 10,
    mb  =  5,
    nzg =  3,
    tn  =  9,
    u   =  4,
    wqg =  8,
    x   =  7,
    zbd =  1
}
```

The original `SortedPairs` would first convert it into a table like:
```lua
{
    [ 1] = { key = "zbd", val = 1 },
    [ 2] = { key = "i", val = 2 },
    [ 3] = { key = "nzg", val = 3 },
    [ 4] = { key = "u", val = 4 },
    [ 5] = { key = "mb", val = 5 },
    [ 6] = { key = "f", val = 6 },
    [ 7] = { key = "x", val = 7 },
    [ 8] = { key = "wqg", val = 8 },
    [ 9] = { key = "tn", val = 9 },
    [10] = { key = "kpz", val = 10 },
}

```

And then use a sorting function like:
```lua
table.sort( sortedTbl, function( a, b ) return a.key > b.key end )
```

Which means that for each step of the sorting process, we're accessing two `.key`s.

But if we're just sorting the keys... why not just sort the keys?

Instead, this refactor simply pulls the keys out into a flat table and sorts them with a standard `table.sort`:
```lua
table.sort( sortedTbl, function( a, b )
    return a > b
end )
```

Then, `SortedPairs` returns an iterator function that loops through the sorted keys in order and returns the appropriate value from the original table:
```lua
local i, key
return function()
    i, key = next( keys, i )
    return key, pTable[key]
end
```

This simplifies the actual sorting functions. It also skips the logic inside of the local [`keyValuePairs`](https://github.com/Facepunch/garrysmod/blob/2616ebd0c77e8138d03e9c52e87543e229abf7d3/garrysmod/lua/includes/extensions/table.lua#L512-L521) function, apparently leading to a significant performance improvement.

## ⚠️ Considerations
The second return value of `SortedPairs` has been removed.

Previously, it was:
```lua
return keyValuePairs, { Index = 0, KeyValues = sortedTbl }
```

Now we only return the first parameter, an iterator function.

I think that in 99% of use cases, this is fine. I searched through a few hundred popular addons and searched through GitHub, and found only one instance of a nonstandard use of SortedPairs, over in [Jazztronauts](https://github.com/Foohy/jazztronauts/blob/master/gamemodes/jazztronauts/gamemode/missions/converse.lua#L71-L74):
```lua
local function first(tbl, cond)
	local func, tbl = SortedPairs(tbl)
	return func(tbl), cond
end
```

This code **still works** _(tested)_ with the proposed refactor. Calling the returned iterator (regardless of parameters) will still return the first sorted `key, value` pair.

However, that being said, **this refactor still introduces a regression in functionality**.

Anything relying on the second return value existing in the format of:
```lua
{
    Index = 0,
    KeyValues = {
        { key = "key", val = 1 },
        ...
    }
}
```

will break after this change.

Fixing this regression would mean having to create the same return table, which eats about 30% of the performance gains that this refactor achieves.

I understand that merging breaking changes is a no-no, but I figured I'd propose the change as a draft and start a discussion about possible ways forward.

If this is truly unacceptable, I'm fine with:
- Making it a new function (`QuickSortedPairs`?)
- Adding some clever, low-cost solution to retain the original functionality
- Closing the PR and making this an optional performance addon

Let me know what you think :)