### PR TITLE
TTT: Fix and optimize T button rendering

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_tbuttons.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_tbuttons.lua
@@ -20,15 +20,14 @@ function TBHUD:Clear()
 end
 
 function TBHUD:CacheEnts()
+   self.buttons = {}
+
    if IsValid(LocalPlayer()) and LocalPlayer():IsActiveTraitor() then
-      self.buttons = {}
       for _, ent in ipairs(ents.FindByClass("ttt_traitor_button")) do
          if IsValid(ent) then
             self.buttons[ent:EntIndex()] = ent
          end
       end
-   else
-      self.buttons = {}
    end
 
    self.buttons_count = table.Count(self.buttons)
@@ -68,64 +67,56 @@ local tbut_focus = surface.GetTextureID("vgui/ttt/tbut_hand_filled")
 local size = 32
 local mid  = size / 2
 local focus_range = 25
+local focus_d = 0
+local sz = 16
 
 local use_key = Key("+use", "USE")
 
 local GetTranslation = LANG.GetTranslation
 local GetPTranslation = LANG.GetParamTranslation
 function TBHUD:Draw(client)
-   if self.buttons_count != 0 then
-      surface.SetTexture(tbut_normal)
+   if self.buttons_count == 0 then return end
 
-      -- we're doing slowish distance computation here, so lots of probably
-      -- ineffective micro-optimization
-      local plypos = client:GetPos()
-      local midscreen_x = ScrW() / 2
-      local midscreen_y = ScrH() / 2
-      local pos, scrpos, d
-      local focus_ent = nil
-      local focus_d, focus_scrpos_x, focus_scrpos_y = 0, midscreen_x, midscreen_y
+   surface.SetTexture(tbut_normal)
 
-      -- draw icon on HUD for every button within range
-      for k, but in pairs(self.buttons) do
-         if IsValid(but) and but.IsUsable then
-            pos = but:GetPos()
-            scrpos = pos:ToScreen()
+   -- we're doing slowish distance computation here, so lots of probably
+   -- ineffective micro-optimization
+   local plypos = client:GetPos()
+   local midscreen_x = ScrW() / 2
+   local midscreen_y = ScrH() / 2
+   local pos, scrpos, d
+   local focus_ent = nil
+   local focus_scrpos_x, focus_scrpos_y = midscreen_x, midscreen_y
 
-            if (not IsOffScreen(scrpos)) and but:IsUsable() then
-               d = pos - plypos
-               d = d:Dot(d) / (but:GetUsableRange() ^ 2)
-               -- draw if this button is within range, with alpha based on distance
-               if d < 1 then
-                  surface.SetDrawColor(255, 255, 255, 200 * (1 - d))
-                  surface.DrawTexturedRect(scrpos.x - mid, scrpos.y - mid, size, size)
+   -- draw icon on HUD for every button within range
+   for k, but in pairs(self.buttons) do
+      if not IsValid(but) or not but.IsUsable or not but:IsUsable() then continue end
 
-                  if d > focus_d then
-                     local x = abs(scrpos.x - midscreen_x)
-                     local y = abs(scrpos.y - midscreen_y)
-                     if (x < focus_range and y < focus_range and
-                         x < focus_scrpos_x and y < focus_scrpos_y) then
+      pos = but:GetPos()
+      scrpos = pos:ToScreen()
 
-                        -- avoid constantly switching focus every frame causing
-                        -- 2+ buttons to appear in focus, instead "stick" to one
-                        -- ent for a very short time to ensure consistency
-                        if self.focus_stick < CurTime() or but == self.focus_ent then
-                           focus_ent = but
-                        end
-                     end
-                  end
-               end
-            end
-         end
+      if IsOffScreen(scrpos) then continue end
 
-         -- draw extra graphics and information for button when it's in-focus
-         if IsValid(focus_ent) then
+      d = pos - plypos
+      d = d:Dot(d) / (but:GetUsableRange() ^ 2)
+
+      -- draw if this button is within range, with alpha based on distance
+      if d >= 1 then continue end
+
+      if not IsValid(focus_ent) and d > focus_d and (self.focus_stick < CurTime() or but == self.focus_ent) then
+         local x = abs(scrpos.x - midscreen_x)
+         local y = abs(scrpos.y - midscreen_y)
+         if (x < focus_range and y < focus_range and
+             x < focus_scrpos_x and y < focus_scrpos_y) then
+
+            -- draw extra graphics and information for button when it's in-focus
+            focus_ent = but
+
+            -- avoid constantly switching focus every frame causing
+            -- 2+ buttons to appear in focus, instead "stick" to one
+            -- ent for a very short time to ensure consistency
             self.focus_ent = focus_ent
             self.focus_stick = CurTime() + 0.1
