### PR TITLE
Allow table initializers in TOOL.ClientConVar and TOOL.ServerConVar

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stool.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stool.lua
@@ -40,14 +40,26 @@ function ToolObj:CreateConVars()
 
 	if ( CLIENT ) then
 
+		local helpText = "Tool specific client setting (" .. mode .. ")"
+
 		for cvar, default in pairs( self.ClientConVar ) do
-			self.ClientConVars[ cvar ] = CreateClientConVar( mode .. "_" .. cvar, default, true, true, "Tool specific client setting (" .. mode .. ")" )
+			if ( istable ( default ) ) then
+				self.ClientConVars[ cvar ] = CreateClientConVar( mode .. "_" .. cvar, default.Value or "", true, true, default.HelpText or helpText, default.Min, default.Max )
+			else
+				self.ClientConVars[ cvar ] = CreateClientConVar( mode .. "_" .. cvar, default, true, true, helpText )
+			end
 		end
 
 	else
 
+		local helpText = "Tool specific server setting (" .. mode .. ")"
+
 		for cvar, default in pairs( self.ServerConVar ) do
-			self.ServerConVars[ cvar ] = CreateConVar( mode .. "_" .. cvar, default, FCVAR_ARCHIVE, "Tool specific server setting (" .. mode .. ")" )
+			if ( istable ( default ) ) then
+				self.ServerConVars[ cvar ] = CreateConVar( mode .. "_" .. cvar, default.Value or "", default.Flags or FCVAR_ARCHIVE, default.HelpText or helpText, default.Min, default.Max )
+			else
+				self.ServerConVars[ cvar ] = CreateConVar( mode .. "_" .. cvar, default, FCVAR_ARCHIVE, helpText )
+			end
 		end
 
 	end


### PR DESCRIPTION
Extends the `TOOL.ClientConVar` and `TOOL.ServerConVar` to use tables to initialize the convars, in case developers want to extend the definitions in the tool easily.

The following presents the tables and their default values (these values are virtual and they're really just nil substitution).

Shared:
```lua
{
Value = "", -- string/number The default value of the convar
HelpText = "Tool specific <server/client> setting (<mode>)", -- string The help text of the convar
Min = nil, -- number The minimum value of the convar
Max = nil -- number The maximum value of the convar
}
```

Server:
```lua
{
Flags = FCVAR_ARCHIVE -- number/table The convar flags to initialize the convar with
}
```
