### PR TITLE
Color MetaTable is not accessible. replace debug.getregistry() with setmetatable

### DIFF
--- a/garrysmod/lua/includes/util/color.lua
+++ b/garrysmod/lua/includes/util/color.lua
@@ -12,12 +12,6 @@ function Color( r, g, b, a )
 end
 
 --[[---------------------------------------------------------
-	Register our metatable to make it accessible using FindMetaTable
------------------------------------------------------------]]
-
-setmetatable(Color, COLOR)
-
---[[---------------------------------------------------------
 	Change the alpha of a color
 -----------------------------------------------------------]]
 function ColorAlpha( c, a )

--- a/garrysmod/lua/includes/util/color.lua
+++ b/garrysmod/lua/includes/util/color.lua
@@ -1,12 +1,5 @@
-
 local COLOR = {}
 COLOR.__index = COLOR
-
---[[---------------------------------------------------------
-	Register our metatable to make it accessible using FindMetaTable
------------------------------------------------------------]]
-
-debug.getregistry().Color = COLOR
 
 --[[---------------------------------------------------------
 	To easily create a color table
@@ -17,6 +10,12 @@ function Color( r, g, b, a )
 	return setmetatable( { r = math.min( tonumber(r), 255 ), g =  math.min( tonumber(g), 255 ), b =  math.min( tonumber(b), 255 ), a =  math.min( tonumber(a), 255 ) }, COLOR )
 
 end
+
+--[[---------------------------------------------------------
+	Register our metatable to make it accessible using FindMetaTable
+-----------------------------------------------------------]]
+
+setmetatable(Color, COLOR)
 
 --[[---------------------------------------------------------
 	Change the alpha of a color


### PR DESCRIPTION
debug.getregistry() is deprecated, and returns an empty table. The Color metatable is currently not accessible.