### PR TITLE
Add PreRegisterTOOL hook

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stool.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stool.lua
@@ -155,7 +155,7 @@ for _, val in ipairs( file.Find( SWEP.Folder .. "/stools/*.lua", "LUA" ) ) do
 
 	TOOL:CreateConVars()
 
-	if ( hook.Run( "PreRegisterTOOL", t, name ) != false ) then
+	if ( hook.Run( "PreRegisterTOOL", TOOL, toolmode ) != false ) then
 		SWEP.Tool[ toolmode ] = TOOL
 	end
 

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stool.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stool.lua
@@ -155,7 +155,9 @@ for _, val in ipairs( file.Find( SWEP.Folder .. "/stools/*.lua", "LUA" ) ) do
 
 	TOOL:CreateConVars()
 
-	SWEP.Tool[ toolmode ] = TOOL
+	if ( hook.Run( "PreRegisterTOOL", t, name ) != false ) then
+		SWEP.Tool[ toolmode ] = TOOL
+	end
 
 	TOOL = nil
 


### PR DESCRIPTION
Considering https://wiki.facepunch.com/gmod/GM:PreRegisterSENT and https://wiki.facepunch.com/gmod/GM:PreRegisterSWEP both exist, i figured PreRegisterTOOL should exist too.

It'd help with preventing some tools from loading / modifying tools.