### PR TITLE
Bug Fix: Infinite loop on string.Comma when second parameter is numerical.

### DIFF
--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -358,8 +358,8 @@ function string.Comma( number, str )
 
 	if ( str ~= nil and !isstring( str ) ) then
 		error( "bad argument #2 to 'string.Comma' (string expected, got " .. type( str ) .. ")" )
-	elseif ( str ~= nil and isnumber( str ) ) then
-		error( "bad argument #2 to 'string.Comma' (Non-numerical value expected, got " .. str .. " )" )
+	elseif ( string.match(str, "%d") ~= nil ) then
+		error( "bad argument #2 to 'string.Comma' (Non-numerical values expected, got " .. str .. " )" )
 	end
 
 	local replace = str == nil and "%1,%2" or "%1" .. str .. "%2"

--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -355,8 +355,7 @@ function string.ToColor( str )
 end
 
 function string.Comma( number, str )
-
-	local replace = str == nil and "%1,%2" or "%1" .. str .. "%2"
+	local replace = ( str == nil or isnumber( str ) ) and "%1,%2" or "%1" .. str .. "%2"
 
 	if ( isnumber( number ) ) then
 		number = string.format( "%f", number )

--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -356,7 +356,11 @@ end
 
 function string.Comma( number, str )
 
-	local replace = ( str == nil or isnumber( str ) ) and "%1,%2" or "%1" .. str .. "%2"
+	if ( isnumber( str ) ) then
+		error( "bad argument #2 to 'string.Comma' (Non-numerical value expected, got " .. str .. " )" )
+	end
+
+	local replace = str == nil and "%1,%2" or "%1" .. str .. "%2"
 
 	if ( isnumber( number ) ) then
 		number = string.format( "%f", number )

--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -358,7 +358,7 @@ function string.Comma( number, str )
 
 	if ( str ~= nil and !isstring( str ) ) then
 		error( "bad argument #2 to 'string.Comma' (string expected, got " .. type( str ) .. ")" )
-	elseif ( string.match(str, "%d") ~= nil ) then
+	elseif ( str ~= nil and string.match(str, "%d") ~= nil ) then
 		error( "bad argument #2 to 'string.Comma' (Non-numerical values expected, got " .. str .. " )" )
 	end
 

--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -356,10 +356,10 @@ end
 
 function string.Comma( number, str )
 
-	if ( str ~= nil and !isstring( str ) ) then
+	if ( str ~= nil and not isstring( str ) ) then
 		error( "bad argument #2 to 'string.Comma' (string expected, got " .. type( str ) .. ")" )
-	elseif ( str ~= nil and string.match(str, "%d") ~= nil ) then
-		error( "bad argument #2 to 'string.Comma' (Non-numerical values expected, got " .. str .. " )" )
+	elseif ( str ~= nil and string.match( str, "%d" ) ~= nil ) then
+		error( "bad argument #2 to 'string.Comma' (non-numerical values expected, got " .. str .. ")" )
 	end
 
 	local replace = str == nil and "%1,%2" or "%1" .. str .. "%2"

--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -355,6 +355,7 @@ function string.ToColor( str )
 end
 
 function string.Comma( number, str )
+
 	local replace = ( str == nil or isnumber( str ) ) and "%1,%2" or "%1" .. str .. "%2"
 
 	if ( isnumber( number ) ) then

--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -356,7 +356,9 @@ end
 
 function string.Comma( number, str )
 
-	if ( isnumber( str ) ) then
+	if ( str ~= nil and !isstring( str ) ) then
+		error( "bad argument #2 to 'string.Comma' (string expected, got " .. type( str ) .. ")" )
+	elseif ( str ~= nil and isnumber( str ) ) then
 		error( "bad argument #2 to 'string.Comma' (Non-numerical value expected, got " .. str .. " )" )
 	end
 


### PR DESCRIPTION
# Description
When string.Comma is called with a number as the second parameter, the function enters an infinite loop.

**Current behaviour:** Gets stuck in an infinite loop. Effectively crashing the game.
**Suggested Behaviour:** Default behaviour ("," is inserted)

## Changes
- Default behaviour is exhibited when the second parameter is a number.

# Testing
Testable on https://www.lua.org/cgi-bin/demo , paste the code, hit run.
- isnumber is stubbed to return true for the purpose of the test on the demo.

## Original
```lua
-- Stub isnumber to return true.
function isnumber(val)
	return true
end

function string.Comma( number, str )

	local replace = str == nil and "%1,%2" or "%1" .. str .. "%2"

	if ( isnumber( number ) ) then
		number = string.format( "%f", number )
		number = string.match( number, "^(.-)%.?0*$" ) -- Remove trailing zeros
	end

	local index = -1
	
	-- keep track of iteration count
	local loopCount = 1
	
	while index ~= 0 do 
		number, index = string.gsub( number, "^(-?%d+)(%d%d%d)", replace ) 

		-- break out of loop after 30 iterations, no point infinitely looping.
		 loopCount = loopCount + 1
		 if loopCount > 30 then
			 break
		 end
	end

	return number

end

print(string.Comma(23432))     -- Output: 23,432
print(string.Comma(23432, "2"))  -- Output: 23222222222222222222222222222222432
```

## New
```lua
-- Stub isstring and isnumber to return true.
function isnumber(val)
        return true
end

function isstring(val)
        return true
end
 
function string.Comma( number, str )

	if ( str ~= nil and not isstring( str ) ) then
		error( "bad argument #2 to 'string.Comma' (string expected, got " .. type( str ) .. ")" )
	elseif ( str ~= nil and string.match(str, "%d") ~= nil ) then
		error( "bad argument #2 to 'string.Comma' (Non-numerical values expected, got " .. str .. " )" )
	end

	local replace = str == nil and "%1,%2" or "%1" .. str .. "%2"

	if ( isnumber( number ) ) then
		number = string.format( "%f", number )
		number = string.match( number, "^(.-)%.?0*$" ) -- Remove trailing zeros
	end

	local index = -1
	while index ~= 0 do number, index = string.gsub( number, "^(-?%d+)(%d%d%d)", replace ) end

	return number

end

print(string.Comma(23432))     -- Output: 23,432
print(string.Comma(23432, "2"))  -- bad argument #2 to 'string.Comma' (Non-numerical values expected, got 22
```