### PR TITLE
Update deprecated GetConVarNumber in weapon_fists

### DIFF
--- a/garrysmod/lua/weapons/weapon_fists.lua
+++ b/garrysmod/lua/weapons/weapon_fists.lua
@@ -172,9 +172,11 @@ function SWEP:OnDrop()
 
 end
 
+local sv_deployspeed = GetConVar( "sv_defaultdeployspeed" )
+
 function SWEP:Deploy()
 
-	local speed = GetConVarNumber( "sv_defaultdeployspeed" )
+	local speed = sv_deployspeed:GetFloat()
 
 	local vm = self:GetOwner():GetViewModel()
 	vm:SendViewModelMatchingSequence( vm:LookupSequence( "fists_draw" ) )


### PR DESCRIPTION
Very small optimization that replaces the `GetConVarNumber` call on weapon deploy in `weapon_fists` to use the better method of retrieving a convar.