### PR TITLE
TTT: Prevent tttbase Lua errors with NPCs

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -314,8 +314,7 @@ function SWEP:ShootBullet( dmg, recoil, numbul, cone )
    self:GetOwner():FireBullets( bullet )
 
    -- Owner can die after firebullets
-   if self:GetOwner():IsNPC() then return end
-   if (not IsValid(self:GetOwner())) or (not self:GetOwner():Alive()) then return end
+   if (not IsValid(self:GetOwner())) or self:GetOwner():IsNPC() or (not self:GetOwner():Alive()) then return end
 
    if ((game.SinglePlayer() and SERVER) or
        ((not game.SinglePlayer()) and CLIENT and IsFirstTimePredicted())) then

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -314,7 +314,8 @@ function SWEP:ShootBullet( dmg, recoil, numbul, cone )
    self:GetOwner():FireBullets( bullet )
 
    -- Owner can die after firebullets
-   if (not IsValid(self:GetOwner())) or (not self:GetOwner():Alive()) or self:GetOwner():IsNPC() then return end
+   if self:GetOwner():IsNPC() then return end
+   if (not IsValid(self:GetOwner())) or (not self:GetOwner():Alive()) then return end
 
    if ((game.SinglePlayer() and SERVER) or
        ((not game.SinglePlayer()) and CLIENT and IsFirstTimePredicted())) then


### PR DESCRIPTION
NPCs create Lua errors when shooting tttbase weapons by calling self:GetOwner():Alive().

Return early if an NPC to prevent calling Alive().