### PR TITLE
Polyfill table.move for 32-bit Gmod

### DIFF
--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -752,3 +752,30 @@ function table.Flip( tab )
 	return res
 
 end
+
+-- Polyfill for table.move on 32-bit
+-- Don't forget to remove this when it's no longer necessary
+if ( !table.move ) then
+	function table.move( sourceTbl, from, to, dest, destTbl )
+
+		if ( !istable( sourceTbl ) ) then error( "bad argument #1 to 'move' (table expected, got " .. type( sourceTbl ) .. ")" ) end
+		if ( !isnumber( from ) ) then error( "bad argument #2 to 'move' (number expected, got " .. type( from ) .. ")" ) end
+		if ( !isnumber( to ) ) then error( "bad argument #3 to 'move' (number expected, got " .. type( to ) .. ")" ) end
+		if ( !isnumber( dest ) ) then error( "bad argument #4 to 'move' (number expected, got " .. type( dest ) .. ")" ) end
+		if ( destTbl != nil ) then
+			if ( !istable( destTbl ) ) then error( "bad argument #5 to 'move' (table expected, got " .. type( destTbl ) .. ")" ) end
+		else
+			destTbl = sourceTbl
+		end
+
+		local buffer = { unpack( sourceTbl, from, to ) }
+
+		dest = math.floor( dest - 1 )
+		for i, v in ipairs( buffer ) do
+			destTbl[ dest + i ] = v
+		end
+
+		return destTbl
+
+	end
+end


### PR DESCRIPTION
Implements [`table.move`](https://wiki.facepunch.com/gmod/table.move) for 32-bit Gmod as accurately as possible, including errors, to preserve forward-compatibility. This solution is, naturally, not completely optimal.

Comment out the if statement and rename the function to compare outputs.

```lua
PrintTable( table.move( { 1, 2, 3, 4 }, 1, 4, -4 ) )
--[[ Outputs:
-4	=	1
-3	=	2
-2	=	3
-1	=	4
1	=	1
2	=	2
3	=	3
4	=	4
]]
```

Additionally, the documentation on the wiki is incorrect. The 4th argument, `dest`, is required (you can test this yourself).