### PR TITLE
Optimize skypaint matproxy

### DIFF
--- a/garrysmod/lua/matproxy/sky_paint.lua
+++ b/garrysmod/lua/matproxy/sky_paint.lua
@@ -1,3 +1,5 @@
+local IsValid = IsValid
+local RealTime = RealTime
 
 matproxy.Add( {
 	name = "SkyPaint",
@@ -10,25 +12,27 @@ matproxy.Add( {
 		local skyPaint = g_SkyPaint
 		if ( !IsValid( skyPaint ) ) then return end
 
-		mat:SetVector( "$TOPCOLOR",		skyPaint:GetTopColor() )
-		mat:SetVector( "$BOTTOMCOLOR",	skyPaint:GetBottomColor() )
-		mat:SetVector( "$DUSKCOLOR",	skyPaint:GetDuskColor() )
-		mat:SetFloat( "$DUSKSCALE",		skyPaint:GetDuskScale() )
-		mat:SetFloat( "$DUSKINTENSITY",	skyPaint:GetDuskIntensity() )
-		mat:SetFloat( "$FADEBIAS",		skyPaint:GetFadeBias() )
-		mat:SetFloat( "$HDRSCALE",		skyPaint:GetHDRScale() )
+		local values = skyPaint:GetNetworkVars()
 
-		mat:SetVector( "$SUNNORMAL",	skyPaint:GetSunNormal() )
-		mat:SetVector( "$SUNCOLOR",		skyPaint:GetSunColor() )
-		mat:SetFloat( "$SUNSIZE",		skyPaint:GetSunSize() )
+		mat:SetVector( "$TOPCOLOR",		values.TopColor )
+		mat:SetVector( "$BOTTOMCOLOR",	values.BottomColor )
+		mat:SetVector( "$DUSKCOLOR",	values.DuskColor )
+		mat:SetFloat( "$DUSKSCALE",		values.DuskScale )
+		mat:SetFloat( "$DUSKINTENSITY",	values.DuskIntensity )
+		mat:SetFloat( "$FADEBIAS",		values.FadeBias )
+		mat:SetFloat( "$HDRSCALE",		values.HDRScale )
 
-		if ( skyPaint:GetDrawStars() ) then
+		mat:SetVector( "$SUNNORMAL",	values.SunNormal )
+		mat:SetVector( "$SUNCOLOR",		values.SunColor )
+		mat:SetFloat( "$SUNSIZE",		values.SunSize )
 
-			mat:SetInt( "$STARLAYERS",		skyPaint:GetStarLayers() )
-			mat:SetFloat( "$STARSCALE",		skyPaint:GetStarScale() )
-			mat:SetFloat( "$STARFADE",		skyPaint:GetStarFade() )
-			mat:SetFloat( "$STARPOS",		skyPaint:GetStarSpeed() * RealTime() )
-			mat:SetTexture( "$STARTEXTURE",	skyPaint:GetStarTexture() )
+		if ( values.DrawStars ) then
+
+			mat:SetInt( "$STARLAYERS",		values.StarLayers )
+			mat:SetFloat( "$STARSCALE",		values.StarScale )
+			mat:SetFloat( "$STARFADE",		values.StarFade )
+			mat:SetFloat( "$STARPOS",		values.StarSpeed * RealTime() )
+			mat:SetTexture( "$STARTEXTURE",	values.StarTexture )
 
 		else
 

--- a/garrysmod/lua/matproxy/sky_paint.lua
+++ b/garrysmod/lua/matproxy/sky_paint.lua
@@ -1,3 +1,4 @@
+
 matproxy.Add( {
 	name = "SkyPaint",
 

--- a/garrysmod/lua/matproxy/sky_paint.lua
+++ b/garrysmod/lua/matproxy/sky_paint.lua
@@ -1,6 +1,3 @@
-local IsValid = IsValid
-local RealTime = RealTime
-
 matproxy.Add( {
 	name = "SkyPaint",
 


### PR DESCRIPTION
We can skip a lot of `__index` calls and `NetworkVar` overhead by getting all of the network vars up front and then accessing them from the local table.

In my tests, this was about 4x faster than the original.

**Default:**
![hl2_CSDp3u6zVx](https://github.com/Facepunch/garrysmod/assets/7936439/fee3d04e-9cfe-465d-ac6e-fe9f70d7c1f2)


**This PR:**
![hl2_I8YTrWrudK](https://github.com/Facepunch/garrysmod/assets/7936439/eb29c412-ea3d-445d-b396-16d601cc4b35)


**Test setup:**
- [`gm_bigcity_improved_lite`](https://steamcommunity.com/sharedfiles/filedetails/?id=1129969546), running around spawn
- ~17 players
- `FProfiler` for measurements