### PR TITLE
TTT: Allow workshop addons to pack rearm scripts

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/ent_replace.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/ent_replace.lua
@@ -487,14 +487,21 @@ function ents.TTT.CanImportEntities(map)
    if not GetConVar("ttt_use_weapon_spawn_scripts"):GetBool() then return false end
 
    local fname = "maps/" .. map .. "_ttt.txt"
+   if file.Exists(fname, "GAME") then
+      return fname
+   end
 
-   return file.Exists(fname, "GAME")
+   -- Allows workshop addons to pack rearm scripts
+   fname = "data_static/" .. map .. "_ttt.txt"
+   if file.Exists(fname, "GAME") then
+      return fname
+   end
 end
 
 local function ImportSettings(map)
-   if not ents.TTT.CanImportEntities(map) then return end
+   local fname = ents.TTT.CanImportEntities(map)
+   if not fname then return end
 
-   local fname = "maps/" .. map .. "_ttt.txt"
    local buf = file.Read(fname, "GAME")
 
    local settings = {}
@@ -521,9 +528,8 @@ local classremap = {
 };
 
 local function ImportEntities(map)
-   if not ents.TTT.CanImportEntities(map) then return end
-
-   local fname = "maps/" .. map .. "_ttt.txt"
+   local fname = ents.TTT.CanImportEntities(map)
+   if not fname then return end
 
    local num = 0
    for k, line in ipairs(string.Explode("\n", file.Read(fname, "GAME"))) do


### PR DESCRIPTION
Last year, the change was made to blacklist any data files from being included in a workshop addon unless they were in the data_static folder.

Before this, workshop addons [like this one](https://steamcommunity.com/sharedfiles/filedetails/?id=1812199726) were able to pack rearm scripts along with the map so that (for example, in the case of that addon) a workshop reupload of a map could bundle in additional spawns without having to decompile and place them manually, and without having to get players to download the rearm script externally.

Now, only legacy addons uploaded or updated before this change are allowed to keep packing a rearm script in the maps folder. This PR simply checks the data_static folder for a ream script if one isn't found in the maps folder.

If you'd like to test the workshop integration, I've set up a test addon here: https://steamcommunity.com/sharedfiles/filedetails/?id=3353238626

If this is merged, you'll probably also want to update [the rearm script tutorial on the TTT website](https://www.troubleinterroristtown.com/development/rearm/) to either mention data_static as an alternative to maps, or to give a tutorial on packing rearm scripts into a workshop addon. Depends on how much effort you feel like putting in.