### PR TITLE
player_manager.GetPlayerClassTable(Player ply)

### DIFF
--- a/garrysmod/lua/includes/modules/player_manager.lua
+++ b/garrysmod/lua/includes/modules/player_manager.lua
@@ -404,7 +404,7 @@ function GetPlayerClassTable( ply )
 	local ct = Type[ util.NetworkIDToString( id ) ]
 	if ( !ct ) then return end
 	
-	return table.Copy(t)
+	return table.Copy(ct)
 
 end
 

--- a/garrysmod/lua/includes/modules/player_manager.lua
+++ b/garrysmod/lua/includes/modules/player_manager.lua
@@ -401,7 +401,10 @@ function GetPlayerClassTable( ply )
 	local id = ply:GetClassID()
 	if ( id == 0 ) then return end
 
-	return table.Copy( Type )[ util.NetworkIDToString( id ) ]
+	local ct = Type[ util.NetworkIDToString( id ) ]
+	if ( !ct ) then return end
+	
+	return table.Copy(t)
 
 end
 

--- a/garrysmod/lua/includes/modules/player_manager.lua
+++ b/garrysmod/lua/includes/modules/player_manager.lua
@@ -396,6 +396,15 @@ function GetPlayerClass( ply )
 
 end
 
+function GetPlayerClassTable( ply )
+
+	local id = ply:GetClassID()
+	if ( id == 0 ) then return end
+
+	return table.Copy( Type )[ util.NetworkIDToString( id ) ]
+
+end
+
 function ClearPlayerClass( ply )
 
 	ply:SetClassID( 0 )

--- a/garrysmod/lua/includes/modules/player_manager.lua
+++ b/garrysmod/lua/includes/modules/player_manager.lua
@@ -404,7 +404,7 @@ function GetPlayerClassTable( ply )
 	local ct = Type[ util.NetworkIDToString( id ) ]
 	if ( !ct ) then return end
 	
-	return table.Copy(ct)
+	return table.Copy( ct )
 
 end
 


### PR DESCRIPTION
This is a method to access **player class definition tables** more quickly.

Instead of doing this:
```lua
player_manager.GetPlayerClasses()[ player_manager.GetPlayerClass( ply ) ]
```
We can do this:
```lua
player_manager.GetPlayerClassTable( ply )
```

When I access the class table, **I still create a deep copy of the table before it is returned**, since we don't want players to mess with the internal tables! However, it should be more performant, because I avoid copying the _entire_ `Type` table.

It's a very simple change that I came up with while working with player classes for my gamemode, but I'd be glad to contribute even something as small as this.