### PR TITLE
Allow custom error message for CanArmDupe

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/duplicator/arming.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/duplicator/arming.lua
@@ -63,8 +63,8 @@ if ( SERVER ) then
 
 		if ( !IsValid( client ) or size < 48 ) then return end
 
-		local res = hook.Run( "CanArmDupe", client )
-		if ( res == false ) then client:ChatPrint( "Server has blocked usage of the Duplicator tool!" ) return end
+		local res, msg = hook.Run( "CanArmDupe", client )
+		if ( res == false ) then client:ChatPrint( msg or "Server has blocked usage of the Duplicator tool!" ) return end
 
 		local part = net.ReadUInt( 8 )
 		local total = net.ReadUInt( 8 )

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/duplicator/arming.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/duplicator/arming.lua
@@ -16,8 +16,8 @@ if ( CLIENT ) then
 		LastDupeArm = CurTime() + 1
 
 		-- Server doesn't allow us to do this, don't even try to send them data
-		local res = hook.Run( "CanArmDupe", ply )
-		if ( res == false ) then ply:ChatPrint( "Refusing to load dupe, server has blocked usage of the Duplicator tool!" ) return end
+		local res, msg = hook.Run( "CanArmDupe", ply )
+		if ( res == false ) then ply:ChatPrint( msg or "Refusing to load dupe, server has blocked usage of the Duplicator tool!" ) return end
 
 		-- Load the dupe (engine takes care of making sure it's a dupe)
 		local dupe = engine.OpenDupe( arg[ 1 ] )

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/dupes.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/dupes.lua
@@ -52,8 +52,8 @@ spawnmenu.AddCreationTab( "#spawnmenu.category.dupes", function()
 	function ws_dupe:DownloadAndArm( id )
 
 		-- Server doesn't allow us to arm dupes, don't even try to download anything
-		local res = hook.Run( "CanArmDupe", LocalPlayer() )
-		if ( res == false ) then LocalPlayer():ChatPrint( "Refusing to download Workshop dupe, server has blocked usage of the Duplicator tool!" ) return end
+		local res, msg = hook.Run( "CanArmDupe", LocalPlayer() )
+		if ( res == false ) then LocalPlayer():ChatPrint( msg or "Refusing to download Workshop dupe, server has blocked usage of the Duplicator tool!" ) return end
 
 		MsgN( "Downloading Dupe..." )
 		steamworks.DownloadUGC( id, function( name )


### PR DESCRIPTION
Adds a second return for the `CanArmDupe` hook that, if provided, will override the default failure message.