### PR TITLE
Improve util.StringToType

### DIFF
--- a/garrysmod/lua/includes/extensions/util.lua
+++ b/garrysmod/lua/includes/extensions/util.lua
@@ -119,7 +119,8 @@ function util.StringToType( str, typename )
 	if ( typename == "string" )	then return tostring( str ) end
 	if ( typename == "entity" )	then return Entity( str ) end
 	if ( typename == "float" )	then return tonumber( str ) end
-	if ( typename == "int" )	then
+	if ( typename == "int" )	or
+	   ( typename == "number" )	then
 	    local num = tonumber( str )
 	    if ( not num ) then return nil end
 

--- a/garrysmod/lua/includes/extensions/util.lua
+++ b/garrysmod/lua/includes/extensions/util.lua
@@ -114,11 +114,17 @@ function util.StringToType( str, typename )
 
 	if ( typename == "vector" )	then return Vector( str ) end
 	if ( typename == "angle" )	then return Angle( str ) end
-	if ( typename == "float" )	then return tonumber( str ) end
-	if ( typename == "int" )	then return math.Round( tonumber( str ) ) end
 	if ( typename == "bool" )	then return tobool( str ) end
+	if ( typename == "boolean" )	then return tobool( str ) end
 	if ( typename == "string" )	then return tostring( str ) end
 	if ( typename == "entity" )	then return Entity( str ) end
+	if ( typename == "float" )	then return tonumber( str ) end
+	if ( typename == "int" )	then
+	    local num = tonumber( str )
+	    if ( not num ) then return nil end
+
+	    return math.Round( num )
+    end
 
 	MsgN( "util.StringToType: unknown type \"", typename, "\"!" )
 


### PR DESCRIPTION
This PR aims to solve these inconsistencies/issues:

- `type( true )` returns `"boolean"` but `StringToType` takes `"bool"`
- `type( 5 )` returns `"number"` but `StringToType` takes `"int"`
- `util.StringToType` does not handle failed `tonumber` conversions and would error on `math.Round`
  ```
  > print( util.StringToType( "blah", "int" ) )...
  L 07/09/2024 - 16:36:33: Lua Error:
  [ERROR] lua/includes/extensions/math.lua:187: attempt to perform arithmetic on local 'num' (a nil value)
  1. StringToType - lua/includes/extensions/math.lua:187
  2. unknown - lua_run:1
  ```


This PR aims to make it more consistent.

I don't like how I did the formatting but I can't decide on a better way. Suggestions appreciated 👍 


Thanks to superjared42 on Discord