### PR TITLE
Optimize DLabel autostretch behavior

### DIFF
--- a/garrysmod/lua/includes/extensions/client/panel.lua
+++ b/garrysmod/lua/includes/extensions/client/panel.lua
@@ -330,10 +330,10 @@ end
 function meta:SizeToContentsY( addVal )
 
 	local w, h = self:GetContentSize()
-	if ( !w || !h ) then return end
+	if ( !w or !h ) then return end
 
 	local newSize = h + ( addVal or 0 )
-	if newSize == self.contentsSizeY then return end
+	if ( newSize == self.contentsSizeY ) then return end
 
 	self:SetTall( newSize )
 
@@ -347,10 +347,10 @@ end
 function meta:SizeToContentsX( addVal )
 
 	local w, h = self:GetContentSize()
-	if ( !w || !h ) then return end
+	if ( !w or !h ) then return end
 
 	local newSize = w + ( addVal or 0 )
-	if newSize == self.contentsSizeX then return end
+	if ( newSize == self.contentsSizeX ) then return end
 
 	self:SetWide( newSize )
 

--- a/garrysmod/lua/includes/extensions/client/panel.lua
+++ b/garrysmod/lua/includes/extensions/client/panel.lua
@@ -333,9 +333,11 @@ function meta:SizeToContentsY( addVal )
 	if ( !w or !h ) then return end
 
 	local newSize = h + ( addVal or 0 )
-	if ( newSize == self:GetTall() ) then return end
+	if ( newSize == self.contentsSizeY ) then return end
 
 	self:SetTall( newSize )
+
+	self.contentsSizeY = newSize
 
 end
 
@@ -348,9 +350,11 @@ function meta:SizeToContentsX( addVal )
 	if ( !w or !h ) then return end
 
 	local newSize = w + ( addVal or 0 )
-	if ( newSize == self:GetWide() ) then return end
+	if ( newSize == self.contentsSizeX ) then return end
 
 	self:SetWide( newSize )
+
+	self.contentsSizeX = newSize
 
 end
 

--- a/garrysmod/lua/includes/extensions/client/panel.lua
+++ b/garrysmod/lua/includes/extensions/client/panel.lua
@@ -327,34 +327,34 @@ end
 --[[---------------------------------------------------------
 	Name: SizeToContentsY (Only works on Labels)
 -----------------------------------------------------------]]
-function meta:SizeToContentsY( addval )
+function meta:SizeToContentsY( addVal )
 
 	local w, h = self:GetContentSize()
 	if ( !w || !h ) then return end
 
-	local newsize = h + ( addval or 0 )
-	if newsize == self.contentsSizeY then return end
+	local newSize = h + ( addVal or 0 )
+	if newSize == self.contentsSizeY then return end
 
-	self:SetTall( newsize )
+	self:SetTall( newSize )
 
-	self.contentsSizeY = newsize
+	self.contentsSizeY = newSize
 
 end
 
 --[[---------------------------------------------------------
 	Name: SizeToContentsX (Only works on Labels)
 -----------------------------------------------------------]]
-function meta:SizeToContentsX( addval )
+function meta:SizeToContentsX( addVal )
 
 	local w, h = self:GetContentSize()
 	if ( !w || !h ) then return end
 
-	local newsize = w + ( addval or 0 )
-	if newsize == self.contentsSizeX then return end
+	local newSize = w + ( addVal or 0 )
+	if newSize == self.contentsSizeX then return end
 
-	self:SetWide( newsize )
+	self:SetWide( newSize )
 
-	self.contentsSizeX = newsize
+	self.contentsSizeX = newSize
 
 end
 

--- a/garrysmod/lua/includes/extensions/client/panel.lua
+++ b/garrysmod/lua/includes/extensions/client/panel.lua
@@ -333,11 +333,9 @@ function meta:SizeToContentsY( addVal )
 	if ( !w or !h ) then return end
 
 	local newSize = h + ( addVal or 0 )
-	if ( newSize == self.contentsSizeY ) then return end
+	if ( newSize == self:GetTall() ) then return end
 
 	self:SetTall( newSize )
-
-	self.contentsSizeY = newSize
 
 end
 
@@ -350,11 +348,9 @@ function meta:SizeToContentsX( addVal )
 	if ( !w or !h ) then return end
 
 	local newSize = w + ( addVal or 0 )
-	if ( newSize == self.contentsSizeX ) then return end
+	if ( newSize == self:GetWide() ) then return end
 
 	self:SetWide( newSize )
-
-	self.contentsSizeX = newSize
 
 end
 

--- a/garrysmod/lua/includes/extensions/client/panel.lua
+++ b/garrysmod/lua/includes/extensions/client/panel.lua
@@ -327,24 +327,24 @@ end
 --[[---------------------------------------------------------
 	Name: SizeToContentsY (Only works on Labels)
 -----------------------------------------------------------]]
-function meta:SizeToContentsY( addVal )
+function meta:SizeToContentsY( addval )
 
 	local w, h = self:GetContentSize()
-	if ( !w or !h ) then return end
+	if ( !w || !h ) then return end
 
-	self:SetTall( h + ( addVal or 0 ) )
+	self:SetTall( h + ( addval or 0 ) )
 
 end
 
 --[[---------------------------------------------------------
 	Name: SizeToContentsX (Only works on Labels)
 -----------------------------------------------------------]]
-function meta:SizeToContentsX( addVal )
+function meta:SizeToContentsX( addval )
 
 	local w, h = self:GetContentSize()
-	if ( !w or !h ) then return end
+	if ( !w || !h ) then return end
 
