### PR TITLE
Clear DOF_Ents on DOF_Kill

### DIFF
--- a/garrysmod/lua/postprocess/dof.lua
+++ b/garrysmod/lua/postprocess/dof.lua
@@ -13,11 +13,15 @@ local NUM_DOF_NODES = 16
 
 function DOF_Kill()
 
-	for k, v in pairs( DOF_Ents ) do
+	for i = #DOF_Ents, 1, -1 do
+
+		local v = DOF_Ents[i]
 
 		if ( IsValid( v ) ) then
 			v:Remove()
 		end
+
+		DOF_Ents[i] = nil
 
 	end
 


### PR DESCRIPTION
### Summary
`DOF_Kill` doesn't actually clean up the `DOF_Ents` table, meaning the table could expand indefinitely.

With this change, the `DOF_Ents` table is efficiently emptied whenever `DOF_Kill` is called.

### Demo
```lua
local ed = EffectData()

print( "Initial count:", #DOF_Ents )

util.Effect( "dof_node", ed )
print( "First Created:", #DOF_Ents )

DOF_Kill()
print( "After normal DOF_Kill(): ", #DOF_Ents )

util.Effect( "dof_node", ed )
print( "Second Created: ", #DOF_Ents )

_DOF_Kill()
print( "After modified DOF_Kill(): ", #DOF_Ents )
```

Outputs:
```
Initial count:	0
First Created:	1
After normal DOF_Kill(): 	1
Second Created: 	2
After modified DOF_Kill(): 	0
```