### PR TITLE
duplicator.GenericDuplicatorFunction() improvements

### DIFF
--- a/garrysmod/lua/includes/modules/duplicator.lua
+++ b/garrysmod/lua/includes/modules/duplicator.lua
@@ -474,7 +474,6 @@ end
    Generic function for duplicating stuff
 -----------------------------------------------------------]]
 function GenericDuplicatorFunction( Player, data )
-
 	if ( !IsAllowed( data.Class ) ) then
 		-- MsgN( "duplicator: ", data.Class, " isn't allowed to be duplicated!" )
 		return
@@ -490,6 +489,9 @@ function GenericDuplicatorFunction( Player, data )
 
 	end
 
+	-- Make sure this is allowed
+	if ( IsValid( Player ) && !gamemode.Call( "PlayerSpawnSENT", Player, data.Class ) ) then return end
+
 	local Entity = ents.Create( data.Class )
 	if ( !IsValid( Entity ) ) then return end
 
@@ -503,6 +505,11 @@ function GenericDuplicatorFunction( Player, data )
 	EntityPhysics.Load( data.PhysicsObjects, Entity )
 
 	table.Merge( Entity:GetTable(), data )
+
+	-- Tell the gamemode we just spawned something
+	if ( IsValid( Player ) ) then
+		gamemode.Call( "PlayerSpawnedSENT", Player, Entity )
+	end
 
 	return Entity
 


### PR DESCRIPTION
`duplicator.GenericDuplicatorFunction()` now runs `PlayerSpawnSENT` and `PlayerSpawnedSENT`, similar to `MakeProp()`.

This change will fix the duplicator ignoring `sbox_maxsents` and will allow you to dynamically control whether specific entities can be duped without having to define a factory function (or worse, redefine it). It also makes duping SENTs more consistent with duping props and other things as they do run their respective `PlayerSpawn*` hooks when duped.

Possible issues: can't find any. Spawning default entities and random workshop dupes seems to be working as expected (e.g. nothing is counting towards 2 limits at the same time)

Further changes: update wiki pages for `PlayerSpawn*` hooks to reflect that they are ran not only when things are spawned from the Q menu. You could also add a `bool Duplicated` argument to these hooks, or maybe even `string SpawnMethod` (= "spawnmenu", 
 "duplicator", "some_custom_method") to allow modders to add and control custom spawn methods organically.