### PR TITLE
Add vgui.FindByClass() to fix PANEL:Pre/PostAutoRefresh()

### DIFF
--- a/garrysmod/lua/derma/derma.lua
+++ b/garrysmod/lua/derma/derma.lua
@@ -25,30 +25,6 @@ SkinMetaTable.__index = function ( self, key )
 
 end
 
-local function FindPanelsByClass( SeekingClass )
-
-	local outtbl = {}
-
-	--
-	-- Going through the registry is a hacky way to do this.
-	-- We're only doing it this way because it doesn't matter if it's a
-	-- bit slow - because this function is only used when reloading.
-	--
-	local tbl = debug.getregistry()
-	for k, v in pairs( tbl ) do
-
-		if ( ispanel( v ) && v.ClassName && v.ClassName == SeekingClass ) then
-
-			table.insert( outtbl, v )
-
-		end
-
-	end
-
-	return outtbl
-
-end
-
 --
 -- Find all the panels that use this class and
 -- if allowed replace the functions with the new ones.
@@ -58,7 +34,7 @@ local function ReloadClass( classname )
 	local ctrl = vgui.GetControlTable( classname )
 	if ( !ctrl ) then return end
 
-	local tbl = FindPanelsByClass( classname )
+	local tbl = vgui.FindByClass( classname )
 
 	for k, v in pairs ( tbl ) do
 

--- a/garrysmod/lua/includes/extensions/client/panel/scriptedpanels.lua
+++ b/garrysmod/lua/includes/extensions/client/panel/scriptedpanels.lua
@@ -128,11 +128,31 @@ function vgui.RegisterFile( filename )
 
 end
 
+local parentToHUDPanel
+
 local function FindPanelsByClass( seekingClass, panelToCheck, tDone, panelsFound )
+
+    local shouldCheckHUDPanels = CLIENT && !panelToCheck
 
     panelToCheck = panelToCheck or vgui.GetWorldPanel()
     panelsFound = panelsFound or {}
     tDone = tDone or {}
+
+    if ( !IsValid( panelToCheck ) ) then return panelsFound end
+
+    if ( shouldCheckHUDPanels ) then
+        FindPanelsByClass( seekingClass, GetHUDPanel(), tDone, panelsFound )
+
+        -- The panel Panel:ParentToHUD() sets as the parent is for some reason different from GetHUDPanel()
+        if ( !IsValid( parentToHUDPanel ) ) then
+            local tempPanel = vgui.CreateX('Panel')
+            tempPanel:ParentToHUD()
+            parentToHUDPanel = tempPanel:GetParent()
+            tempPanel:Remove()
+        end
+            
+        FindPanelsByClass( seekingClass, parentToHUDPanel, tDone, panelsFound )
+    end
 
     for k, panel in ipairs( panelToCheck:GetChildren() ) do
         if ( panel.ClassName == seekingClass ) then

--- a/garrysmod/lua/includes/extensions/client/panel/scriptedpanels.lua
+++ b/garrysmod/lua/includes/extensions/client/panel/scriptedpanels.lua
@@ -127,3 +127,32 @@ function vgui.RegisterFile( filename )
 	return mtable
 
 end
+
+local function FindPanelsByClass( seekingClass, panelToCheck, tDone, panelsFound )
+
+    panelToCheck = panelToCheck or vgui.GetWorldPanel()
+    panelsFound = panelsFound or {}
+    tDone = tDone or {}
+
+    for k, panel in ipairs( panelToCheck:GetChildren() ) do
+        if ( panel.ClassName == seekingClass ) then
+            table.insert( panelsFound, panel )
+        end
+
+        if ( !tDone[ panel ] ) then
+            tDone[ panel ] = true
+
+            FindPanelsByClass( seekingClass, panel, tDone, panelsFound )
+        end
+    end
+
+    return panelsFound
+
+end
+
+function vgui.FindByClass( seekingClass )
+
+    return FindPanelsByClass( seekingClass )
+
+end
+


### PR DESCRIPTION
Due to `debug.getregistry()` being removed, it broke the `PANEL:Pre/PostAutoRefresh()` hooks. This PR adds `vgui.FindByClass()` for `derma` to use to fix this problem.