### PR TITLE
Fix GetHighestKey not choosing anything if values are all 0

### DIFF
--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -535,7 +535,7 @@ function GetHighestKey( obj )
 
 	for ( k in obj )
 	{
-		if ( obj[k] > h )
+		if ( h == 0 || obj[k] > h )
 		{
 			h = obj[k];
 			v = k;


### PR DESCRIPTION
Fixes totally empty gamemodes not using *any* description, instead falling back to internal folder name.

Before:
![image](https://github.com/Facepunch/garrysmod/assets/2799393/c5e224fd-1391-46b3-b5eb-1d37182fb499)

After:
![image](https://github.com/Facepunch/garrysmod/assets/2799393/a552ca87-95cf-4d6e-8d37-7fd5a8a4a1fb)