### PR TITLE
Add chainstodoor to Door @BaseClass in base.fgd

### DIFF
--- a/bin/base.fgd
+++ b/bin/base.fgd
@@ -1,4 +1,4 @@
-//====== Copyright © 1996-2005, Valve Corporation, All rights reserved. =======
+//====== Copyright Â© 1996-2005, Valve Corporation, All rights reserved. =======
 //
 // Purpose: General game definition file (.fgd)
 //
@@ -3669,6 +3669,7 @@
 
 @BaseClass base(Targetname, Parentname, RenderFields, Global, Shadow, GMODSandbox) = Door
 [
+	chainstodoor(target_destination) : "Linked Door" : : "(Optional) Passes the door's +use inputs and touch events onto a different door, so it also is activated."
 	speed(integer) : "Speed" : 100 : "The speed at which the door moves."
 	master(string) : "Master (Obsolete)" : : "Legacy support: The name of a master entity. If the master hasn't been activated, this button cannot be used."
 	noise1(sound) : "Start Sound" : : "Sound to play when the door starts moving."


### PR DESCRIPTION
This has caught me out about 10 times now and I'm sick of it.

We should probably actually go through ALL of the entities with "[Non-FGD Features](https://developer.valvesoftware.com/w/index.php?title=Special:WhatLinksHere/Non-FGD_features&limit=500)" (aka shit missing from the FGDs), check if the functionality works in GMod, and add them to GMod's FGDs if so, but I don't have time to do that right now.

Hammer reflecting what's actually possible at all times instead of mappers doing stupid I/O hacks to replicate functionality that already exists, would be ideal.