-
-            local scrpos = focus_ent:GetPos():ToScreen()
-
-            local sz = 16
 
             -- redraw in-focus version of icon
             surface.SetTexture(tbut_focus)
@@ -136,25 +127,37 @@ function TBHUD:Draw(client)
             surface.SetTextColor(255, 50, 50, 255)
             surface.SetFont("TabLarge")
 
-            local x = scrpos.x + sz + 10
-            local y = scrpos.y - sz - 3
+            x = scrpos.x + sz + 10
+            y = scrpos.y - sz - 3
             surface.SetTextPos(x, y)
             surface.DrawText(focus_ent:GetDescription())
 
             y = y + 12
             surface.SetTextPos(x, y)
-            if focus_ent:GetDelay() < 0 then
+
+            local delay = focus_ent:GetDelay()
+            if delay < 0 then
                surface.DrawText(GetTranslation("tbut_single"))
-            elseif focus_ent:GetDelay() == 0 then
+            elseif delay == 0 then
                surface.DrawText(GetTranslation("tbut_reuse"))
             else
-               surface.DrawText(GetPTranslation("tbut_retime", {num = focus_ent:GetDelay()}))
+               local txt = GetPTranslation("tbut_retime", {num = delay})
+               surface.DrawText(txt)
             end
 
             y = y + 12
             surface.SetTextPos(x, y)
-            surface.DrawText(GetPTranslation("tbut_help", {key = use_key}))
+
+            local txt = GetPTranslation("tbut_help", {key = use_key})
+            surface.DrawText(txt)
+
+            surface.SetTexture(tbut_normal)
+
+            continue
          end
       end
+
+      surface.SetDrawColor(255, 255, 255, 200 * (1 - d))
+      surface.DrawTexturedRect(scrpos.x - mid, scrpos.y - mid, size, size)
    end
 end


### PR DESCRIPTION
There's 4 fixes to this:

### Prevent the highlighted button from redrawing for every button iterated through afterwards
Currently, once focus_ent is set, it won't be unset until the next loop and so the highlighted button will be redrawn for each button the loop iterates through afterwards regardless of whether those other buttons are actually drawn or not.
Instead, moving the highlighted button drawing code to where focus_ent is set and using focus_ent to determine whether the highlighted button checks should be performed will ensure that the highlighted button is drawn only once.
Before |  After
:-------------------------:|:-------------------------:
![image](https://github.com/user-attachments/assets/aedea084-31b0-40d7-b86a-e739542c093a)  |  ![image](https://github.com/user-attachments/assets/b7a145a4-d85f-4821-b5de-d19475ce4039)

### Don't draw an unhighlighted button if that button is highlighted
Move the check to see if a button should be drawn highlighted to before the unhighlighted button is drawn and continue to the next button after the highlighted button has been drawn.

### Reset button texture after drawing a highlighted button so that other buttons don't appear highlighted
Currently, a highlighted button will set texture to the highlighted texture without resetting back to the normal texture afterwards, which causes every button drawn after the highlighted button appear highlighted.
Before |  After
:-------------------------:|:-------------------------:
![image](https://github.com/user-attachments/assets/8f43813a-76c0-4dab-8ae2-1d3be1eaac20)  |  ![image](https://github.com/user-attachments/assets/7249adc2-a089-4680-aa94-8f94b3f6d374)

### Fix param translation text causing forced additive rendering
LANG.GetParamTranslation returns 2 values: the string itself and the number of replacements made to reach the final string. In both uses of GetParamTranslation in this case, the second argument is 1. This wasn't an issue until the October 2020 update added the forceAdditive argument to surface.DrawText, which causes the "Reusable after X seconds" and "Press E to activate" text to be rendered additive. The solution is to separate the first return value into its own variable and use that in DrawText.
Before |  After
:-------------------------:|:-------------------------:
![image](https://github.com/user-attachments/assets/b79c5b38-bedf-4d01-936f-5e6ec81b6e8d)  | ![image](https://github.com/user-attachments/assets/3d9fa818-3e79-47e7-9c1c-43b8cea86e4f)