### PR TITLE
Improve Physgun Halo drawing

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/cl_init.lua
@@ -144,7 +144,7 @@ end
 
 hook.Add( "PreDrawHalos", "AddPhysgunHalos", function()
 
-	if ( !PhysgunHalos || physgun_halo:GetInt() == 0 || table.IsEmpty( PhysgunHalos ) ) then return end
+	if ( !PhysgunHalos || table.IsEmpty( PhysgunHalos ) ) then return end
 
 	for k, v in pairs( PhysgunHalos ) do
 

--- a/garrysmod/gamemodes/sandbox/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/cl_init.lua
@@ -123,11 +123,20 @@ local PhysgunHalos = {}
 -----------------------------------------------------------]]
 function GM:DrawPhysgunBeam( ply, weapon, bOn, target, boneid, pos )
 
-	if ( physgun_halo:GetInt() == 0 ) then return true end
+	if ( physgun_halo:GetInt() == 0 ) then 
+		
+		PhysgunHalos = nil
+		
+		return true 
 
-	if ( IsValid( target ) ) then
-		PhysgunHalos[ ply ] = target
 	end
+
+	PhysgunHalos = PhysgunHalos || {}
+
+	local ent = PhysgunHalos[ ply ] || {}
+	ent[1] = IsValid( target ) && target || nil
+
+	PhysgunHalos[ ply ] = ent
 
 	return true
 
@@ -135,20 +144,23 @@ end
 
 hook.Add( "PreDrawHalos", "AddPhysgunHalos", function()
 
-	if ( !PhysgunHalos || table.IsEmpty( PhysgunHalos ) ) then return end
+	if ( !PhysgunHalos || physgun_halo:GetInt() == 0 || table.IsEmpty( PhysgunHalos ) ) then return end
 
 	for k, v in pairs( PhysgunHalos ) do
 
-		if ( !IsValid( k ) ) then continue end
+		if ( !IsValid( k ) ) then
+			PhysgunHalos[ k ] = nil
+			continue
+		end
+
+		if ( !v[1] ) then continue end
 
 		local size = math.random( 1, 2 )
 		local colr = k:GetWeaponColor() + VectorRand() * 0.3
 
-		halo.Add( PhysgunHalos, Color( colr.x * 255, colr.y * 255, colr.z * 255 ), size, size, 1, true, false )
+		halo.Add( v, Color( colr.x * 255, colr.y * 255, colr.z * 255 ), size, size, 1, true, false )
 
 	end
-
-	PhysgunHalos = {}
 
 end )
 


### PR DESCRIPTION
This improves it by:

- No longer creating a new table every draw
- Fixes a bug where halo's stack if multiple players are physgunning entities at the same time
- Sets `PhysgunHalos` table to `nil` when `physgun_halo` convar is set to 0, as it isn't going to be used