### PR TITLE
TTT: Fix DoPlayerDeath not running twice on DyingShot

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/player.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player.lua
@@ -570,22 +570,19 @@ local function CheckCreditAward(victim, attacker)
 end
 
 function GM:DoPlayerDeath(ply, attacker, dmginfo)
-   if ply:IsSpec() then return end
+   if ply:IsSpec() or IsValid(ply.dying_wep) then return end
 
    -- Experimental: Fire a last shot if ironsighting and not headshot
    if GetConVar("ttt_dyingshot"):GetBool() then
       local wep = ply:GetActiveWeapon()
       if IsValid(wep) and wep.DyingShot and not ply.was_headshot and dmginfo:IsBulletDamage() then
-         local fired = wep:DyingShot()
-         if fired then
-            return
-         end
+         wep:DyingShot()
       end
 
       -- Note that funny things can happen here because we fire a gun while the
-      -- player is dead. Specifically, this DoPlayerDeath is run twice for
-      -- him. This is ugly, and we have to return the first one to prevent crazy
-      -- shit.
+      -- player is dead. Specifically, this DoPlayerDeath can run twice for
+      -- him. This is ugly, and we have to return if ply.dying_wep is set
+      -- to prevent crazy shit.
    end
 
    -- Drop all weapons


### PR DESCRIPTION
I've noticed that, if the TTT Dyingshot feature is enabled and a shot is fired, the player/victims ragdoll does not get created.

The way this check is written currently is bad practice.
It returns if Dyingshot is executed successfully and expects the Function to run again.

However this is (no longer?) the Case.

With this fix the first DoPlayerDeath function runs fully and prevent any future triggers.
We can do this by checking if ply.dying_wep is set, this being a RoundFlag it is reset on player (re)spawns