### PR TITLE
Bring Sandbox context menu icons to spawn menu

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/contextmenu.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/contextmenu.lua
@@ -184,6 +184,7 @@ function CreateContextMenu()
 	IconLayout:SetStretchWidth( true )
 	IconLayout:SetStretchHeight( false ) -- No infinite re-layouts
 	IconLayout:Dock( LEFT )
+	IconLayout:DockMargin(0, 0, IconLayout:GetBorder(), 0)
 
 	-- This overrides DIconLayout's OnMousePressed (which is inherited from DPanel), but we don't care about that in this case
 	IconLayout.OnMousePressed = function( s, ... ) s:GetParent():OnMousePressed( ... ) end

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/contextmenu.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/contextmenu.lua
@@ -36,6 +36,13 @@ function PANEL:Open()
 	self:SetKeyboardInputEnabled( false )
 	self:SetMouseInputEnabled( true )
 
+	if IsValid(g_IconLayout) then
+		g_IconLayout:SetParent(self)
+		g_IconLayout:SetWorldClicker(true)
+
+		g_IconLayout:Layout()
+	end
+
 	RestoreCursorPosition()
 
 	local bShouldShow = hook.Run( "ContextMenuShowTool" )
@@ -160,7 +167,15 @@ function CreateContextMenu()
 
 	hook.Run( "ContextMenuCreated", g_ContextMenu )
 
-	local IconLayout = g_ContextMenu:Add( "DIconLayout" )
+	if IsValid(g_IconLayout) then
+		g_IconLayout:Remove()
+		g_IconLayout = nil
+	end
+
+	g_IconLayout = g_ContextMenu:Add( "DIconLayout" )
+	if not IsValid(g_IconLayout) then return end
+
+	local IconLayout = g_IconLayout
 	IconLayout:SetBorder( 8 )
 	IconLayout:SetSpaceX( 8 )
 	IconLayout:SetSpaceY( 8 )
@@ -202,14 +217,17 @@ function CreateContextMenu()
 
 			if ( v.onewindow and IsValid( icon.Window ) ) then
 				icon.Window:Center()
+				icon.Window:MakePopup()
+
 				return
 			end
 
 			-- Make the window
-			icon.Window = g_ContextMenu:Add( "DFrame" )
+			icon.Window = vgui.Create("DFrame")
 			icon.Window:SetSize( newv.width, newv.height )
 			icon.Window:SetTitle( newv.title )
 			icon.Window:Center()
+			icon.Window:MakePopup()
 
 			newv.init( icon, icon.Window )
 

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/spawnmenu.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/spawnmenu.lua
@@ -180,8 +180,6 @@ function PANEL:PerformLayout()
 		local IconWidth = IconLayout:GetWide()
 
 		if MarginLeft < IconWidth then -- Don't let the spawn menu cover the icons
-			IconLayout:DockMargin(0, 0, IconLayout:GetBorder(), 0)
-
 			MarginLeft = 0
 		end
 	end

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/spawnmenu.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/spawnmenu.lua
@@ -123,6 +123,13 @@ function PANEL:Open()
 	self:SetMouseInputEnabled( true )
 	self:SetAlpha( 255 )
 
+	if IsValid(g_IconLayout) then
+		g_IconLayout:SetParent(self)
+		g_IconLayout:SetWorldClicker(false)
+
+		g_IconLayout:Layout()
+	end
+
 	achievements.SpawnMenuOpen()
 
 	if ( IsValid( self.StartupTool ) && self.StartupTool.Name ) then
@@ -165,7 +172,21 @@ function PANEL:PerformLayout()
 	end
 
 	self:DockPadding( 0, 0, 0, 0 )
-	self.HorizontalDivider:DockMargin( MarginX, MarginY, MarginX, MarginY )
+
+	local MarginLeft = MarginX
+	local IconLayout = g_IconLayout
+
+	if IsValid(IconLayout) and IconLayout:IsVisible() then
+		local IconWidth = IconLayout:GetWide()
+
+		if MarginLeft < IconWidth then -- Don't let the spawn menu cover the icons
+			IconLayout:DockMargin(0, 0, IconLayout:GetBorder(), 0)
+
+			MarginLeft = 0
+		end
+	end
+
+	self.HorizontalDivider:DockMargin( MarginLeft, MarginY, MarginX, MarginY )
 	self.HorizontalDivider:SetLeftMin( self.HorizontalDivider:GetWide() / 3 )
 
 	self.ToolToggle:AlignRight( 6 )


### PR DESCRIPTION
Passes the panel back and forth as the menus open