### PR TITLE
Improve SortedPairs even more

### DIFF
--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -536,10 +536,11 @@ end
 
 local function getKeys( tbl )
 
-	local keys = {}
+	local keys, i = {}, 0
 
 	for k in pairs( tbl ) do
-		keys[ #keys + 1 ] = k
+		i = i + 1
+		keys[ i ] = k
 	end
 
 	return keys

--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -539,7 +539,7 @@ local function getKeys( tbl )
 	local keys = {}
 
 	for k in pairs( tbl ) do
-		table.insert( keys, k )
+		keys[ #keys + 1 ] = k
 	end
 
 	return keys
@@ -564,10 +564,10 @@ function SortedPairs( pTable, Desc )
 		end )
 	end
 
-	local i, key
+	local i, key = 1
 	return function()
-		i, key = next( keys, i )
-		return key, pTable[key]
+		key, i = keys[ i ], i + 1
+		return key, pTable[ key ]
 	end
 
 end


### PR DESCRIPTION
PR #2015 is good, but we can make it much better.

Improvements:

- `table.insert( tbl, val )` > `tbl[ #tbl + 1 ] = val`
- `next( keys, i )` > `keys [ i ]`

benchmarks:

- brandonsturgeon's version is 11.23% better than default
- my version is 36% better than default
- or 27.92% better than brandonsturgeon's

bench src: https://gist.github.com/Be1zebub/4b90791fc7ab2d89a18c7a93da143095
<details>
	<summary>bench results:</summary>
	<img src="https://github.com/Facepunch/garrysmod/assets/34854689/b75f6cbe-1cf0-4c54-b193-0682ae14977e">
</details>

benchmarks have been tested on a default branch, in p2p server.