### PR TITLE
Don't call gmod.GetGamemode() in hook.Run

### DIFF
--- a/garrysmod/lua/includes/modules/hook.lua
+++ b/garrysmod/lua/includes/modules/hook.lua
@@ -1,4 +1,4 @@
-local gmod = gmod
+local _G = _G
 local pairs = pairs
 local isfunction = isfunction
 local isstring = isstring
@@ -67,7 +67,7 @@ end
     Desc: Calls hooks associated with the hook name.
 -----------------------------------------------------------]]
 function Run( name, ... )
-	return Call( name, gmod and gmod.GetGamemode() or nil, ... )
+	return Call( name, _G.GAMEMODE or _G.GM, ... )
 end
 
 


### PR DESCRIPTION
hook.Run currently calls gmod.GetGamemode() which is a C call so it's unnecessarily slower than it should be

the function's return value is always equivalent to `GAMEMODE or GM`

```lua
lua_run local s=SysTime() for i=1,1000000 do hook.Run("test") end print(SysTime()-s)
> local s=SysTime() for i=1,1000000 do hook.Run("test") end print(SysTime()-s)...
0.106619362

lua_run function gmod.GetGamemode() return GAMEMODE end
> function gmod.GetGamemode() return GAMEMODE end...

lua_run local s=SysTime() for i=1,1000000 do hook.Run("test") end print(SysTime()-s)
> local s=SysTime() for i=1,1000000 do hook.Run("test") end print(SysTime()-s)...
0.00039914499999583

lua_run local s=SysTime() for i=1,1000000 do hook.Call("test", GAMEMODE) end print(SysTime()-s)
> local s=SysTime() for i=1,1000000 do hook.Call("test", GAMEMODE) end print(SysTime()-s)...
0.00066306600000132
```