### PR TITLE
Allow return true in ENT:PreEntityCopy() to prevent table.Merge in Duplicator Copy

### DIFF
--- a/garrysmod/lua/includes/modules/duplicator.lua
+++ b/garrysmod/lua/includes/modules/duplicator.lua
@@ -131,8 +131,13 @@ local EntitySaver =
 		-- Merge the entities actual table with the table we're saving
 		-- this is terrible behaviour - but it's what we've always done.
 		--
-		if ( ent.PreEntityCopy ) then ent:PreEntityCopy() end
-		table.Merge( data, ent:GetTable() )
+		if ( ent.PreEntityCopy ) then
+			if not ent:PreEntityCopy() then
+				table.Merge( data, ent:GetTable() )
+			end
+		else
+			table.Merge( data, ent:GetTable() )
+		end
 		if ( ent.PostEntityCopy ) then ent:PostEntityCopy() end
 
 		--


### PR DESCRIPTION
This will allow ENT:PreEntityCopy() to prevent the table.Merge in Duplicator

Useful for more complex entities that rely on a specific way of spawning or have alot of cached things that break when duped/made persistant

Fixes issue in one of my addons here https://github.com/SpaxscE/lvs_base/issues/72