### PR TITLE
Prevent infinite loop from `panel:SetDragParent`

### DIFF
--- a/garrysmod/lua/includes/extensions/client/panel/dragdrop.lua
+++ b/garrysmod/lua/includes/extensions/client/panel/dragdrop.lua
@@ -329,7 +329,6 @@ end
 -- dragging the defined parent
 --
 function meta:SetDragParent( parent )
-	if ( parent == self ) then return end
 	self.m_pDragParent = parent
 end
 

--- a/garrysmod/lua/includes/extensions/client/panel/dragdrop.lua
+++ b/garrysmod/lua/includes/extensions/client/panel/dragdrop.lua
@@ -416,6 +416,8 @@ function meta:DragMousePress( mcode )
 	if ( dragndrop.IsDragging() ) then dragndrop.StopDragging() return end
 
 	if ( IsValid( self.m_pDragParent ) ) then
+		if ( self.m_pDragParent == self ) then return end
+
 		return self.m_pDragParent:DragMousePress( mcode )
 	end
 

--- a/garrysmod/lua/includes/extensions/client/panel/dragdrop.lua
+++ b/garrysmod/lua/includes/extensions/client/panel/dragdrop.lua
@@ -329,6 +329,7 @@ end
 -- dragging the defined parent
 --
 function meta:SetDragParent( parent )
+	if ( parent == self ) then return end
 	self.m_pDragParent = parent
 end
 

--- a/garrysmod/lua/includes/extensions/client/panel/dragdrop.lua
+++ b/garrysmod/lua/includes/extensions/client/panel/dragdrop.lua
@@ -414,9 +414,7 @@ function meta:DragMousePress( mcode )
 	if ( IsValid( dragndrop.m_DropMenu ) ) then return end
 	if ( dragndrop.IsDragging() ) then dragndrop.StopDragging() return end
 
-	if ( IsValid( self.m_pDragParent ) ) then
-		if ( self.m_pDragParent == self ) then return end
-
+	if ( IsValid( self.m_pDragParent ) and self.m_pDragParent ~= self ) then
 		return self.m_pDragParent:DragMousePress( mcode )
 	end
 


### PR DESCRIPTION
Calling `panel:SetDragParent` with the panel itself as `parent` argument freezes the game