### PR TITLE
Update Team Fortress 2 map categories

### DIFF
--- a/garrysmod/lua/menu/getmaps.lua
+++ b/garrysmod/lua/menu/getmaps.lua
@@ -147,6 +147,7 @@ local function UpdateMaps()
 	MapNames[ "trade_" ] = "Team Fortress 2"
 	MapNames[ "pass_" ] = "Team Fortress 2"
 	MapNames[ "vsh_" ] = "Team Fortress 2"
+	MapNames[ "zi_" ] = "Team Fortress 2"
 
 	MapNames[ "zpa_" ] = "Zombie Panic! Source"
 	MapNames[ "zpl_" ] = "Zombie Panic! Source"


### PR DESCRIPTION
The Scream Fortress update came along, and with it a new map category, `zi_`. This commit makes the "other" category empty again by adding it, like my [previous](https://github.com/Facepunch/garrysmod/pull/2013) [two](https://github.com/Facepunch/garrysmod/pull/1996) similar pull requests.