### PR TITLE
Add math.IsNearlyZero() and math.IsNearlyEqual()

### DIFF
--- a/garrysmod/lua/includes/extensions/math.lua
+++ b/garrysmod/lua/includes/extensions/math.lua
@@ -255,3 +255,29 @@ function math.Factorial( num )
 
 	return res
 end
+
+local smallNumber = math.exp( -8 )
+
+--[[---------------------------------------------------------
+	Name: IsNearlyZero( num )
+	Desc: Checks if a floating point number is nearly zero
+-----------------------------------------------------------]]
+function math.IsNearlyZero( num, tolerance )
+	if tolerance == nil then
+		tolerance = smallNumber
+	end
+
+	return math.abs( num ) <= tolerance
+end
+
+--[[---------------------------------------------------------
+	Name: IsNearlyEqual( a, b )
+	Desc: Checks if two floating point numbers are nearly equal
+-----------------------------------------------------------]]
+function math.IsNearlyEqual( a, b, tolerance )
+	if tolerance == nil then
+		tolerance = smallNumber
+	end
+
+	return math.abs( a - b ) <= tolerance
+end


### PR DESCRIPTION
These simple functions should be used when comparing numbers instead of `==`, since floating point precision issues easily arise.
Felt like making them since someone on the Garry's Mod Discord server was confused as to why the following didn't work:

![image](https://github.com/user-attachments/assets/22862adb-fa45-4636-b57c-73b9d45cb980)

So now, you can use `math.IsNearlyEqual()` or `math.IsNearlyZero()` which solves the issue:

![image](https://github.com/user-attachments/assets/830b2ec6-de62-45f2-a64a-bc8a0739a227)

The functions allow you to give them a tolerance of your choice, but they'll default to `math.exp( -8 )` otherwise.