### PR TITLE
Add killicon overriding logic

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/npc.lua
+++ b/garrysmod/gamemodes/base/gamemode/npc.lua
@@ -87,11 +87,11 @@ AccessorFunc( entMeta, "m_strKillIcon", "KilliconOverride", FORCE_STRING )
 -----------------------------------------------------------]]
 function entMeta:SetDeathKillicon( classOverride )
 	if ( !classOverride ) then return end
+
 	self:SetKilliconOverride( classOverride )
 	timer.Simple( 0, function()
 		if ( !IsValid( self ) ) then return end
 		self:SetKilliconOverride( nil )
-
 
 	end )
 end
@@ -101,6 +101,7 @@ end
    Desc: Finds the classname ( or override ) to pass along to the death notice system
 -----------------------------------------------------------]]
 function GM:GetDeathNoticeInflictorClass( killed, inflictor )
+
 	local override = killed:GetKilliconOverride()
 	if ( override ) then return override end
 	if ( IsValid( inflictor ) ) then return inflictor:GetClass() end
@@ -141,7 +142,6 @@ function GM:OnNPCKilled( ent, attacker, inflictor )
 
 	if ( !InflictorClass ) then
 		inflictorClass = "worldspawn"
-
 	end
 
 	if ( IsValid( attacker ) ) then

--- a/garrysmod/gamemodes/base/gamemode/player.lua
+++ b/garrysmod/gamemodes/base/gamemode/player.lua
@@ -160,7 +160,12 @@ function GM:PlayerDeath( ply, inflictor, attacker )
 
 	if ( attacker == ply ) then
 
-		self:SendDeathNotice( nil, "suicide", ply, 0 )
+		local inflictorClass = self:GetDeathNoticeInflictorClass( ply )
+		if ( !inflictorClass ) then
+			inflictorClass = "suicide"
+		end
+
+		self:SendDeathNotice( nil, inflictorClass, ply, 0 )
 
 		MsgAll( attacker:Nick() .. " suicided!\n" )
 
@@ -168,7 +173,7 @@ function GM:PlayerDeath( ply, inflictor, attacker )
 
 	if ( attacker:IsPlayer() ) then
 
-		self:SendDeathNotice( attacker, inflictor:GetClass(), ply, 0 )
+		self:SendDeathNotice( attacker, self:GetDeathNoticeInflictorClass( ply, inflictor ), ply, 0 )
 
 		MsgAll( attacker:Nick() .. " killed " .. ply:Nick() .. " using " .. inflictor:GetClass() .. "\n" )
 
@@ -177,7 +182,7 @@ function GM:PlayerDeath( ply, inflictor, attacker )
 	local flags = 0
 	if ( attacker:IsNPC() and attacker:Disposition( ply ) != D_HT ) then flags = flags + DEATH_NOTICE_FRIENDLY_ATTACKER end
 
-	self:SendDeathNotice( self:GetDeathNoticeEntityName( attacker ), inflictor:GetClass(), ply, 0 )
+	self:SendDeathNotice( self:GetDeathNoticeEntityName( attacker ), self:GetDeathNoticeInflictorClass( ply, inflictor ), ply, 0 )
 
 	MsgAll( ply:Nick() .. " was killed by " .. attacker:GetClass() .. "\n" )
 


### PR DESCRIPTION
Allow for the overriding of killicons.
Fluff change, for adding custom killicons, without creating/spawning a custom inflictor.

Adds
entity:Set/GetKilliconOverride( string )
entity:SetDeathKillicon( string )

+Gamemode hook,
GM:GetDeathNoticeInflictorClass( killed, inflictor )