### PR TITLE
Fix "Bad SetLocalOrigin(x,y,z) on gmod_hands" warnings

### DIFF
--- a/garrysmod/gamemodes/base/entities/entities/gmod_hands.lua
+++ b/garrysmod/gamemodes/base/entities/entities/gmod_hands.lua
@@ -34,8 +34,10 @@ end
 
 function ENT:GetPlayerColor()
 
+	--
 	-- Make sure there's an owner and they have this function
 	-- before trying to call it!
+	--
 	local owner = self:GetOwner()
 	if ( !IsValid( owner ) ) then return end
 	if ( !owner.GetPlayerColor ) then return end
@@ -44,10 +46,11 @@ function ENT:GetPlayerColor()
 
 end
 
-function ENT:ViewModelChanged( vm )
+function ENT:ViewModelChanged( vm, old, new )
 
 	-- Ignore other people's viewmodel changes!
 	if ( vm:GetOwner() != self:GetOwner() ) then return end
+
 	-- Don't try to attach again if we're already attached
 	if ( self:GetParent() == vm ) then return end
 

--- a/garrysmod/gamemodes/base/entities/entities/gmod_hands.lua
+++ b/garrysmod/gamemodes/base/entities/entities/gmod_hands.lua
@@ -34,10 +34,8 @@ end
 
 function ENT:GetPlayerColor()
 
-	--
 	-- Make sure there's an owner and they have this function
 	-- before trying to call it!
-	--
 	local owner = self:GetOwner()
 	if ( !IsValid( owner ) ) then return end
 	if ( !owner.GetPlayerColor ) then return end
@@ -46,22 +44,33 @@ function ENT:GetPlayerColor()
 
 end
 
-function ENT:ViewModelChanged( vm, old, new )
+function ENT:ViewModelChanged( vm )
 
-	-- Ignore other peoples viewmodel changes!
+	-- Ignore other people's viewmodel changes!
 	if ( vm:GetOwner() != self:GetOwner() ) then return end
+	-- Don't try to attach again if we're already attached
+	if ( self:GetParent() == vm ) then return end
 
 	self:AttachToViewmodel( vm )
 
 end
 
+function ENT:OnRemove( fullUpdate )
+
+	if ( fullUpdate ) then return end
+
+	-- Resolve engine complaints when unparenting from the viewmodel
+	self:SetPos( vector_origin )
+
+end
+
 function ENT:AttachToViewmodel( vm )
+
+	self:SetPos( self:GetOwner():GetPos() )
+	self:SetAngles( angle_zero )
 
 	self:AddEffects( EF_BONEMERGE )
 	self:SetParent( vm )
 	self:SetMoveType( MOVETYPE_NONE )
-
-	self:SetPos( vector_origin )
-	self:SetAngles( angle_zero )
 
 end


### PR DESCRIPTION
Closes Facepunch/garrysmod-issues#1184

This PR should fix all instances of this mildly annoying warning that can occur under normal gameplay circumstances. Hands will be (re)parented to the viewmodel only when they actually need to be, and their position will now always be set to prevent the engine from complaining when they are parented or unparented.