### PR TITLE
Use `m_pitch` and `m_yaw` for looking around in the taunt camera

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/player_class/taunt_camera.lua
+++ b/garrysmod/gamemodes/base/gamemode/player_class/taunt_camera.lua
@@ -1,6 +1,9 @@
 
 AddCSLuaFile()
 
+local m_pitch = GetConVar( "m_pitch" )
+local m_yaw = GetConVar( "m_yaw" )
+
 --
 -- This is designed so you can call it like
 --
@@ -104,8 +107,8 @@ function TauntCamera()
 		--
 		-- Rotate our view
 		--
-		CustomAngles.pitch	= CustomAngles.pitch	+ cmd:GetMouseY() * 0.01
-		CustomAngles.yaw	= CustomAngles.yaw		- cmd:GetMouseX() * 0.01
+		CustomAngles.pitch	= CustomAngles.pitch	+ cmd:GetMouseY() * m_pitch:GetFloat()
+		CustomAngles.yaw	= CustomAngles.yaw		- cmd:GetMouseX() * m_yaw:GetFloat()
 
 		--
 		-- Lock the player's controls and angles


### PR DESCRIPTION
This is what's used normally while looking around in-game.
`0.01` is kind of arbitrary, and it leads to a bit of a lower sensitivity while looking through the taunt camera.