### PR TITLE
Optimized player.GetBySteamID/player.GetBySteamID64

### DIFF
--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -289,6 +289,10 @@ local sIDCache = {}
 function player.GetBySteamID( ID )
 	ID = string.upper( ID )
 
+	if ( ID == "BOT" ) then
+		return false
+	end
+
 	local cID = util.SteamIDFrom64( ID )
 
 	return sIDCache[cID] or false

--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -317,14 +317,14 @@ local function InvalidatePlayer( ent, fullUpdate )
 
 	if ( isPlayer ) then PlayerCache = nil end
 
-	if fullUpdate or !isPlayer then
+	if ( fullUpdate or not isPlayer ) then
 		return
 	end
 
 	local steamID = ent:SteamID64()
 
 	-- If fullUpdate isn't nil, this player was invalidated by EntityRemoved.
-	if fullUpdate == false then
+	if ( fullUpdate == false ) then
 		sIDCache[steamID] = nil
 	else
 		sIDCache[steamID] = ent

--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -324,7 +324,7 @@ local function InvalidatePlayer( ent, fullUpdate )
 	local steamID = ent:SteamID64()
 
 	-- If fullUpdate isn't nil, this player was invalidated by EntityRemoved.
-	if fullUpdate != nil and !fullUpdate then
+	if fullUpdate == false then
 		sIDCache[steamID] = nil
 	else
 		sIDCache[steamID] = ent
@@ -332,5 +332,5 @@ local function InvalidatePlayer( ent, fullUpdate )
 
 end
 
-hook.Add( "OnEntityCreated", "player.Iterator", InvalidatePlayer )
-hook.Add( "EntityRemoved", "player.Iterator", InvalidatePlayer )
+hook.Add( "OnEntityCreated", "player.Invalidation", InvalidatePlayer )
+hook.Add( "EntityRemoved", "player.Invalidation", InvalidatePlayer )


### PR DESCRIPTION
instead of doing a full loop through player.GetAll, this creates a hashtable and updates it via OnEntityCreated/EntityRemoved

this is a draft PR as its best tested in a multiplayer environment and I can't really do that easily :(