### PR TITLE
Add spawnicon safe check in new SWEP autorefresh thing to prevent errors with certain addons

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/weapons.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/weapons.lua
@@ -105,6 +105,8 @@ local function AutorefreshWeaponToSpawnmenu( weapon, name )
 		if ( !IsValid( catPnl.PropPanel ) ) then continue end
 
 		for _, icon in pairs( catPnl.PropPanel.IconList:GetChildren() ) do
+			if ( icon:GetName() != "ContentIcon" ) then continue end
+
 			if ( icon:GetSpawnName() == name ) then
 				icon:Remove()
 			end


### PR DESCRIPTION
One of latest commits https://github.com/Facepunch/garrysmod/commit/7143ab7bf4503a629528e28642a519e11c5488b6 made editing any swep lua produce an error related to it:
`[ERROR] gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/weapons.lua:108: attempt to call method 'GetSpawnName' (a nil value)`

Happens only if some addon added a `ContentHeader` into `PropPanel.IconList` of weapons (to act like sub-categories) - [ARC9](https://steamcommunity.com/sharedfiles/filedetails/?id=2910505837) and [Modern Warfare](https://steamcommunity.com/workshop/filedetails/?id=2459720887) weapon bases do that

Easiest way to reproduce an error is to get those two addons - [swep base](https://steamcommunity.com/sharedfiles/filedetails/?id=2910505837) and [swep pack](https://steamcommunity.com/sharedfiles/filedetails/?id=3098824960) then open weapon pack category and try to reload any (even base game) swep lua file

https://github.com/user-attachments/assets/0979eb19-40a0-4591-b2f8-d616a4e41adf


It errors because new code blindly checks for GetSpawnName() of each dpanel children, expecting them to be only `ContentIcon`s while mentioned addons also add `ContentHeader` into lists, this PR adds one line to check for presumably "icon" to be a `ContentIcon`

If SWEP or SENT sub-categories would ever be in base game (just like them being in prop lists), current code will also produce that error