### PR TITLE
Make MAX_EDICT_BITS globally available

### DIFF
--- a/garrysmod/lua/includes/extensions/net.lua
+++ b/garrysmod/lua/includes/extensions/net.lua
@@ -3,6 +3,7 @@
 -- as the entity at given index may have changed during transport.
 -- If this becomes a problem, inclusion of entity's serial will also be necessary
 local MAX_EDICT_BITS = 13
+net.MAX_EDICT_BITS = MAX_EDICT_BITS 
 
 TYPE_COLOR = 255
 


### PR DESCRIPTION
Having `MAX_EDICT_BITS` globally available would help a lot for other addons that write entity indexes, currently they hardcode `13` but this can eventually be broken if gmod ever changes the entity limit.
Feel free to do it in another way, i figured having it on the net library table would make the most sense.
