### PR TITLE
Set cl_smooth to 0 so there is no client smoothing applied to the local player

### DIFF
--- a/garrysmod/cfg/network.cfg
+++ b/garrysmod/cfg/network.cfg
@@ -1,3 +1,4 @@
 cl_cmdrate 66
 cl_updaterate 66
+cl_smooth 0
 rate 100000


### PR DESCRIPTION
This should fix some network related bugs and maybe improve optimization