### PR TITLE
Cache result of gmod.GetGamemode() in gamemode.Call

### DIFF
--- a/garrysmod/lua/includes/modules/gamemode.lua
+++ b/garrysmod/lua/includes/modules/gamemode.lua
@@ -71,17 +71,16 @@ end
 	Name: Call( name, args )
 	Desc: Calls a gamemode function
 -----------------------------------------------------------]]
-local CurrentGM
-
+local currentGM
 function Call( name, ... )
 	
-	if ( !CurrentGM ) then
-        CurrentGM = gmod.GetGamemode()
+	if ( !currentGM ) then
+        currentGM = gmod.GetGamemode()
     end
 	
 	-- If the gamemode function doesn't exist just return false
-	if ( CurrentGM && CurrentGM[name] == nil ) then return false end
+	if ( currentGM && currentGM[name] == nil ) then return false end
 
-	return hook.Call( name, CurrentGM, ... )
+	return hook.Call( name, currentGM, ... )
 
 end


### PR DESCRIPTION
Does the same as #2075 (Pls merge it too), but for gamemode.Call

Benchmark code:
```lua
local SysTime = SysTime
local ipairs = ipairs
local MsgN = MsgN

function GMODBenchmark(repeats, ...)
    local times = {}

    for k, benchmark_function in ipairs({...}) do
        local start_time = SysTime()

        for i = 1, repeats do
            benchmark_function()
        end

        local end_time = SysTime()
        times[k] = end_time - start_time
    end

    MsgN("\nBenchmark result:")
    for k, v in ipairs(times) do
        MsgN(k, ": " .. v)
    end
end
```
Benchmark:
```lua
local ent = Entity(1)

GMODBenchmark(10000, 
function()
    gamemode.Call("Test")
end,
function()
    gamemode.Call("PlayerSpawnProp", ent, "")
end)

local CurrentGM

function gamemode.Call( name, ... )
        if ( !CurrentGM ) then
           CurrentGM = gmod.GetGamemode()
        end

	-- If the gamemode function doesn't exist just return false
	if ( CurrentGM && CurrentGM[name] == nil ) then return false end

	return hook.Call( name, CurrentGM, ... )

end

GMODBenchmark(10000, 
function()
    gamemode.Call("Test")
end,
function()
    gamemode.Call("PlayerSpawnProp", ent, "")
end)
```
Result:
```
] lua_openscript 1.lua
Running script 1.lua...

Benchmark result:
1: 0.0021544999999996
2: 0.0094025999999978

Benchmark result:
1: 5.0599999998013e-05
2: 0.0057702999999982
] lua_openscript_cl 1.lua
Running script 1.lua...

Benchmark result:
1: 0.0022110000000026
2: 0.0033515999999985

Benchmark result:
1: 4.9900000000491e-05
2: 3.7999999999982e-05
```