### PR TITLE
Make all post-processing conditional

### DIFF
--- a/garrysmod/lua/postprocess/bloom.lua
+++ b/garrysmod/lua/postprocess/bloom.lua
@@ -58,21 +58,25 @@ function DrawBloom( darken, multiply, sizex, sizey, passes, color, colr, colg, c
 
 end
 
---[[---------------------------------------------------------
-	The function to draw the bloom (called from the hook)
------------------------------------------------------------]]
-hook.Add( "RenderScreenspaceEffects", "RenderBloom", function()
+cvars.AddChangeCallback( "pp_bloom", function( _, _, newValue )
 
 	-- No bloom for crappy gpus
 
 	if ( !render.SupportsPixelShaders_2_0() ) then return end
-	if ( !pp_bloom:GetBool() ) then return end
 	if ( !GAMEMODE:PostProcessPermitted( "bloom" ) ) then return end
 
-	DrawBloom( pp_bloom_darken:GetFloat(), pp_bloom_multiply:GetFloat(),
+	if ( newValue != "0" ) then
+		hook.Add( "RenderScreenspaceEffects", "RenderBloom", function()
+
+			DrawBloom( pp_bloom_darken:GetFloat(), pp_bloom_multiply:GetFloat(),
 				pp_bloom_sizex:GetFloat(), pp_bloom_sizey:GetFloat(),
 				pp_bloom_passes:GetFloat(), pp_bloom_color:GetFloat(),
 				pp_bloom_color_r:GetFloat() / 255, pp_bloom_color_g:GetFloat() / 255, pp_bloom_color_b:GetFloat() / 255 )
+
+		end)
+	else
+		hook.Remove( "RenderScreenspaceEffects", "RenderBloom" )
+	end
 
 end )
 

--- a/garrysmod/lua/postprocess/bokeh_dof.lua
+++ b/garrysmod/lua/postprocess/bokeh_dof.lua
@@ -28,21 +28,18 @@ local function OnChange( name, oldvalue, newvalue )
 
 	if ( newvalue != "0" ) then
 		DOFModeHack( true )
+		hook.Add( "RenderScreenspaceEffects", "RenderBokeh", function()
+
+			DrawBokehDOF( pp_bokeh_blur:GetFloat(), pp_bokeh_distance:GetFloat(), pp_bokeh_focus:GetFloat() )
+
+		end)
 	else
+		hook.Remove( "RenderScreenspaceEffects", "RenderBokeh" )
 		DOFModeHack( false )
 	end
 
 end
 cvars.AddChangeCallback( "pp_bokeh", OnChange )
-
-hook.Add( "RenderScreenspaceEffects", "RenderBokeh", function()
-
-	if ( !pp_bokeh:GetBool() ) then return end
-	if ( !GAMEMODE:PostProcessPermitted( "bokeh" ) ) then return end
-
-	DrawBokehDOF( pp_bokeh_blur:GetFloat(), pp_bokeh_distance:GetFloat(), pp_bokeh_focus:GetFloat() )
-
-end )
 
 hook.Add( "NeedsDepthPass", "NeedsDepthPass_Bokeh", function()
 

--- a/garrysmod/lua/postprocess/color_modify.lua
+++ b/garrysmod/lua/postprocess/color_modify.lua
@@ -32,10 +32,7 @@ function DrawColorModify( tab )
 
 end
 
-hook.Add( "RenderScreenspaceEffects", "RenderColorModify", function()
-
-	if ( !pp_colormod:GetBool() ) then return end
-	if ( !GAMEMODE:PostProcessPermitted( "color mod" ) ) then return end
+local function RenderColorModify()
 
 	local tab = {}
 
@@ -51,6 +48,18 @@ hook.Add( "RenderScreenspaceEffects", "RenderColorModify", function()
 	tab[ "$pp_colour_inv" ] = pp_colormod_inv:GetFloat()
 
 	DrawColorModify( tab )
+
+end
+
+cvars.AddChangeCallback( "pp_colormod", function( _, _, newValue )
+
+	if ( !GAMEMODE:PostProcessPermitted( "color mod" ) ) then return end
+
+	if ( newValue != "0" ) then
+		hook.Add( "RenderScreenspaceEffects", "RenderColorModify", RenderColorModify )
+	else
+		hook.Remove( "RenderScreenspaceEffects", "RenderColorModify" )
+	end
 
 end )
 

--- a/garrysmod/lua/postprocess/dof.lua
+++ b/garrysmod/lua/postprocess/dof.lua
@@ -27,6 +27,8 @@ function DOF_Kill()
 
 	DOFModeHack( false )
 
+	hook.Remove( "Think", "DOFThink" )
+
 end
 
 function DOF_Start()
@@ -43,14 +45,14 @@ function DOF_Start()
 
 	DOFModeHack( true )
 
+	hook.Add( "Think", "DOFThink", function()
+
+		DOF_SPACING = pp_dof_spacing:GetFloat()
+		DOF_OFFSET = pp_dof_initlength:GetFloat()
+
+	end)
+
 end
-
-hook.Add( "Think", "DOFThink", function()
-
-	DOF_SPACING = pp_dof_spacing:GetFloat()
-	DOF_OFFSET = pp_dof_initlength:GetFloat()
-
-end )
 
 cvars.AddChangeCallback( "pp_dof", function( name, oldvalue, newvalue )
 

--- a/garrysmod/lua/postprocess/frame_blend.lua
+++ b/garrysmod/lua/postprocess/frame_blend.lua
@@ -174,9 +174,9 @@ end
 --
 if ( engine.IsPlayingDemo() ) then return end
 
-hook.Add( "PostRender", "RenderFrameBlend", function()
+local function RenderFrameBlend()
 
-	if ( !frame_blend.IsActive() ) then return end
+	if ( !frame_blend.IsActive() ) then hook.Remove( "RenderFrameBlend", "RenderFrameBlend" ) return end
 
 	if ( !frame_blend.ShouldSkipFrame() ) then
 		render.CopyRenderTargetToTexture( texFB )
@@ -185,6 +185,18 @@ hook.Add( "PostRender", "RenderFrameBlend", function()
 	
 	frame_blend.AddFrame()
 	frame_blend.DrawPreview()
+
+end
+
+cvars.AddChangeCallback( "pp_fb", function( _, _, newValue )
+
+	if ( !GAMEMODE:PostProcessPermitted( "fb" ) ) then return end
+
+	if ( newValue != "0" ) then
+		hook.Add( "PostRender", "RenderFrameBlend", RenderFrameBlend )
+	else
+		hook.Remove( "RenderFrameBlend", "RenderFrameBlend" )
+	end
 
 end )
 

--- a/garrysmod/lua/postprocess/motion_blur.lua
+++ b/garrysmod/lua/postprocess/motion_blur.lua
@@ -60,12 +60,19 @@ function DrawMotionBlur( addalpha, drawalpha, delay )
 
 end
 
-hook.Add( "RenderScreenspaceEffects", "RenderMotionBlur", function()
+cvars.AddChangeCallback( "pp_motionblur", function( _, _, newValue )
 
-	if ( !pp_motionblur:GetBool() ) then return end
 	if ( !GAMEMODE:PostProcessPermitted( "motion blur" ) ) then return end
 
-	DrawMotionBlur( pp_motionblur_addalpha:GetFloat(), pp_motionblur_drawalpha:GetFloat(), pp_motionblur_delay:GetFloat() )
+	if ( newValue != "0" ) then
+		hook.Add( "RenderScreenspaceEffects", "RenderMotionBlur", function()
+
+			DrawMotionBlur( pp_motionblur_addalpha:GetFloat(), pp_motionblur_drawalpha:GetFloat(), pp_motionblur_delay:GetFloat() )
+
+		end )
+	else
+		hook.Remove( "RenderScreenspaceEffects", "RenderMotionBlur" )
+	end
 
 end )
 

--- a/garrysmod/lua/postprocess/overlay.lua
+++ b/garrysmod/lua/postprocess/overlay.lua
@@ -30,14 +30,19 @@ function DrawMaterialOverlay( texture, refractamount )
 
 end
 
-hook.Add( "RenderScreenspaceEffects", "RenderMaterialOverlay", function()
+cvars.AddChangeCallback( "pp_mat_overlay", function( _, _, newValue )
 
-	local overlay = pp_mat_overlay:GetString()
-
-	if ( overlay == "" ) then return end
 	if ( !GAMEMODE:PostProcessPermitted( "material overlay" ) ) then return end
 
-	DrawMaterialOverlay( overlay, pp_mat_overlay_refractamount:GetFloat() )
+	if ( newValue != "" ) then
+		hook.Add( "RenderScreenspaceEffects", "RenderMaterialOverlay", function()
+
+			DrawMaterialOverlay( newValue, pp_mat_overlay_refractamount:GetFloat() )
+
+		end)
+	else
+		hook.Remove( "RenderScreenspaceEffects", "RenderMaterialOverlay" )
+	end
 
 end )
 

--- a/garrysmod/lua/postprocess/sharpen.lua
+++ b/garrysmod/lua/postprocess/sharpen.lua
@@ -21,12 +21,19 @@ function DrawSharpen( contrast, distance )
 
 end
 
-hook.Add( "RenderScreenspaceEffects", "RenderSharpen", function()
+cvars.AddChangeCallback( "pp_sharpen", function( _, _, newValue )
 
-	if ( !pp_sharpen:GetBool() ) then return end
 	if ( !GAMEMODE:PostProcessPermitted( "sharpen" ) ) then return end
 
-	DrawSharpen( pp_sharpen_contrast:GetFloat(), pp_sharpen_distance:GetFloat() )
+	if ( newValue != "0" ) then
+		hook.Add( "RenderScreenspaceEffects", "RenderSharpen", function()
+
+			DrawSharpen( pp_sharpen_contrast:GetFloat(), pp_sharpen_distance:GetFloat() )
+
+		end )
+	else
+		hook.Remove( "RenderScreenspaceEffects", "RenderSharpen" )
+	end
 
 end )
 

--- a/garrysmod/lua/postprocess/sobel.lua
+++ b/garrysmod/lua/postprocess/sobel.lua
@@ -17,12 +17,19 @@ function DrawSobel( threshold )
 
 end
 
-hook.Add( "RenderScreenspaceEffects", "RenderSobel", function()
+cvars.AddChangeCallback( "pp_sobel", function( _, _, newValue )
 
-	if ( !pp_sobel:GetBool() ) then return end
 	if ( !GAMEMODE:PostProcessPermitted( "sobel" ) ) then return end
 
-	DrawSobel( pp_sobel_threshold:GetFloat() )
+	if ( newValue != "0" ) then
+		hook.Add( "RenderScreenspaceEffects", "RenderSobel", function()
+
+			DrawSobel( pp_sobel_threshold:GetFloat() )
+
+		end )
+	else
+		hook.Remove( "RenderScreenspaceEffects", "RenderSobel" )
+	end
 
 end )
 

--- a/garrysmod/lua/postprocess/stereoscopy.lua
+++ b/garrysmod/lua/postprocess/stereoscopy.lua
@@ -36,17 +36,22 @@ function RenderStereoscopy( ViewOrigin, ViewAngles )
 
 end
 
---[[---------------------------------------------------------
-	The function to draw the bloom (called from the hook)
------------------------------------------------------------]]
-hook.Add( "RenderScene", "RenderStereoscopy", function( ViewOrigin, ViewAngles, ViewFOV )
+cvars.AddChangeCallback( "pp_stereoscopy", function( _, _, newValue )
 
-	if ( !pp_stereoscopy:GetBool() ) then return end
+	if ( !GAMEMODE:PostProcessPermitted( "stereoscopy" ) ) then return end
 
-	RenderStereoscopy( ViewOrigin, ViewAngles )
+	if ( newValue != "0" ) then
+		hook.Add( "RenderScene", "RenderStereoscopy", function(ViewOrigin, ViewAngles)
 
-	-- Return true to override drawing the scene
-	return true
+			RenderStereoscopy( ViewOrigin, ViewAngles )
+
+			-- Return true to override drawing the scene
+			return true
+
+		end)
+	else
+		hook.Remove( "RenderScene", "RenderStereoscopy" )
+	end
 
 end )
 

--- a/garrysmod/lua/postprocess/sunbeams.lua
+++ b/garrysmod/lua/postprocess/sunbeams.lua
@@ -28,11 +28,7 @@ function DrawSunbeams( darken, multiply, sunsize, sunx, suny )
 
 end
 
-hook.Add( "RenderScreenspaceEffects", "RenderSunbeams", function()
-
-	if ( !pp_sunbeams:GetBool() ) then return end
-	if ( !GAMEMODE:PostProcessPermitted( "sunbeams" ) ) then return end
-	if ( !render.SupportsPixelShaders_2_0() ) then return end
+local function RenderSunbeams()
 
 	local sun = util.GetSunInfo()
 
@@ -46,6 +42,19 @@ hook.Add( "RenderScreenspaceEffects", "RenderSunbeams", function()
 	if ( dot <= 0 ) then return end
 
 	DrawSunbeams( pp_sunbeams_darken:GetFloat(), pp_sunbeams_multiply:GetFloat() * dot * sun.obstruction, pp_sunbeams_sunsize:GetFloat(), scrpos.x / ScrW(), scrpos.y / ScrH() )
+
+end
+
+cvars.AddChangeCallback( "pp_sunbeams", function( _, _, newValue )
+
+	if ( !render.SupportsPixelShaders_2_0() ) then return end
+	if ( !GAMEMODE:PostProcessPermitted( "sunbeams" ) ) then return end
+
+	if ( newValue != "0" ) then
+		hook.Add( "RenderScreenspaceEffects", "RenderSunbeams", RenderSunbeams )
+	else
+		hook.Remove( "RenderScreenspaceEffects", "RenderSunbeams" )
+	end
 
 end )
 

--- a/garrysmod/lua/postprocess/super_dof.lua
+++ b/garrysmod/lua/postprocess/super_dof.lua
@@ -328,18 +328,6 @@ function RenderSuperDoF( ViewOrigin, ViewAngles, ViewFOV )
 
 end
 
-hook.Add( "RenderScene", "RenderSuperDoF", function( ViewOrigin, ViewAngles, ViewFOV )
-
-	if ( !IsValid( SuperDOFWindow ) ) then return end
-
-	-- Don't render it when the console is up
-	if ( FrameTime() == 0 ) then return end
-
-	RenderSuperDoF( ViewOrigin, ViewAngles, ViewFOV )
-	return true
-
-end )
-
 concommand.Add( "pp_superdof", function()
 
 	Status = "Preview"
@@ -354,23 +342,35 @@ concommand.Add( "pp_superdof", function()
 	SuperDOFWindow:MakePopup()
 	SuperDOFWindow:PositionMyself()
 
-end )
+	hook.Add( "RenderScene", "RenderSuperDoF", function( ViewOrigin, ViewAngles, ViewFOV )
 
-hook.Add( "GUIMousePressed", "SuperDOFMouseDown", function( mouse )
+		if ( !IsValid( SuperDOFWindow ) ) then hook.Remove( "RenderScene", "RenderSuperDoF" ) return end
 
-	if ( !IsValid( SuperDOFWindow ) ) then return end
+		-- Don't render it when the console is up
+		if ( FrameTime() == 0 ) then return end
 
-	vgui.GetWorldPanel():MouseCapture( true )
-	FocusGrabber = true
+		RenderSuperDoF( ViewOrigin, ViewAngles, ViewFOV )
+		return true
 
-end )
+	end )
 
-hook.Add( "GUIMouseReleased", "SuperDOFMouseUp", function( mouse )
+	hook.Add( "GUIMousePressed", "SuperDOFMouseDown", function( mouse )
 
-	if ( !IsValid( SuperDOFWindow ) ) then return end
+		if ( !IsValid( SuperDOFWindow ) ) then hook.Remove( "GUIMousePressed", "SuperDOFMouseDown" ) return end
 
-	vgui.GetWorldPanel():MouseCapture( false )
-	FocusGrabber = false
+		vgui.GetWorldPanel():MouseCapture( true )
+		FocusGrabber = true
+
+	end )
+
+	hook.Add( "GUIMouseReleased", "SuperDOFMouseUp", function( mouse )
+
+		if ( !IsValid( SuperDOFWindow ) ) then hook.Remove( "GUIMouseReleased", "SuperDOFMouseUp" ) return end
+
+		vgui.GetWorldPanel():MouseCapture( false )
+		FocusGrabber = false
+
+	end )
 
 end )
 

--- a/garrysmod/lua/postprocess/texturize.lua
+++ b/garrysmod/lua/postprocess/texturize.lua
@@ -18,14 +18,20 @@ function DrawTexturize( scale, pMaterial )
 
 end
 
-hook.Add( "RenderScreenspaceEffects", "RenderTexturize", function()
+cvars.AddChangeCallback( "pp_texturize", function( _, _, newValue )
 
-	local texturize = pp_texturize:GetString()
+	if ( !GAMEMODE:PostProcessPermitted( "texturize" ) ) then return end
 
-	if ( texturize == "" ) then return end
-	if ( !GAMEMODE:PostProcessPermitted( "texurize" ) ) then return end
+	if ( newValue != "" ) then
+		local material = Material( newValue )
+		hook.Add( "RenderScreenspaceEffects", "RenderTexturize", function()
 
-	DrawTexturize( pp_texturize_scale:GetFloat(), Material( texturize ) )
+			DrawTexturize( pp_texturize_scale:GetFloat(), material )
+
+		end)
+	else
+		hook.Remove( "RenderScreenspaceEffects", "RenderTexturize" )
+	end
 
 end )
 

--- a/garrysmod/lua/postprocess/toytown.lua
+++ b/garrysmod/lua/postprocess/toytown.lua
@@ -27,16 +27,25 @@ function DrawToyTown( NumPasses, H )
 	cam.End2D()
 end
 
-hook.Add( "RenderScreenspaceEffects", "RenderToyTown", function()
-
-	if ( !pp_toytown:GetBool() ) then return end
-	if ( !GAMEMODE:PostProcessPermitted( "toytown" ) ) then return end
-	if ( !render.SupportsPixelShaders_2_0() ) then return end
+local function RenderToyTown()
 
 	local NumPasses = pp_toytown_passes:GetInt()
 	local H = math.floor( ScrH() * pp_toytown_size:GetFloat() )
 
 	DrawToyTown( NumPasses, H )
+
+end
+
+cvars.AddChangeCallback( "pp_toytown", function( _, _, newValue )
+
+	if ( !render.SupportsPixelShaders_2_0() ) then return end
+	if ( !GAMEMODE:PostProcessPermitted( "toytown" ) ) then return end
+
+	if ( newValue != "0" ) then
+		hook.Add( "RenderScreenspaceEffects", "RenderToyTown", RenderToyTown )
+	else
+		hook.Remove( "RenderScreenspaceEffects", "RenderToyTown" )
+	end
 
 end )
 


### PR DESCRIPTION
Optimizes post-processing by not having their hooks run when they're never used. Also removes some unnecessary checks or moves them to run only once.

Now post-processing hooks run only when needed.

I tested it and it all works fine, but I would appreciate anyone looking over this to make sure I didn't do any copying errors.

Was waiting for someone else to do this before I realized it'd be faster to do it myself.