### PR TITLE
Add ENT:DrawPhysgunHalo() for all entities

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/cl_init.lua
@@ -140,7 +140,7 @@ function GM:DrawPhysgunBeam( ply, weapon, bOn, target, boneid, pos )
 		local DrawPhysgunHalo = target.DrawPhysgunHalo 
 
 		--
-		-- Allow entities to suppress the halo or to add the halo to other entities
+		-- Allow entities to modify how the halo is drawn, or to add the halo to other entities
 		-- e.g. adding the halo to entities parented to the entity
 		--
 		if ( DrawPhysgunHalo ) then

--- a/garrysmod/gamemodes/sandbox/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/cl_init.lua
@@ -152,11 +152,7 @@ function GM:DrawPhysgunBeam( ply, weapon, bOn, target, boneid, pos )
 				tab.color = color
 				tab.size = size
 
-				if ( val == true ) then
-
-					tab[ 1 ] = target
-
-				elseif ( isentity( val ) ) then
+				if ( isentity( val ) ) then
 
 					tab[ 1 ] = val
 


### PR DESCRIPTION
This will allow entities to modify how the physgun halo is drawn on them. This function has three returns: the entity or entities to draw the halo on, the color of the halo, and the size.

```lua
function ENT:DrawPhysgunHalo(ply, weapon, boneid, pos)
    return self
end
```

The first return value can either be an entity, or a table of entities. I want to allow a table of entities, so that, for example, you can draw the halo on any entities that are parented to the physgunned entity.

### Example
**Before:**
![example_1](https://github.com/user-attachments/assets/8db84201-9bd1-4ae7-8445-371e709dd48b)

**Code:**
```lua
function ENT:DrawPhysgunHalo()
    local entsToHalo = self.haloTab

    if not entsToHalo then
        entsToHalo = { self }
        self.haloTab = entsToHalo
    end

    local light = self.light

    if not IsValid(light) then
        self.light = self:GetChildren()[1]

        return
    end

    entsToHalo[2] = light

    return entsToHalo
end
```

**After:**
![example_2](https://github.com/user-attachments/assets/b1840ddf-3c14-46aa-8c95-a68448919289)

### Example 2
**Rainbow physgun halo:**
```lua
function ENT:DrawPhysgunHalo()

    return self, HSVToColor( ( CurTime() * 100 ) % 360, 1, 1 )

end
```