### PR TITLE
Fix LocalPlayer MouthMoveAnimation

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/animations.lua
+++ b/garrysmod/gamemodes/base/gamemode/animations.lua
@@ -283,7 +283,7 @@ function GM:MouthMoveAnimation( ply )
 		ply:GetFlexIDByName( "right_mouth_drop" )
 	}
 
-	local weight = ply:IsSpeaking() && math.Clamp( ply:VoiceVolume() * 2, 0, 2 ) || 0
+	local weight = ply:IsSpeaking() && ( ply == LocalPlayer() and 1 or math.Clamp( ply:VoiceVolume() * 2, 0, 2 ) ) || 0
 
 	for k, v in ipairs( flexes ) do
 


### PR DESCRIPTION
`Player:VoiceVolume` doesn't work on local player unless the voice_loopback convar is set to 1.