### PR TITLE
[TTT] Fixed can_rag_pin_inno overwriting can_rag_pin in Magneto Stick

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
@@ -531,7 +531,7 @@ function SWEP:SetupDataTables()
    -- we've got these dt slots anyway, might as well use them instead of a
    -- globalvar, probably cheaper
    self:DTVar("Bool", 0, "can_rag_pin")
-   self:DTVar("Bool", 0, "can_rag_pin_inno")
+   self:DTVar("Bool", 1, "can_rag_pin_inno")
 
    -- client actually has no idea what we're holding, and almost never needs to
    -- know


### PR DESCRIPTION
This was something I messed up in my PR that fixed the pinning instructions (#1753)
Thanks to @figardo for pointing it out