### PR TITLE
Reduced bits used by net.Read/WritePlayer based on maxplayers

### DIFF
--- a/garrysmod/lua/includes/extensions/net.lua
+++ b/garrysmod/lua/includes/extensions/net.lua
@@ -76,7 +76,7 @@ end
 --
 -- Read/Write a player to the stream
 --
-local maxplayers_bits = math.ceil(math.log(1 + game.MaxPlayers()) / math.log(2))
+local maxplayers_bits = math.ceil( math.log( 1 + game.MaxPlayers() ) / math.log( 2 ) )
 
 function net.WritePlayer( ply )
 	net.WriteUInt( IsValid( ply ) and ply:IsPlayer() and ply:EntIndex() or 0, maxplayers_bits )

--- a/garrysmod/lua/includes/extensions/net.lua
+++ b/garrysmod/lua/includes/extensions/net.lua
@@ -76,24 +76,14 @@ end
 --
 -- Read/Write a player to the stream
 --
+local maxplayers_bits = math.ceil(math.log(1 + game.MaxPlayers()) / math.log(2))
+
 function net.WritePlayer( ply )
-
-	if ( !IsValid( ply ) || !ply:IsPlayer() ) then 
-		net.WriteUInt( 0, 8 )
-	else
-		net.WriteUInt( ply:EntIndex(), 8 )
-	end
-
+	net.WriteUInt( IsValid( ply ) and ply:IsPlayer() and ply:EntIndex() or 0, maxplayers_bits )
 end
 
 function net.ReadPlayer()
-
-	local i = net.ReadUInt( 8 )
-	if ( !i ) then return end
-	
-	local ply = Entity( i )
-	return ply
-	
+	return Entity( net.ReadUInt( maxplayers_bits ) )
 end
 
 


### PR DESCRIPTION
it is impossible for maxplayers to be changed without a server restart

also, i removed all the extra stuff from net.ReadPlayer because net.ReadUInt will never return a falsy value

also, changing net.WritePlayer into a single line is probably a little unnecessary, but imo it's harmless and i'll change it back if it's unwanted