### PR TITLE
[TTT] add TTTShowSearchScreen hook

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_search.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_search.lua
@@ -490,7 +490,7 @@ local function ReceiveRagdollSearch()
    
    hook.Call("TTTBodySearchEquipment", nil, search, eq)
 
-   if search.show and hook.Run("TTTShowSearchScreen", search) == nil then
+   if search.show and hook.Run("TTTShowSearchScreen", search) ~= false then
       ShowSearchScreen(search)
    end
 

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_search.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_search.lua
@@ -490,7 +490,7 @@ local function ReceiveRagdollSearch()
    
    hook.Call("TTTBodySearchEquipment", nil, search, eq)
 
-   if search.show then
+   if search.show and hook.Run("TTTShowSearchScreen", search) == nil then
       ShowSearchScreen(search)
    end
 


### PR DESCRIPTION
allows addons to more elegantly replace the corpse search ui

currently the only way for addons to change the search ui is either to replace the whole cl_search.lua file or replace the whole "TTT_RagdollSearch" net receiver