### PR TITLE
Fix error when using sent_ball on non-singleplayer server

### DIFF
--- a/garrysmod/lua/entities/sent_ball.lua
+++ b/garrysmod/lua/entities/sent_ball.lua
@@ -141,7 +141,7 @@ end
 
 function ENT:Use( activator, caller )
 
-	if SERVER and activator:IsPlayer() then
+	if ( SERVER && activator:IsPlayer() ) then
 
 		self:Remove()
 

--- a/garrysmod/lua/entities/sent_ball.lua
+++ b/garrysmod/lua/entities/sent_ball.lua
@@ -141,9 +141,9 @@ end
 
 function ENT:Use( activator, caller )
 
-	self:Remove()
+	if ( activator:IsPlayer() ) and ( ( game.SinglePlayer() and CLIENT ) or SERVER ) then
 
-	if ( activator:IsPlayer() ) then
+		self:Remove()
 
 		-- Give the collecting player some free health
 		local health = activator:Health()

--- a/garrysmod/lua/entities/sent_ball.lua
+++ b/garrysmod/lua/entities/sent_ball.lua
@@ -141,7 +141,7 @@ end
 
 function ENT:Use( activator, caller )
 
-	if ( activator:IsPlayer() ) and ( ( game.SinglePlayer() and CLIENT ) or SERVER ) then
+	if SERVER and activator:IsPlayer() then
 
 		self:Remove()
 


### PR DESCRIPTION
Fixes `Trying to remove server entity sent_ball#335 on client!`
