### PR TITLE
Redundant call in `Entity:__index`

### DIFF
--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -26,7 +26,7 @@ function meta:__index( key )
 	--
 	-- Search the entity table
 	--
-	local tab = self:GetTable()
+	local tab = meta.GetTable( self )
 	if ( tab ) then
 		local tabval = tab[ key ]
 		if ( tabval != nil ) then return tabval end


### PR DESCRIPTION
Replaced `self:GetTable()` with `meta.GetTable( self )`.

`self:GetTable()` forces to call `__index` one more time when accessing a table value.