### PR TITLE
More Spawn Menu Customization

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenticon.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenticon.lua
@@ -100,29 +100,21 @@ function PANEL:DoRightClick()
 	self:OpenMenu()
 
 	local openedMenus = GetOpenDermaMenus()
-	local newMenuCount = #openedMenus
 
-	local menuIndex = newMenuCount == oldMenuCount and oldMenuCount or oldMenuCount + 1
+	local menuIndex = #openedMenus == oldMenuCount and oldMenuCount or oldMenuCount + 1
 	local menu = openedMenus[ menuIndex ]
 
 	if ( !IsValid( menu ) ) then return end
 
-	--
-	-- Get the correct derma menu
-	-- Each option in a derma menu is a derma menu itself
-	--
-	while ( IsValid( menu.ParentMenu ) ) do
-		
-		menuIndex = menuIndex - 1
-		menu = openedMenus[ menuIndex ]
+	local parent = menu.ParentMenu
+
+	if ( IsValid( parent ) ) then
+
+		menu = parent
 
 	end
 
-	if ( IsValid( menu ) ) then
-
-		hook.Run( "OnContentIconOpenMenu", self, menu )
-
-	end
+	hook.Run( "OnContentIconOpenMenu", self, menu )
 
 end
 

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenticon.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenticon.lua
@@ -90,20 +90,34 @@ end
 function PANEL:DoRightClick()
 
 	local pCanvas = self:GetSelectionCanvas()
+
 	if ( IsValid( pCanvas ) && pCanvas:NumSelectedChildren() > 0 && self:IsSelected() ) then
 		return hook.Run( "SpawnlistOpenGenericMenu", pCanvas )
 	end
 
-	local openedMenus = GetOpenDermaMenus()
-	local menuCount = #openedMenus
+	local oldMenuCount = #GetOpenDermaMenus()
 
 	self:OpenMenu()
 
-	local menu = openedMenus[ menuCount + 1 ]
+	local openedMenus = GetOpenDermaMenus()
+	local newMenuCount = #openedMenus
+
+	local menuIndex = newMenuCount == oldMenuCount and oldMenuCount or oldMenuCount + 1
+	local menu = openedMenus[ menuIndex ]
+
+	if ( !IsValid( menu ) ) then return end
 
 	--
-	-- Allow addons to easily add their own options to the opened menu
+	-- Get the correct derma menu
+	-- Each option in a derma menu is a derma menu itself
 	--
+	while ( IsValid( menu.ParentMenu ) ) do
+		
+		menuIndex = menuIndex - 1
+		menu = openedMenus[ menuIndex ]
+
+	end
+
 	if ( IsValid( menu ) ) then
 
 		hook.Run( "OnContentIconOpenMenu", self, menu )

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenticon.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenticon.lua
@@ -94,7 +94,21 @@ function PANEL:DoRightClick()
 		return hook.Run( "SpawnlistOpenGenericMenu", pCanvas )
 	end
 
+	local openedMenus = GetOpenDermaMenus()
+	local menuCount = #openedMenus
+
 	self:OpenMenu()
