### PR TITLE
Fixed EFL_KEEP_ON_RECREATE_ENTITIES not being respected on Admin Cleanup

### DIFF
--- a/garrysmod/lua/includes/modules/cleanup.lua
+++ b/garrysmod/lua/includes/modules/cleanup.lua
@@ -68,7 +68,7 @@ if ( SERVER ) then
 		cleanup_list[ id ][ type ] = cleanup_list[ id ][ type ] or {}
 
 		table.insert( cleanup_list[ id ][ type ], ent )
-	
+
 	end
 
 	function ReplaceEntity( from, to )

--- a/garrysmod/lua/includes/modules/cleanup.lua
+++ b/garrysmod/lua/includes/modules/cleanup.lua
@@ -68,6 +68,7 @@ if ( SERVER ) then
 		cleanup_list[ id ][ type ] = cleanup_list[ id ][ type ] or {}
 
 		table.insert( cleanup_list[ id ][ type ], ent )
+	
 	end
 
 	function ReplaceEntity( from, to )

--- a/garrysmod/lua/includes/modules/cleanup.lua
+++ b/garrysmod/lua/includes/modules/cleanup.lua
@@ -59,10 +59,8 @@ if ( SERVER ) then
 
 	function Add( pl, type, ent )
 
-		if ( !ent ) then return end
-
-		if ( !IsType( type ) ) then return end
 		if ( !IsValid( ent ) ) then return end
+		if ( !IsType( type ) ) then return end
 
 		local id = pl:UniqueID()
 
@@ -156,7 +154,7 @@ if ( SERVER ) then
 
 					for __, ent in pairs( type ) do
 
-						if ( IsValid( ent ) and not ent:IsEFlagSet( EFL_KEEP_ON_RECREATE_ENTITIES) ) then ent:Remove() end
+						if ( IsValid( ent ) and !ent:IsEFlagSet( EFL_KEEP_ON_RECREATE_ENTITIES ) ) then ent:Remove() end
 
 					end
 

--- a/garrysmod/lua/includes/modules/cleanup.lua
+++ b/garrysmod/lua/includes/modules/cleanup.lua
@@ -62,16 +62,14 @@ if ( SERVER ) then
 		if ( !ent ) then return end
 
 		if ( !IsType( type ) ) then return end
+		if ( !IsValid( ent ) ) then return end
 
 		local id = pl:UniqueID()
 
 		cleanup_list[ id ] = cleanup_list[ id ] or {}
 		cleanup_list[ id ][ type ] = cleanup_list[ id ][ type ] or {}
 
-		if ( !IsValid( ent ) ) then return end
-
 		table.insert( cleanup_list[ id ][ type ], ent )
-
 	end
 
 	function ReplaceEntity( from, to )
@@ -158,7 +156,7 @@ if ( SERVER ) then
 
 					for __, ent in pairs( type ) do
 
-						if ( IsValid( ent ) ) then ent:Remove() end
+						if ( IsValid( ent ) and not ent:IsEFlagSet( EFL_KEEP_ON_RECREATE_ENTITIES) ) then ent:Remove() end
 
 					end
 


### PR DESCRIPTION
I was debating adding it to cleanup.Add and Client Cleanup.
I think it might be worth while adding it to them and to the specific forms of clean up as well.
But I have left this as minimal, but enough to work for my use case.

I also moved all the checks next to each other inside the Add function, so its clearer what is being checked.