### PR TITLE
Add util.In( any thing, vararg values )

### DIFF
--- a/garrysmod/lua/includes/extensions/util.lua
+++ b/garrysmod/lua/includes/extensions/util.lua
@@ -408,3 +408,15 @@ function util.IsBinaryModuleInstalled( name )
 
 	return false
 end
+
+function util.In( thing, ... )
+    for i = 1, select( '#', ... ) do
+        local cur = select( i, ... )
+
+        if thing == cur then
+            return true
+        end
+    end
+
+    return false
+end


### PR DESCRIPTION
Allows you to check if `thing` is among `values`.
Using the function, we can do this:

```lua
local myUsergroup = 'user'
if util.In( curState, 'user', 'vip' ) then
    -- ...
end
```

... instead of:
```lua
local allowedUsergroups = {
    user = true,
    vip = true,
}

local myUsergroup = 'user'
if allowedUsergroups[ myUsergroup ] then
    -- ...
end
```

Of course, the second code is faster because it performs a key lookup (which is O(1) vs. my O(n) implementation), but `util.In` is useful in contexts where performance is not so important