### PR TITLE
Update Team Fortress 2 map categories (tow_)

### DIFF
--- a/garrysmod/lua/menu/getmaps.lua
+++ b/garrysmod/lua/menu/getmaps.lua
@@ -181,6 +181,7 @@ local function UpdateMaps()
 	MapNames[ "pass_" ] = "Team Fortress 2"
 	MapNames[ "vsh_" ] = "Team Fortress 2"
 	MapNames[ "zi_" ] = "Team Fortress 2"
+	MapNames[ "tow_" ] = "Team Fortress 2"
 
 	MapNames[ "zpa_" ] = "Zombie Panic! Source"
 	MapNames[ "zpl_" ] = "Zombie Panic! Source"


### PR DESCRIPTION
This year's Scream Fortress update came along again, and with it a new map category, `tow_`. This commit makes the "other" category empty again by adding it, like [my](https://github.com/Facepunch/garrysmod/pull/2017) [previous](https://github.com/Facepunch/garrysmod/pull/2013) [three](https://github.com/Facepunch/garrysmod/pull/1996) similar pull requests.