### PR TITLE
Added Metro Cops with Simple Cops ticked on

### DIFF
--- a/garrysmod/lua/autorun/base_npcs.lua
+++ b/garrysmod/lua/autorun/base_npcs.lua
@@ -113,6 +113,18 @@ AddNPC( {
 	Weapons = { "weapon_pistol", "weapon_smg1" }
 }, "Refugee" )
 
+-- Simple Cops (from starter chapters of HL2)
+-- Uses different squadname from standard overwatch units
+-- will only spawn with usp and play holster anims
+-- will ignore unseen enemies?
+AddNPC( {
+	Class = "npc_metropolice",
+	Category = Category,
+	Weapons = { "weapon_pistol" },
+	SpawnFlags = 131072, -- Simple Cops flag
+	KeyValues = { SquadName = "civil_protection", weapondrawn = true, ignoreunseenenemies = true }
+} )
+
 if ( IsMounted( "ep2" ) ) then
 	AddNPC( {
 		Name = "Uriah",

--- a/garrysmod/lua/autorun/base_npcs.lua
+++ b/garrysmod/lua/autorun/base_npcs.lua
@@ -113,18 +113,6 @@ AddNPC( {
 	Weapons = { "weapon_pistol", "weapon_smg1" }
 }, "Refugee" )
 
--- Simple Cops (from starter chapters of HL2)
--- Uses different squadname from standard overwatch units
--- will only spawn with usp and play holster anims
--- will ignore unseen enemies?
-AddNPC( {
-	Class = "npc_metropolice",
-	Category = Category,
-	Weapons = { "weapon_pistol" },
-	SpawnFlags = 131072, -- Simple Cops flag
-	KeyValues = { SquadName = "civil_protection", weapondrawn = true, ignoreunseenenemies = true }
-} )
-
 if ( IsMounted( "ep2" ) ) then
 	AddNPC( {
 		Name = "Uriah",
@@ -292,6 +280,18 @@ AddNPC( {
 	Weapons = { "weapon_stunstick", "weapon_pistol", "weapon_smg1" },
 	SpawnFlags = SF_NPC_DROP_HEALTHKIT,
 	KeyValues = { SquadName = "overwatch" }
+} )
+
+-- Simple Cops (from starter chapters of HL2)
+-- Uses different squadname from standard overwatch units
+-- will only spawn with usp and play holster anims
+-- will ignore unseen enemies?
+AddNPC( {
+	Class = "npc_metropolice",
+	Category = Category,
+	Weapons = { "weapon_pistol" },
+	SpawnFlags = 131072, -- Simple Cops flag
+	KeyValues = { SquadName = "civil_protection", weapondrawn = true, ignoreunseenenemies = true }
 } )
 
 AddNPC( {


### PR DESCRIPTION
This adds a metro cop variant with Simple Cops ticked on, basically allows to spawn the metro cops at the first few chapters of HL2

I learned standard metro cops don't have simple cops ticked on, and this makes it difficult to test out addons making use of metro cops with simple cop health without going to early chapters of HL2