+
+	local menu = openedMenus[ menuCount + 1 ]
+
+	--
+	-- Allow addons to easily add their own options to the opened menu
+	--
+	if ( IsValid( menu ) ) then
+
+		hook.Run( "OnContentIconOpenMenu", self, menu )
+
+	end
 
 end
 

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/entities.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/entities.lua
@@ -9,24 +9,33 @@ hook.Add( "PopulateEntities", "AddEntityContent", function( pnlContent, tree, br
 
 	-- Add this list into the tormoil
 	local SpawnableEntities = list.Get( "SpawnableEntities" )
+
 	if ( SpawnableEntities ) then
+		
 		for k, v in pairs( SpawnableEntities ) do
 
 			local Category = v.Category or "Other"
-			if ( !isstring( Category ) ) then Category = tostring( Category ) end
-			Categorised[ Category ] = Categorised[ Category ] or {}
+			Category = tostring( Category )
+	
+			local SubCategory = v.SubCategory or "Other"
+			SubCategory = tostring( SubCategory )
 
 			v.SpawnName = k
-			table.insert( Categorised[ Category ], v )
+	
+			Categorised[ Category ] = Categorised[ Category ] or {}
+			Categorised[ Category ][ SubCategory ] = Categorised[ Category ][ SubCategory ] or {}
+	
+			table.insert( Categorised[ Category ][ SubCategory ], v )
 
 		end
+
 	end
 
 	--
 	-- Add a tree node for each category
 	--
 	local CustomIcons = list.Get( "ContentCategoryIcons" )
-	for CategoryName, v in SortedPairs( Categorised ) do
+	for CategoryName, subCategories in SortedPairs( Categorised ) do
 
 		-- Add a node to the tree
 		local node = tree:AddNode( CategoryName, CustomIcons[ CategoryName ] or "icon16/bricks.png" )
@@ -42,14 +51,55 @@ hook.Add( "PopulateEntities", "AddEntityContent", function( pnlContent, tree, br
 			self.PropPanel:SetVisible( false )
 			self.PropPanel:SetTriggerSpawnlistChange( false )
 
-			for k, ent in SortedPairsByMemberValue( v, "PrintName" ) do
+			local createOtherHeader = false
 
-				spawnmenu.CreateContentIcon( ent.ScriptedEntityType or "entity", self.PropPanel, {
-					nicename	= ent.PrintName or ent.ClassName,
-					spawnname	= ent.SpawnName,
-					material	= ent.IconOverride or ( "entities/" .. ent.SpawnName .. ".png" ),
-					admin		= ent.AdminOnly
-				} )
+			for subCategoryName, tab in SortedPairs( subCategories ) do
+
+				if ( subCategoryName == "Other" ) then continue end
+
+				local label = vgui.Create( "ContentHeader" )
+
+				label:SetText( subCategoryName )
+
+				self.PropPanel:Add( label )
+
+				for k, ent in SortedPairsByMemberValue( tab, "PrintName" ) do
+
+					spawnmenu.CreateContentIcon( ent.ScriptedEntityType or "entity", self.PropPanel, {
+						nicename	= ent.PrintName or ent.ClassName,
+						spawnname	= ent.SpawnName,
+						material	= ent.IconOverride or ( "entities/" .. ent.SpawnName .. ".png" ),
+						admin		= ent.AdminOnly
+					} )
+	
+				end
+
+				createOtherHeader = true
+
+			end
+
+			if ( subCategories.Other ) then
+
+				if ( createOtherHeader ) then
+
+					local label = vgui.Create( "ContentHeader" )
+
+					label:SetText( "Other" )
+
+					self.PropPanel:Add( label )
+
+				end
+
+				for k, ent in SortedPairsByMemberValue( subCategories.Other, "PrintName" ) do
+
+					spawnmenu.CreateContentIcon( ent.ScriptedEntityType or "entity", self.PropPanel, {
+						nicename	= ent.PrintName or ent.ClassName,
+						spawnname	= ent.SpawnName,
+						material	= ent.IconOverride or ( "entities/" .. ent.SpawnName .. ".png" ),
+						admin		= ent.AdminOnly
+					} )
+	
+				end
 
 			end
 

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/entities.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/entities.lua
@@ -3,6 +3,39 @@ list.Set( "ContentCategoryIcons", "Half-Life: Source", "games/16/hl1.png" )
 list.Set( "ContentCategoryIcons", "Half-Life 2", "games/16/hl2.png" )
 list.Set( "ContentCategoryIcons", "Portal", "games/16/portal.png" )
 
+local function BuildContentList( tab, propPanel )
+
+	local orderedList = {}
+
+	for k, ent in SortedPairsByMemberValue( tab, "PrintName" ) do
+
+		local order = isnumber( ent.SpawnListOrder ) and ent.SpawnListOrder
+
+		if ( order ) then
+
+			table.insert( orderedList, order, ent )
+
+		else
+			
+			table.insert( orderedList, ent )
+
+		end
+
+	end
+
+	for k, ent in SortedPairs( orderedList ) do
+
+		spawnmenu.CreateContentIcon( ent.ScriptedEntityType or "entity", propPanel, {
+			nicename	= ent.PrintName or ent.ClassName,
+			spawnname	= ent.SpawnName,
+			material	= ent.IconOverride or ( "entities/" .. ent.SpawnName .. ".png" ),
+			admin		= ent.AdminOnly
+		} )
+		
+	end
+
+end
+
 hook.Add( "PopulateEntities", "AddEntityContent", function( pnlContent, tree, browseNode )
 
 	local Categorised = {}
@@ -11,7 +44,6 @@ hook.Add( "PopulateEntities", "AddEntityContent", function( pnlContent, tree, br
 	local SpawnableEntities = list.Get( "SpawnableEntities" )
 
 	if ( SpawnableEntities ) then
-		
 		for k, v in pairs( SpawnableEntities ) do
 
 			local Category = v.Category or "Other"
@@ -28,7 +60,6 @@ hook.Add( "PopulateEntities", "AddEntityContent", function( pnlContent, tree, br
 			table.insert( Categorised[ Category ][ SubCategory ], v )
 
 		end
-
 	end
 
 	--
@@ -63,16 +94,7 @@ hook.Add( "PopulateEntities", "AddEntityContent", function( pnlContent, tree, br
 
 				self.PropPanel:Add( label )
 
-				for k, ent in SortedPairsByMemberValue( tab, "PrintName" ) do
-
-					spawnmenu.CreateContentIcon( ent.ScriptedEntityType or "entity", self.PropPanel, {
-						nicename	= ent.PrintName or ent.ClassName,
-						spawnname	= ent.SpawnName,
-						material	= ent.IconOverride or ( "entities/" .. ent.SpawnName .. ".png" ),
-						admin		= ent.AdminOnly
-					} )
-	
-				end
+				BuildContentList( tab, self.PropPanel )
 
 				createOtherHeader = true
 
@@ -90,16 +112,7 @@ hook.Add( "PopulateEntities", "AddEntityContent", function( pnlContent, tree, br
 
 				end
 
-				for k, ent in SortedPairsByMemberValue( subCategories.Other, "PrintName" ) do
-
-					spawnmenu.CreateContentIcon( ent.ScriptedEntityType or "entity", self.PropPanel, {
-						nicename	= ent.PrintName or ent.ClassName,
-						spawnname	= ent.SpawnName,
-						material	= ent.IconOverride or ( "entities/" .. ent.SpawnName .. ".png" ),
-						admin		= ent.AdminOnly
-					} )
-	
-				end
+				BuildContentList( subCategories.Other, self.PropPanel )
 
 			end
 

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/npcs.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/npcs.lua
@@ -6,20 +6,28 @@ hook.Add( "PopulateNPCs", "AddNPCContent", function( pnlContent, tree, browseNod
 
 	-- Categorize them
 	local Categories = {}
+
 	for k, v in pairs( NPCList ) do
 
 		local Category = v.Category or "Other"
-		if ( !isstring( Category ) ) then Category = tostring( Category ) end
+		Category = tostring( Category )
+
+		local SubCategory = v.SubCategory or "Other"
+		SubCategory = tostring( SubCategory )
 
 		local Tab = Categories[ Category ] or {}
-		Tab[ k ] = v
+		local subCategoryTab = Tab[ SubCategory ] or {}
+
+		subCategoryTab[ k ] = v
+
+		Tab[ SubCategory ] = subCategoryTab
 		Categories[ Category ] = Tab
 
 	end
 
 	-- Create an icon for each one and put them on the panel
 	local CustomIcons = list.Get( "ContentCategoryIcons" )
-	for CategoryName, v in SortedPairs( Categories ) do
+	for CategoryName, subCategories in SortedPairs( Categories ) do
 
 		-- Add a node to the tree
 		local node = tree:AddNode( CategoryName, CustomIcons[ CategoryName ] or "icon16/monkey.png" )
@@ -35,15 +43,57 @@ hook.Add( "PopulateNPCs", "AddNPCContent", function( pnlContent, tree, browseNod
 			self.PropPanel:SetVisible( false )
 			self.PropPanel:SetTriggerSpawnlistChange( false )
 
-			for name, ent in SortedPairsByMemberValue( v, "Name" ) do
+			local createOtherHeader = false
 
-				spawnmenu.CreateContentIcon( ent.ScriptedEntityType or "npc", self.PropPanel, {
-					nicename	= ent.Name or name,
-					spawnname	= name,
-					material	= ent.IconOverride or "entities/" .. name .. ".png",
-					weapon		= ent.Weapons,
-					admin		= ent.AdminOnly
-				} )
+			for subCategoryName, tab in SortedPairs( subCategories ) do
+
+				if ( subCategoryName == "Other" ) then continue end
+
+				local label = vgui.Create( "ContentHeader" )
+
+				label:SetText( subCategoryName )
+
+				self.PropPanel:Add( label )
+
+				for name, ent in SortedPairsByMemberValue( tab, "Name" ) do
+
+					spawnmenu.CreateContentIcon( ent.ScriptedEntityType or "npc", self.PropPanel, {
+						nicename	= ent.Name or name,
+						spawnname	= name,
+						material	= ent.IconOverride or "entities/" .. name .. ".png",
+						weapon		= ent.Weapons,
+						admin		= ent.AdminOnly
+					} )
+
+				end
+
+				createOtherHeader = true
+
+			end
+
+			if ( subCategories.Other ) then
+
+				if ( createOtherHeader ) then
+
+					local label = vgui.Create( "ContentHeader" )
+
+					label:SetText( "Other" )
+
+					self.PropPanel:Add( label )
+
+				end
+
+				for name, ent in SortedPairsByMemberValue( subCategories.Other, "Name" ) do
+
+					spawnmenu.CreateContentIcon( ent.ScriptedEntityType or "npc", self.PropPanel, {
+						nicename	= ent.Name or name,
+						spawnname	= name,
+						material	= ent.IconOverride or "entities/" .. name .. ".png",
+						weapon		= ent.Weapons,
+						admin		= ent.AdminOnly
+					} )
+
+				end
 
 			end
 

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/npcs.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/npcs.lua
@@ -1,4 +1,42 @@
 
+local function BuildContentList( tab, propPanel )
+
+	local orderedList = {}
+
+	for name, ent in SortedPairsByMemberValue( tab, "Name" ) do
+
+		local order = isnumber( ent.SpawnListOrder ) and ent.SpawnListOrder
+		local data = { name = name, ent = ent }
+
+		if ( order ) then
+
+			table.insert( orderedList, order, data )
+
+		else
+			
+			table.insert( orderedList, data )
+
+		end
+
+	end
+
+	for k, data in SortedPairs( orderedList ) do
+
+		local ent = data.ent
+		local name = data.name
+
+		spawnmenu.CreateContentIcon( ent.ScriptedEntityType or "npc", propPanel, {
+			nicename	= ent.Name or name,
+			spawnname	= name,
+			material	= ent.IconOverride or "entities/" .. name .. ".png",
+			weapon		= ent.Weapons,
+			admin		= ent.AdminOnly
+		} )
+
+	end
+
+end
+
 hook.Add( "PopulateNPCs", "AddNPCContent", function( pnlContent, tree, browseNode )
 
 	-- Get a list of available NPCs
@@ -55,17 +93,7 @@ hook.Add( "PopulateNPCs", "AddNPCContent", function( pnlContent, tree, browseNod
 
 				self.PropPanel:Add( label )
 
-				for name, ent in SortedPairsByMemberValue( tab, "Name" ) do
-
-					spawnmenu.CreateContentIcon( ent.ScriptedEntityType or "npc", self.PropPanel, {
-						nicename	= ent.Name or name,
-						spawnname	= name,
-						material	= ent.IconOverride or "entities/" .. name .. ".png",
-						weapon		= ent.Weapons,
-						admin		= ent.AdminOnly
-					} )
-
-				end
+				BuildContentList( tab, self.PropPanel )
 
 				createOtherHeader = true
 
@@ -83,17 +111,7 @@ hook.Add( "PopulateNPCs", "AddNPCContent", function( pnlContent, tree, browseNod
 
 				end
 
-				for name, ent in SortedPairsByMemberValue( subCategories.Other, "Name" ) do
-
-					spawnmenu.CreateContentIcon( ent.ScriptedEntityType or "npc", self.PropPanel, {
-						nicename	= ent.Name or name,
-						spawnname	= name,
-						material	= ent.IconOverride or "entities/" .. name .. ".png",
-						weapon		= ent.Weapons,
-						admin		= ent.AdminOnly
-					} )
-
-				end
+				BuildContentList( subCategories.Other, self.PropPanel )
 
 			end
 

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/vehicles.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/vehicles.lua
@@ -1,4 +1,37 @@
 
+local function BuildContentList( tab, propPanel )
+
+	local orderedList = {}
+
+	for k, ent in SortedPairsByMemberValue( tab, "PrintName" ) do
+
+		local order = isnumber( ent.SpawnListOrder ) and ent.SpawnListOrder
+
+		if ( order ) then
+
+			table.insert( orderedList, order, ent )
+
+		else
+			
+			table.insert( orderedList, ent )
+
+		end
+
+	end
+
+	for k, ent in SortedPairs( orderedList ) do
+
+		spawnmenu.CreateContentIcon( ent.ScriptedEntityType or "entity", propPanel, {
+			nicename	= ent.PrintName or ent.ClassName,
+			spawnname	= ent.ClassName,
+			material	= ent.IconOverride or "entities/" .. ent.ClassName .. ".png",
+			admin		= ent.AdminOnly
+		} )
+
+	end
+
+end
+
 hook.Add( "PopulateVehicles", "AddEntityContent", function( pnlContent, tree, browseNode )
 
 	-- Add this list into the tormoil
@@ -61,16 +94,7 @@ hook.Add( "PopulateVehicles", "AddEntityContent", function( pnlContent, tree, br
 
 				self.PropPanel:Add( label )
 
-				for k, ent in SortedPairsByMemberValue( tab, "PrintName" ) do
-
-					spawnmenu.CreateContentIcon( ent.ScriptedEntityType or "entity", self.PropPanel, {
-						nicename	= ent.PrintName or ent.ClassName,
-						spawnname	= ent.ClassName,
-						material	= ent.IconOverride or "entities/" .. ent.ClassName .. ".png",
-						admin		= ent.AdminOnly
-					} )
-	
-				end
+				BuildContentList( tab, self.PropPanel )
 
 				createOtherHeader = true
 
@@ -88,16 +112,7 @@ hook.Add( "PopulateVehicles", "AddEntityContent", function( pnlContent, tree, br
 
 				end
 
-				for k, ent in SortedPairsByMemberValue( subCategories.Other, "PrintName" ) do
-
-					spawnmenu.CreateContentIcon( ent.ScriptedEntityType or "entity", self.PropPanel, {
-						nicename	= ent.PrintName or ent.ClassName,
-						spawnname	= ent.ClassName,
-						material	= ent.IconOverride or "entities/" .. ent.ClassName .. ".png",
-						admin		= ent.AdminOnly
-					} )
-					
-				end
+				BuildContentList( subCategories.Other, self.PropPanel )
 
 			end
 

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/vehicles.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/vehicles.lua
@@ -1,35 +1,44 @@
 
 hook.Add( "PopulateVehicles", "AddEntityContent", function( pnlContent, tree, browseNode )
 
-	local Categorised = {}
-
 	-- Add this list into the tormoil
 	local Vehicles = list.Get( "Vehicles" )
+	local Categorised = {}
+
 	if ( Vehicles ) then
+
 		for k, v in pairs( Vehicles ) do
 
 			local Category = v.Category or "Other"
-			if ( !isstring( Category ) ) then Category = tostring( Category ) end
-			Categorised[ Category ] = Categorised[ Category ] or {}
+			Category = tostring( Category )
+	
+			local SubCategory = v.SubCategory or "Other"
+			SubCategory = tostring( SubCategory )
 
 			v.ClassName = k
 			v.PrintName = v.Name
 			v.ScriptedEntityType = "vehicle"
-			table.insert( Categorised[ Category ], v )
+
+			Categorised[ Category ] = Categorised[ Category ] or {}
+			Categorised[ Category ][ SubCategory ] = Categorised[ Category ][ SubCategory ] or {}
+
+			table.insert( Categorised[ Category ][ SubCategory ], v )
 
 		end
+
 	end
 
 	--
 	-- Add a tree node for each category
 	--
 	local CustomIcons = list.Get( "ContentCategoryIcons" )
-	for CategoryName, v in SortedPairs( Categorised ) do
+
+	for CategoryName, subCategories in SortedPairs( Categorised ) do
 
 		-- Add a node to the tree
 		local node = tree:AddNode( CategoryName, CustomIcons[ CategoryName ] or "icon16/bricks.png" )
 
-			-- When we click on the node - populate it using this function
+		-- When we click on the node - populate it using this function
 		node.DoPopulate = function( self )
 
 			-- If we've already populated it - forget it.
@@ -40,14 +49,55 @@ hook.Add( "PopulateVehicles", "AddEntityContent", function( pnlContent, tree, br
 			self.PropPanel:SetVisible( false )
 			self.PropPanel:SetTriggerSpawnlistChange( false )
 
-			for k, ent in SortedPairsByMemberValue( v, "PrintName" ) do
+			local createOtherHeader = false
 
-				spawnmenu.CreateContentIcon( ent.ScriptedEntityType or "entity", self.PropPanel, {
-					nicename	= ent.PrintName or ent.ClassName,
-					spawnname	= ent.ClassName,
-					material	= ent.IconOverride or "entities/" .. ent.ClassName .. ".png",
-					admin		= ent.AdminOnly
-				} )
+			for subCategoryName, tab in SortedPairs( subCategories ) do
+
+				if ( subCategoryName == "Other" ) then continue end
+
+				local label = vgui.Create( "ContentHeader" )
+
+				label:SetText( subCategoryName )
+
+				self.PropPanel:Add( label )
+
+				for k, ent in SortedPairsByMemberValue( tab, "PrintName" ) do
+
+					spawnmenu.CreateContentIcon( ent.ScriptedEntityType or "entity", self.PropPanel, {
+						nicename	= ent.PrintName or ent.ClassName,
+						spawnname	= ent.ClassName,
+						material	= ent.IconOverride or "entities/" .. ent.ClassName .. ".png",
+						admin		= ent.AdminOnly
+					} )
+	
+				end
+
+				createOtherHeader = true
+
+			end
+
+			if ( subCategories.Other ) then
+
+				if ( createOtherHeader ) then
+
+					local label = vgui.Create( "ContentHeader" )
+
+					label:SetText( "Other" )
+
+					self.PropPanel:Add( label )
+
+				end
+
+				for k, ent in SortedPairsByMemberValue( subCategories.Other, "PrintName" ) do
+
+					spawnmenu.CreateContentIcon( ent.ScriptedEntityType or "entity", self.PropPanel, {
+						nicename	= ent.PrintName or ent.ClassName,
+						spawnname	= ent.ClassName,
+						material	= ent.IconOverride or "entities/" .. ent.ClassName .. ".png",
+						admin		= ent.AdminOnly
+					} )
+					
+				end
 
 			end
 

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/weapons.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/weapons.lua
@@ -24,6 +24,39 @@ local function BuildWeaponCategories()
 	return Categorised
 end
 
+local function BuildContentList( tab, propPanel )
+
+	local orderedList = {}
+
+	for k, ent in SortedPairsByMemberValue( tab, "PrintName" ) do
+
+		local order = isnumber( ent.SpawnListOrder ) and ent.SpawnListOrder
+
+		if ( order ) then
+
+			table.insert( orderedList, order, ent )
+
+		else
+			
+			table.insert( orderedList, ent )
+
+		end
+
+	end
+
+	for k, ent in SortedPairs( orderedList ) do
+
+		spawnmenu.CreateContentIcon( ent.ScriptedEntityType or "weapon", propPanel, {
+			nicename	= ent.PrintName or ent.ClassName,
+			spawnname	= ent.ClassName,
+			material	= ent.IconOverride or ( "entities/" .. ent.ClassName .. ".png" ),
+			admin		= ent.AdminOnly
+		} )
+
+	end
+
+end
+
 local function AddCategory( tree, cat )
 	local CustomIcons = list.Get( "ContentCategoryIcons" )
 
@@ -55,16 +88,7 @@ local function AddCategory( tree, cat )
 
 			self.PropPanel:Add( label )
 
-			for k, ent in SortedPairsByMemberValue( weps, "PrintName" ) do
-
-				spawnmenu.CreateContentIcon( ent.ScriptedEntityType or "weapon", self.PropPanel, {
-					nicename	= ent.PrintName or ent.ClassName,
-					spawnname	= ent.ClassName,
-					material	= ent.IconOverride or ( "entities/" .. ent.ClassName .. ".png" ),
-					admin		= ent.AdminOnly
-				} )
-	
-			end
+			BuildContentList( weps, self.PropPanel )
 
 			createOtherHeader = true
 
@@ -82,16 +106,7 @@ local function AddCategory( tree, cat )
 
 			end
 
-			for name, ent in SortedPairsByMemberValue( subCategories.Other, "Name" ) do
-
-				spawnmenu.CreateContentIcon( ent.ScriptedEntityType or "weapon", self.PropPanel, {
-					nicename	= ent.PrintName or ent.ClassName,
-					spawnname	= ent.ClassName,
-					material	= ent.IconOverride or ( "entities/" .. ent.ClassName .. ".png" ),
-					admin		= ent.AdminOnly
-				} )
-
-			end
+			BuildContentList( subCategories.Other, self.PropPanel )
 
 		end
 

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/weapons.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/weapons.lua
@@ -9,10 +9,15 @@ local function BuildWeaponCategories()
 		if ( !weapon.Spawnable ) then continue end
 
 		local Category = weapon.Category or "Other"
-		if ( !isstring( Category ) ) then Category = tostring( Category ) end
+		Category = tostring( Category )
+
+		local SubCategory = weapon.SubCategory or "Other"
+		SubCategory = tostring( SubCategory )
 
 		Categorised[ Category ] = Categorised[ Category ] or {}
-		table.insert( Categorised[ Category ], weapon )
+		Categorised[ Category ][ SubCategory ] = Categorised[ Category ][ SubCategory ] or {}
+
+		table.insert( Categorised[ Category ][ SubCategory ], weapon )
 
 	end
 
@@ -37,15 +42,56 @@ local function AddCategory( tree, cat )
 		self.PropPanel:SetVisible( false )
 		self.PropPanel:SetTriggerSpawnlistChange( false )
 
-		local weps = BuildWeaponCategories()[ cat ]
-		for k, ent in SortedPairsByMemberValue( weps, "PrintName" ) do
+		local subCategories = BuildWeaponCategories()[ cat ]
+		local createOtherHeader = false
 
-			spawnmenu.CreateContentIcon( ent.ScriptedEntityType or "weapon", self.PropPanel, {
-				nicename	= ent.PrintName or ent.ClassName,
-				spawnname	= ent.ClassName,
-				material	= ent.IconOverride or ( "entities/" .. ent.ClassName .. ".png" ),
-				admin		= ent.AdminOnly
-			} )
+		for subCategoryName, weps in SortedPairs( subCategories ) do
+
+			if ( subCategoryName == "Other" ) then continue end
+
+			local label = vgui.Create( "ContentHeader" )
+
+			label:SetText( subCategoryName )
+
+			self.PropPanel:Add( label )
+
+			for k, ent in SortedPairsByMemberValue( weps, "PrintName" ) do
+
+				spawnmenu.CreateContentIcon( ent.ScriptedEntityType or "weapon", self.PropPanel, {
+					nicename	= ent.PrintName or ent.ClassName,
+					spawnname	= ent.ClassName,
+					material	= ent.IconOverride or ( "entities/" .. ent.ClassName .. ".png" ),
+					admin		= ent.AdminOnly
+				} )
+	
+			end
+
+			createOtherHeader = true
+
+		end
+
+		if ( subCategories.Other ) then
+
+			if ( createOtherHeader ) then
+
+				local label = vgui.Create( "ContentHeader" )
+
+				label:SetText( "Other" )
+
+				self.PropPanel:Add( label )
+
+			end
+
+			for name, ent in SortedPairsByMemberValue( subCategories.Other, "Name" ) do
+
+				spawnmenu.CreateContentIcon( ent.ScriptedEntityType or "weapon", self.PropPanel, {
+					nicename	= ent.PrintName or ent.ClassName,
+					spawnname	= ent.ClassName,
+					material	= ent.IconOverride or ( "entities/" .. ent.ClassName .. ".png" ),
+					admin		= ent.AdminOnly
+				} )
+
+			end
 
 		end
 

--- a/garrysmod/lua/derma/derma_menus.lua
+++ b/garrysmod/lua/derma/derma_menus.lua
@@ -1,6 +1,26 @@
 
 local tblOpenMenus = {}
 
+function GetOpenDermaMenus()
+
+	--
+	-- Clear the table of any removed derma menus
+	-- Each option in a derma menu is another derma menu itself
+	--
+	for k, menu in ipairs( tblOpenMenus ) do
+
+		if ( !IsValid( menu ) ) then
+
+			table.remove( tblOpenMenus, k )
+
+		end
+		
+	end
+
+	return tblOpenMenus
+
+end
+
 function RegisterDermaMenuForClose( dmenu )
 
 	table.insert( tblOpenMenus, dmenu )
@@ -30,9 +50,10 @@ function CloseDermaMenus()
 
 		end
 
+		tblOpenMenus[ k ] = nil
+
 	end
 
-	tblOpenMenus = {}
 	hook.Run( "CloseDermaMenus" )
 
 end

--- a/garrysmod/lua/derma/derma_menus.lua
+++ b/garrysmod/lua/derma/derma_menus.lua
@@ -3,21 +3,19 @@ local tblOpenMenus = {}
 
 function GetOpenDermaMenus()
 
-	--
-	-- Clear the table of any removed derma menus
-	-- Each option in a derma menu is another derma menu itself
-	--
+	local fixedCopy = {}
+
 	for k, menu in ipairs( tblOpenMenus ) do
 
-		if ( !IsValid( menu ) ) then
+		if ( IsValid( menu ) ) then
 
-			table.remove( tblOpenMenus, k )
+			table.insert( fixedCopy, menu )
 
 		end
 		
 	end
 
-	return tblOpenMenus
+	return fixedCopy
 
 end
 

--- a/garrysmod/lua/includes/modules/scripted_ents.lua
+++ b/garrysmod/lua/includes/modules/scripted_ents.lua
@@ -127,6 +127,7 @@ function Register( t, name )
 		Category		= t.Category,
 
 		-- Optional information
+		SubCategory 	= t.SubCategory,
 		NormalOffset	= t.NormalOffset,
 		DropToFloor		= t.DropToFloor,
 		Author			= t.Author,

--- a/garrysmod/lua/includes/modules/scripted_ents.lua
+++ b/garrysmod/lua/includes/modules/scripted_ents.lua
@@ -127,6 +127,7 @@ function Register( t, name )
 		Category		= t.Category,
 
 		-- Optional information
+		SpawnListOrder = t.SpawnListOrder,
 		SubCategory 	= t.SubCategory,
 		NormalOffset	= t.NormalOffset,
 		DropToFloor		= t.DropToFloor,

--- a/garrysmod/lua/includes/modules/weapons.lua
+++ b/garrysmod/lua/includes/modules/weapons.lua
@@ -59,6 +59,7 @@ function Register( t, name )
 		ClassName = name,
 		PrintName = t.PrintName or name,
 		Category = t.Category or "Other",
+		SubCategory = t.SubCategory,
 		Spawnable = t.Spawnable,
 		AdminOnly = t.AdminOnly,
 		ScriptedEntityType = t.ScriptedEntityType,

--- a/garrysmod/lua/includes/modules/weapons.lua
+++ b/garrysmod/lua/includes/modules/weapons.lua
@@ -59,6 +59,7 @@ function Register( t, name )
 		ClassName = name,
 		PrintName = t.PrintName or name,
 		Category = t.Category or "Other",
+		SpawnListOrder = t.SpawnListOrder,
 		SubCategory = t.SubCategory,
 		Spawnable = t.Spawnable,
 		AdminOnly = t.AdminOnly,

--- a/garrysmod/lua/vgui/spawnicon.lua
+++ b/garrysmod/lua/vgui/spawnicon.lua
@@ -34,30 +34,22 @@ function PANEL:DoRightClick()
 	self:OpenMenu()
 
 	local openedMenus = GetOpenDermaMenus()
-	local newMenuCount = #openedMenus
 
-	local menuIndex = newMenuCount == oldMenuCount and oldMenuCount or oldMenuCount + 1
+	local menuIndex = #openedMenus == oldMenuCount and oldMenuCount or oldMenuCount + 1
 	local menu = openedMenus[ menuIndex ]
 
 	if ( !IsValid( menu ) ) then return end
 
-	--
-	-- Get the correct derma menu
-	-- Each option in a derma menu is a derma menu itself
-	--
-	while ( IsValid( menu.ParentMenu ) ) do
-		
-		menuIndex = menuIndex - 1
-		menu = openedMenus[ menuIndex ]
+	local parent = menu.ParentMenu
+
+	if ( IsValid( parent ) ) then
+
+		menu = parent
 
 	end
 
-	if ( IsValid( menu ) ) then
-
-		hook.Run( "OnSpawnIconOpenMenu", self, menu )
-
-	end
-
+	hook.Run( "OnSpawnIconOpenMenu", self, menu )
+	
 end
 
 function PANEL:DoClick()

--- a/garrysmod/lua/vgui/spawnicon.lua
+++ b/garrysmod/lua/vgui/spawnicon.lua
@@ -28,17 +28,30 @@ function PANEL:DoRightClick()
 	if ( IsValid( pCanvas ) && pCanvas:NumSelectedChildren() > 0 && self:IsSelected() ) then
 		return hook.Run( "SpawnlistOpenGenericMenu", pCanvas )
 	end
-	
-	local openedMenus = GetOpenDermaMenus()
-	local menuCount = #openedMenus
+
+	local oldMenuCount = #GetOpenDermaMenus()
 
 	self:OpenMenu()
 
-	local menu = openedMenus[ menuCount + 1 ]
+	local openedMenus = GetOpenDermaMenus()
+	local newMenuCount = #openedMenus
+
+	local menuIndex = newMenuCount == oldMenuCount and oldMenuCount or oldMenuCount + 1
+	local menu = openedMenus[ menuIndex ]
+
+	if ( !IsValid( menu ) ) then return end
 
 	--
-	-- Allow addons to easily add their own options to the opened menu
+	-- Get the correct derma menu
+	-- Each option in a derma menu is a derma menu itself
 	--
+	while ( IsValid( menu.ParentMenu ) ) do
+		
+		menuIndex = menuIndex - 1
+		menu = openedMenus[ menuIndex ]
+
+	end
+
 	if ( IsValid( menu ) ) then
 
 		hook.Run( "OnSpawnIconOpenMenu", self, menu )

--- a/garrysmod/lua/vgui/spawnicon.lua
+++ b/garrysmod/lua/vgui/spawnicon.lua
@@ -28,8 +28,23 @@ function PANEL:DoRightClick()
 	if ( IsValid( pCanvas ) && pCanvas:NumSelectedChildren() > 0 && self:IsSelected() ) then
 		return hook.Run( "SpawnlistOpenGenericMenu", pCanvas )
 	end
+	
+	local openedMenus = GetOpenDermaMenus()
+	local menuCount = #openedMenus
 
 	self:OpenMenu()
+
+	local menu = openedMenus[ menuCount + 1 ]
+
+	--
+	-- Allow addons to easily add their own options to the opened menu
+	--
+	if ( IsValid( menu ) ) then
+
+		hook.Run( "OnSpawnIconOpenMenu", self, menu )
+
+	end
+
 end
 
 function PANEL:DoClick()


### PR DESCRIPTION
This pull request aims to add more customization to the spawn menu.

### Sub category headers for NPCs, Weapons, Entities, and Vehicles
This adds `SubCategory` to the ENT and SWEP structs.

**Example**
![spawnmenu_headers](https://github.com/user-attachments/assets/a5b5ddbd-315d-4a6a-97f5-cf678b4577d3)
(This pull request does not add these headers to any of the default NPC categories. This is just a demonstration.)
 
### Ability to easily add options to the right click menu for Content Icons and Spawn Icons
Adds two hooks and one function to achieve this:
- `GetOpenDermaMenus() function`
- `OnContentIconOpenMenu hook`
- `OnSpawnIconOpenMenu hook`

**Example**
Code:
```lua
hook.Add('OnContentIconOpenMenu', 'CopyName', function(icon, menu)
    if icon:GetContentType() ~= 'npc' then return end

    menu:AddOption('Copy Name', function()
        SetClipboardText(language.GetPhrase(icon.m_NiceName))
    end):SetIcon( "icon16/page_copy.png" )
end)
```
Output:
![spawnmenu_copy](https://github.com/user-attachments/assets/ee5ba4b7-13a6-4bd2-bbc1-fd5e914fd2a9)

### Custom spawn list ordering for NPCs, Weapons, Entities, and Vehicles
This adds `SpawnListOrder` to the ENT and SWEP structs. This determines the order in which the icons will be created in. This mixes well with the default alphabetical ordering.
