### PR TITLE
TTT: Optimize ragdoll search network traffic + fix disconnected player networking

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_search.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_search.lua
@@ -431,6 +431,8 @@ local function bitsRequired(num)
    return bits
 end
 
+local plyBits = bitsRequired(game.MaxPlayers())
+
 local search = {}
 local function ReceiveRagdollSearch()
    search = {}
@@ -438,7 +440,7 @@ local function ReceiveRagdollSearch()
    -- Basic info
    search.eidx = net.ReadUInt(16)
 
-   search.owner = Entity(net.ReadUInt(8))
+   search.owner = Entity(net.ReadUInt(plyBits))
    if not (IsValid(search.owner) and search.owner:IsPlayer() and (not search.owner:IsTerror())) then
       search.owner = nil
    end
@@ -446,7 +448,7 @@ local function ReceiveRagdollSearch()
    search.nick = net.ReadString()
 
    -- Equipment
-   local eq = net.ReadUInt(16)
+   local eq = net.ReadUInt(bitsRequired(EQUIP_MAX))
 
    -- All equipment pieces get their own icon
    search.eq_armor = util.BitSet(eq, EQUIP_ARMOR)
@@ -455,30 +457,30 @@ local function ReceiveRagdollSearch()
 
    -- Traitor things
    search.role = net.ReadUInt(2)
-   search.c4 = net.ReadInt(bitsRequired(C4_WIRE_COUNT) + 1)
+   search.c4 = net.ReadUInt(bitsRequired(C4_WIRE_COUNT))
 
    -- Kill info
    search.dmg = net.ReadUInt(30)
    search.wep = net.ReadString()
-   search.head = net.ReadBit() == 1
-   search.dtime = net.ReadInt(16)
-   search.stime = net.ReadInt(16)
+   search.head = net.ReadBool()
+   search.dtime = net.ReadUInt(15)
+   search.stime = net.ReadUInt(15)
 
    -- Players killed
    local num_kills = net.ReadUInt(8)
    if num_kills > 0 then
       search.kills = {}
       for i=1,num_kills do
-         table.insert(search.kills, net.ReadUInt(8))
+         table.insert(search.kills, net.ReadUInt(plyBits))
       end
    else
       search.kills = nil
    end
 
-   search.lastid = {idx=net.ReadUInt(8)}
+   search.lastid = {idx=net.ReadUInt(plyBits)}
 
    -- should we show a menu for this result?
-   search.finder = net.ReadUInt(8)
+   search.finder = net.ReadUInt(plyBits)
 
    search.show = (LocalPlayer():EntIndex() == search.finder)
 

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_search.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_search.lua
@@ -173,7 +173,7 @@ function PreprocSearch(raw)
          local num = table.Count(d)
          if num == 1 then
             local vic = Entity(d[1])
-            local dc = d[1] == -1 -- disconnected
+            local dc = d[1] == 0 -- disconnected
             if dc or (IsValid(vic) and vic:IsPlayer()) then
                search[t].text = PT("search_kills1", {player = (dc and "<Disconnected>" or vic:Nick())})
             end
@@ -181,9 +181,9 @@ function PreprocSearch(raw)
             local txt = T("search_kills2") .. "\n"
 
             local nicks = {}
-            for k, idx in pairs(d) do
+            for k, idx in ipairs(d) do
                local vic = Entity(idx)
-               local dc = idx == -1
+               local dc = idx == 0
                if dc or (IsValid(vic) and vic:IsPlayer()) then
                   table.insert(nicks, (dc and "<Disconnected>" or vic:Nick()))
                end
@@ -196,7 +196,7 @@ function PreprocSearch(raw)
 
          search[t].p = 30
       elseif t == "lastid" then
-         if d and d.idx != -1 then
+         if d and d.idx != 0 then
             local ent = Entity(d.idx)
             if IsValid(ent) and ent:IsPlayer() then
                search[t].text = PT("search_eyes", {player = ent:Nick()})

--- a/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
@@ -93,7 +93,7 @@ local function IdentifyBody(ply, rag)
    end
 
    -- Handle kill list
-   for k, vicsid64 in pairs(rag.kills) do
+   for k, vicsid64 in ipairs(rag.kills) do
       -- filter out disconnected
       local vic = player.GetBySteamID64(vicsid64)
 
@@ -206,7 +206,7 @@ function CORPSE.ShowSearch(ply, rag, covert, long_range)
    local dtime = rag.time or 0
 
    local owner = player.GetBySteamID64(rag.sid64)
-   owner = IsValid(owner) and owner:EntIndex() or -1
+   owner = IsValid(owner) and owner:EntIndex() or 0
 
    -- basic sanity check
    if nick == nil or eq == nil or role == nil then return end
@@ -242,17 +242,17 @@ function CORPSE.ShowSearch(ply, rag, covert, long_range)
 
    -- build list of people this traitor killed
    local kill_entids = {}
-   for k, vicsid64 in pairs(rag.kills) do
+   for k, vicsid64 in ipairs(rag.kills) do
       -- also send disconnected players as a marker
       local vic = player.GetBySteamID64(vicsid64)
-      table.insert(kill_entids, IsValid(vic) and vic:EntIndex() or -1)
+      table.insert(kill_entids, IsValid(vic) and vic:EntIndex() or 0)
    end
 
-   local lastid = -1
+   local lastid = 0
    if rag.lastid and ply:IsActiveDetective() then
-      -- if the person this victim last id'd has since disconnected, send -1 to
+      -- if the person this victim last id'd has since disconnected, send 0 to
       -- indicate this
-      lastid = IsValid(rag.lastid.ent) and rag.lastid.ent:EntIndex() or -1
+      lastid = IsValid(rag.lastid.ent) and rag.lastid.ent:EntIndex() or 0
    end
 
    -- Send a message with basic info


### PR DESCRIPTION
TL;DR saves around 20-40 bits depending on playercount and fixes instances where it overflows trying to network a disconnected player (most noticeable in the kill list).

Optimizations:

- Create a constant to store bits required to network player ent indexes.
	- Same as #2078.
	- This value could be used to network #kill_entids in vanilla, but if there's an addon that allows player respawning there can potentially be more kills than there are player slots, so I've left it as 8 bits.
- Calculate bits required to network equipment items instead of a hardcoded 16 bits.
	- Saves 13 bits by default.
	- Increases equipment item limit to 32.
- Use unsigned int for safe C4 wire networking. Fallback value changed from -1 -> 0.
	- Search results screen already checks for search.c4 > 0, so no change in behaviour.
	- Saves 1 entire bit by default.
- Use unsigned ints for death/sample time networking. Reduce bitcount to 15 for each.
	- Neither value can be negative, so there's no point in sending them as signed ints.
	- Saves 2 bits.

Disconnected player fix:
- Player ent indexes are networked as unsigned ints, but the fallback value when a player isn't valid is -1.
- This is most noticeable on the kill list, where instead of displaying \<Disconnected\> as it should, nothing appears in the list.
	- (Also, this is one of the few hardcoded strings left in the game, maybe it should be moved to the language file?)
- The fix is to simply use 0 as a fallback instead.

Misc:

- Switched Read/WriteBit for Read/WriteBool on search.head.
	- Since ReadBool is literally just ReadBit == 1 anyway.
- Use ipairs with the kill list table.
	- Since every other sequential table in the gamemode already uses ipairs.