### PR TITLE
made ammo types reflect game.GetAmmoTypes

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_stungun.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_stungun.lua
@@ -33,7 +33,7 @@ SWEP.Primary.ClipSize      = 30
 SWEP.Primary.ClipMax       = 60
 SWEP.Primary.DefaultClip   = 30
 SWEP.Primary.Automatic     = true
-SWEP.Primary.Ammo          = "smg1"
+SWEP.Primary.Ammo          = "SMG1"
 SWEP.Primary.Recoil        = 1.2
 SWEP.Primary.Sound         = Sound( "Weapon_UMP45.Single" )
 

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_mac10.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_mac10.lua
@@ -25,7 +25,7 @@ SWEP.Primary.ClipSize    = 30
 SWEP.Primary.ClipMax     = 60
 SWEP.Primary.DefaultClip = 30
 SWEP.Primary.Automatic   = true
-SWEP.Primary.Ammo        = "smg1"
+SWEP.Primary.Ammo        = "SMG1"
 SWEP.Primary.Recoil      = 1.15
 SWEP.Primary.Sound       = Sound( "Weapon_mac10.Single" )
 


### PR DESCRIPTION
to the benefit of anyone reading the ammo type and trying to pair it up to things without running string.lower/upper across the board.