### PR TITLE
Don't draw effect rings w/gravgun equipped.

### DIFF
--- a/garrysmod/gamemodes/base/entities/entities/prop_effect.lua
+++ b/garrysmod/gamemodes/base/entities/entities/prop_effect.lua
@@ -79,7 +79,7 @@ function ENT:Draw()
 
 	local weapon_name = wep:GetClass()
 
-	if ( weapon_name != "weapon_physgun" && weapon_name != "weapon_physcannon" && weapon_name != "gmod_tool" ) then
+	if ( weapon_name != "weapon_physgun" && weapon_name != "gmod_tool" ) then
 		return
 	end
 


### PR DESCRIPTION
I get why this was a feature, since the gravgun _can_ pick up, move effects. 

But I'm gonna be straight, nobody places, moves effects with the gravgun, it's a weapon you use to "play the game".
If I'm wrong, and someone does use the gravgun to place effects, I feel very confident saying they're vastly outnumbered by the players who use it solely as a weapon.

"cl_draweffectrings 0" does exist, but it's not the "default player experience", it's another, albeit very small, "barrier to entry".

Thanks for considering this very small PR, for what I feel is an equally small oversight.