### PR TITLE
player/ents.GetCached

### DIFF
--- a/garrysmod/lua/includes/extensions/ents.lua
+++ b/garrysmod/lua/includes/extensions/ents.lua
@@ -38,6 +38,19 @@ function ents.Iterator()
 
 end
 
+function ents.IteratorForEdit()
+
+	if ( EntityCache == nil ) then EntityCache = ents.GetAll() end
+
+	local entities = {}
+	for k, v in ipairs( EntityCache ) do
+		entities[k] = v
+	end
+
+	return entities
+
+end
+
 local function InvalidateEntityCache( ent )
 
 	EntityCache = nil

--- a/garrysmod/lua/includes/extensions/ents.lua
+++ b/garrysmod/lua/includes/extensions/ents.lua
@@ -38,7 +38,7 @@ function ents.Iterator()
 
 end
 
-function ents.IteratorForEdit()
+function ents.GetCached()
 
 	if ( EntityCache == nil ) then EntityCache = ents.GetAll() end
 

--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -319,6 +319,20 @@ function player.Iterator()
 
 end
 
+function player.IteratorForEdit()
+
+	if ( PlayerCache == nil ) then PlayerCache = player.GetAll() end
+
+	local players = {}
+	for k, v in ipairs( PlayerCache ) do
+		players[k] = v
+	end
+
+	return players
+
+end
+
+
 local function InvalidatePlayerCache( ent )
 
 	if ( ent:IsPlayer() ) then PlayerCache = nil end

--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -319,7 +319,7 @@ function player.Iterator()
 
 end
 
-function player.IteratorForEdit()
+function player.GetCached()
 
 	if ( PlayerCache == nil ) then PlayerCache = player.GetAll() end
 


### PR DESCRIPTION
An addition to ents.Iterator and player.Iterator that allows you to modify the returned table. It is still much faster than ents/player.GetAll, but slower than ents/player.Iterator. Below is a comparison

Benchmark code:
```lua
local SysTime = SysTime
local ipairs = ipairs
local MsgN = MsgN

function GMODBenchmark(repeats, ...)
    local times = {}

    for k, benchmark_function in ipairs({...}) do
        local start_time = SysTime()

        for i = 1, repeats do
            benchmark_function()
        end

        local end_time = SysTime()
        times[k] = end_time - start_time
    end

    MsgN(string.format("\nBenchmark result %s:", SERVER and "(SERVER)" or "(CLIENT)"))
    for k, v in ipairs(times) do
        MsgN(k, ": " .. v)
    end
end
```
Benchmark:
```lua
--gm_construct with 128 bots
GMODBenchmark(10000, 
function()
    local players = player.GetAll()
end,
function()
    local players = player.GetCached()
end)

GMODBenchmark(10000, 
function()
    local players = ents.GetAll()
end,
function()
    local players = ents.GetCached()
end)
```

Result:
```
Benchmark result (SERVER):
1: 0.056322099999988
2: 0.012729499999978

Benchmark result (SERVER):
1: 1.1994984999999
2: 0.10440289999997
```