### PR TITLE
Add OnPlayerRequestRespawn hook

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/player.lua
+++ b/garrysmod/gamemodes/base/gamemode/player.lua
@@ -98,6 +98,8 @@ function GM:PlayerDeathThink( pl )
 
 	if ( pl:IsBot() || pl:KeyPressed( IN_ATTACK ) || pl:KeyPressed( IN_ATTACK2 ) || pl:KeyPressed( IN_JUMP ) ) then
 
+		hook.Run( "OnPlayerRequestRespawn ", pl )
+
 		pl:Spawn()
 
 	end


### PR DESCRIPTION
If a player presses a button, to respawn the base gamemode currently just calls spawn.
This way there was no way of actually detecting this kind of spawn.

I added a simple hook, that is called before Spawning the player, to allow programmers, to have behavior depending on a "normal respawn"

I feel like people could use such a hook in general, so I'm writing a pull request.