### PR TITLE
Implemented hook.Exists function into the hook module

### DIFF
--- a/garrysmod/lua/includes/modules/hook.lua
+++ b/garrysmod/lua/includes/modules/hook.lua
@@ -62,6 +62,25 @@ end
 
 
 --[[---------------------------------------------------------
+    Name: Exists
+    Args: string hookName, identifier
+    Desc: Returns if the hook exists or not
+-----------------------------------------------------------]]
+function Exists( event_name, name )
+
+	if ( !isstring( event_name ) ) then ErrorNoHaltWithStack( "bad argument #1 to 'Exists' (string expected, got " .. type( event_name ) .. ")" ) return end
+
+	local notValid = isnumber( name ) or isbool( name ) or isfunction( name ) or !name.IsValid or !IsValid( name )
+	if ( !isstring( name ) and notValid ) then ErrorNoHaltWithStack( "bad argument #2 to 'Exists' (string expected, got " .. type( name ) .. ")" ) return end
+
+	if ( Hooks[ event_name ] and Hooks[ event_name ][ name ] ) then return true end	--Return true if the hook exists
+
+	return false	--Otherwise return false
+
+end
+
+
+--[[---------------------------------------------------------
     Name: Run
     Args: string hookName, vararg args
     Desc: Calls hooks associated with the hook name.


### PR DESCRIPTION
Summary:
Implemented a simple hook.Exists() function to check if a hook exists or not. I've verified that this function works as intended and that the code is consistent with what is already in the hook module. Args are validated just the same as with other functions already in the module.

Why this was implemented:
This would be a much cleaner and straightforward way to check if a hook exists instead of having to do a work around such as hook.GetTable()[ event_name ][ name ]


Name: Exists
Args: string event_name, string name
Desc: Returns if the hook exists or not

Usage:
```lua
//Check if hook doesn't exist yet
if ( not hook.Exists( "InitPostEntity", "test" ) ) then
	//Add the hook if it doesn't exist
	hook.Add( "InitPostEntity", "test", function()
		print( "howdy!" )
	end )
end

//Check if the hook exists now
if ( hook.Exists( "InitPostEntity", "test" ) ) then
	print( "hook exists" )	//This will print because the hook exists now
end
```
