### PR TITLE
Add string.EscapeSpecialChars function to escape special characters

### DIFF
--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -76,6 +76,26 @@ function string.PatternSafe( str )
 end
 
 --[[---------------------------------------------------------
+	Name: string.EscapeSpecialChars( string )
+	Desc: Takes a string and escapes special characters (\0, \n, \t, etc)
+	Usage: string.EscapeSpecialChars( "Hello\nWorld\0" )
+-----------------------------------------------------------]]
+local escape_sequences = {
+	["\0"] = "\\0",
+	["\b"] = "\\b",
+	["\f"] = "\\f",
+	["\n"] = "\\n",
+	["\r"] = "\\r",
+	["\t"] = "\\t",
+	["\v"] = "\\v",
+	["\\"] = "\\\\"
+}
+
+function string.EscapeSpecialChars( str )
+	return ( string.gsub( str, "[%z\b\f\n\r\t\v\\]", escape_sequences ) )
+end
+
+--[[---------------------------------------------------------
 	Name: explode(seperator ,string)
 	Desc: Takes a string and turns it into a table
 	Usage: string.explode( " ", "Seperate this string")

--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -88,11 +88,12 @@ local escape_sequences = {
 	["\r"] = "\\r",
 	["\t"] = "\\t",
 	["\v"] = "\\v",
-	["\\"] = "\\\\"
+	["\\"] = "\\\\",
+	["\a"] = "\\a"
 }
 
 function string.EscapeSpecialChars( str )
-	return ( string.gsub( str, "[%z\b\f\n\r\t\v\\]", escape_sequences ) )
+	return ( string.gsub( str, "[%z\b\f\n\r\t\v\\\a]", escape_sequences ) )
 end
 
 --[[---------------------------------------------------------


### PR DESCRIPTION
Allows escaping escape sequences: "\0 \b \f \n \r \t \v \\"
```lua
local user_input = "hey there \0\t\n"
print(user_input:EscapeSpecialChars()) -- outputs "hey there \0\t\n"
```