### PR TITLE
TTT: Fix Swedish chef language borking itself

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/lang/chef.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/lang/chef.lua
@@ -21,6 +21,8 @@ local function LanguageChanged(old, new)
 
    local eng = LANG.GetUnsafeNamed("english")
    for k, v in pairs(eng) do
+      if k == "language_name" then continue end
+
       L[k] = gsub(v, "[{}%w]+", Borkify)
    end
 


### PR DESCRIPTION
If you open the settings menu, switch the language to Swedish chef, then close and reopen the settings menu, you'll find the Swedish chef option replaced with "Bork". Since Bork isn't a valid language, once you switch languages again you won't be able to switch back to Swedish chef without using the console.

This happens in the process of Borkifying english, where it Borkifies language_name and overwrites the existing entry "Swedish chef" from when the language was initialized.

The fix is to simply ignore language_name during the Borkification process.