### PR TITLE
Add 2 convars: cl_show_shiftesc_hint and cl_show_error_duration

### DIFF
--- a/garrysmod/lua/menu/errors.lua
+++ b/garrysmod/lua/menu/errors.lua
@@ -1,5 +1,5 @@
-local cl_show_shiftesc_hint = CreateClientConVar( "cl_show_shiftesc_hint", "1", true, false, "Show notification about Shift+ESC" )
-local cl_show_error_duration = CreateClientConVar( "cl_show_error_duration", "10", true, false, "For how many seconds error banner will be displayed", 1, 30 )
+local cl_show_shiftesc_hint = CreateClientConVar( "cl_show_shiftesc_hint", "1", true, false, "Show notification about Shift+ESC after pressing ESC too many times" )
+local cl_show_error_duration = CreateClientConVar( "cl_show_error_duration", "10", true, false, "For how many seconds the error banner will be displayed", 1, 30 )
 
 --
 -- Here we get a callback from the game/client code on Lua errors, and display a nice notification.


### PR DESCRIPTION
`cl_show_shiftesc_hint`- 0/1 - Show notification about Shift+ESC after pressing ESC too many times
`cl_show_error_duration` - 1-30, default 10 - For how many seconds the error banner will be displayed

Convars should be added to the blocklist https://wiki.facepunch.com/gmod/Blocked_ConCommands