### PR TITLE
Remove duplicate function call from skyeditor

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/entities/edit_sky.lua
+++ b/garrysmod/gamemodes/sandbox/entities/entities/edit_sky.lua
@@ -95,7 +95,6 @@ hook.Add( "PlayerSpawnedSENT", "CopyOverEditSkySettings", function( ply, ent )
 	ent:SetStarTexture( skyPaint:GetStarTexture() )
 	ent:SetStarSpeed( skyPaint:GetStarSpeed() )
 	ent:SetStarFade( skyPaint:GetStarFade() )
-	ent:SetStarFade( skyPaint:GetStarFade() )
 
 	ent:SetDuskIntensity( skyPaint:GetDuskIntensity() )
 	ent:SetDuskScale( skyPaint:GetDuskScale() )


### PR DESCRIPTION
Removes the unecessary duplicate function call of SetStarFade()