### PR TITLE
TTT: Reduce radar ping bit count

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_radar.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_radar.lua
@@ -240,9 +240,9 @@ local function ReceiveRadarScan()
       local r = net.ReadUInt(2)
 
       local pos = Vector()
-      pos.x = net.ReadInt(32)
-      pos.y = net.ReadInt(32)
-      pos.z = net.ReadInt(32)
+      pos.x = net.ReadInt(15)
+      pos.y = net.ReadInt(15)
+      pos.z = net.ReadInt(15)
 
       table.insert(RADAR.targets, {role=r, pos=pos})
    end

--- a/garrysmod/gamemodes/terrortown/gamemode/radar.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/radar.lua
@@ -57,9 +57,9 @@ local function RadarScan(ply, cmd, args)
             for k, tgt in ipairs(targets) do
                net.WriteUInt(tgt.role, 2)
 
-               net.WriteInt(tgt.pos.x, 32)
-               net.WriteInt(tgt.pos.y, 32)
-               net.WriteInt(tgt.pos.z, 32)
+               net.WriteInt(tgt.pos.x, 15)
+               net.WriteInt(tgt.pos.y, 15)
+               net.WriteInt(tgt.pos.z, 15)
             end
          net.Send(ply)
 


### PR DESCRIPTION
I know there's been some talk about increasing the map size limits, but to be perfectly honest with you 4 billion units cubed seems a tad bit excessive.

[This used to use umsg.Short](https://github.com/Facepunch/garrysmod/blob/329e7979ea0cbb9dfbf9e89f27510baba791fd12/garrysmod/gamemodes/terrortown/gamemode/radar.lua#L60), but another 16 bits were added to each axis along with the conversion to the net library for some reason.

Testing with 31 other scan targets, the message length goes from 3046 bits to 1465 bits.

Using WriteVector creates a 1744 bit message, and the coordinates are rounded to integers anyway so there's no need for the extra precision.

Thanks @mgetJane for pointing it out.