-	self:SetWide( w + ( addVal or 0 ) )
+	self:SetWide( w + ( addval or 0 ) )
 
 end
 

--- a/garrysmod/lua/includes/extensions/client/panel.lua
+++ b/garrysmod/lua/includes/extensions/client/panel.lua
@@ -332,7 +332,12 @@ function meta:SizeToContentsY( addval )
 	local w, h = self:GetContentSize()
 	if ( !w || !h ) then return end
 
-	self:SetTall( h + ( addval or 0 ) )
+	local newsize = h + ( addval or 0 )
+	if newsize == self.contentsSizeY then return end
+
+	self:SetTall( newsize )
+
+	self.contentsSizeY = newsize
 
 end
 
@@ -344,7 +349,12 @@ function meta:SizeToContentsX( addval )
 	local w, h = self:GetContentSize()
 	if ( !w || !h ) then return end
 
-	self:SetWide( w + ( addval or 0 ) )
+	local newsize = w + ( addval or 0 )
+	if newsize == self.contentsSizeX then return end
+
+	self:SetWide( newsize )
+
+	self.contentsSizeX = newsize
 
 end
 

--- a/garrysmod/lua/includes/extensions/client/panel.lua
+++ b/garrysmod/lua/includes/extensions/client/panel.lua
@@ -332,12 +332,7 @@ function meta:SizeToContentsY( addVal )
 	local w, h = self:GetContentSize()
 	if ( !w or !h ) then return end
 
-	local newSize = h + ( addVal or 0 )
-	if ( newSize == self.contentsSizeY ) then return end
-
-	self:SetTall( newSize )
-
-	self.contentsSizeY = newSize
+	self:SetTall( h + ( addVal or 0 ) )
 
 end
 
@@ -349,12 +344,7 @@ function meta:SizeToContentsX( addVal )
 	local w, h = self:GetContentSize()
 	if ( !w or !h ) then return end
 
-	local newSize = w + ( addVal or 0 )
-	if ( newSize == self.contentsSizeX ) then return end
-
-	self:SetWide( newSize )
-
-	self.contentsSizeX = newSize
+	self:SetWide( w + ( addVal or 0 ) )
 
 end
 

--- a/garrysmod/lua/vgui/dlabel.lua
+++ b/garrysmod/lua/vgui/dlabel.lua
@@ -119,17 +119,13 @@ function PANEL:ApplySchemeSettings()
 
 end
 
-function PANEL:Think()
+function PANEL:PerformLayout()
+
+	self:ApplySchemeSettings()
 
 	if ( self:GetAutoStretchVertical() ) then
 		self:SizeToContentsY()
 	end
-
-end
-
-function PANEL:PerformLayout()
-
-	self:ApplySchemeSettings()
 
 end
 

--- a/garrysmod/lua/vgui/dlabel.lua
+++ b/garrysmod/lua/vgui/dlabel.lua
@@ -123,12 +123,20 @@ function PANEL:PerformLayout()
 
 	self:ApplySchemeSettings()
 
-	local curHeight = self:GetTall()
+	if ( self:GetAutoStretchVertical() ) then
 
-	if ( self:GetAutoStretchVertical() && self.lastAutoStretchSize != curHeight ) then
+		local dockType = self:GetDock()
 
-		self.lastAutoStretchSize = curHeight
-		self:SizeToContentsY()
+		-- Auto stretch will layout infinitely with these dock types, so we'll undo them
+		if ( dockType != FILL && dockType != LEFT && dockType != RIGHT ) then
+
+			self:SizeToContentsY()
+
+		else
+
+			self:Dock( NODOCK )
+
+		end
 
 	end
 

--- a/garrysmod/lua/vgui/dlabel.lua
+++ b/garrysmod/lua/vgui/dlabel.lua
@@ -123,8 +123,13 @@ function PANEL:PerformLayout()
 
 	self:ApplySchemeSettings()
 
-	if ( self:GetAutoStretchVertical() ) then
+	local curHeight = self:GetTall()
+
+	if ( self:GetAutoStretchVertical() && self.lastAutoStretchSize != curHeight ) then
+
+		self.lastAutoStretchSize = curHeight
 		self:SizeToContentsY()
+
 	end
 
 end

--- a/garrysmod/lua/vgui/dlabel.lua
+++ b/garrysmod/lua/vgui/dlabel.lua
@@ -127,14 +127,10 @@ function PANEL:PerformLayout()
 
 		local dockType = self:GetDock()
 
-		-- Auto stretch will layout infinitely with these dock types, so we'll undo them
+		-- Auto stretch will layout infinitely with these dock types, so we'll ignore them
 		if ( dockType != FILL && dockType != LEFT && dockType != RIGHT ) then
 
 			self:SizeToContentsY()
-
-		else
-
-			self:Dock( NODOCK )
 
 		end
 


### PR DESCRIPTION
Currently, DLabels will constantly try to perform their vertical autostretch behavior on Think, which has a notable performance impact when many panels derived from it are present on screen (such as in a DListView). This PR simply moves this behavior into PerformLayout, forcing these panels to attempt autostretch only when they may actually need to do so.

This also modifies Panel:SizeToContentsY and Panel:SizeToContentsX behavior to cache their last respective contents sizes used in order to avoid constant PerformLayout loops.

Autostretch logic before (measured over 20 seconds):
![image](https://github.com/Facepunch/garrysmod/assets/64441307/b25db66a-f6d5-4bc7-a51d-5b85e78d7f2c)

Autostretch logic after (measured over the same time period):
![image](https://github.com/Facepunch/garrysmod/assets/64441307/717a056e-06a7-4645-b163-93aeb6663ae7)
