### PR TITLE
Allow passing varargs from vgui.Create to Panel:Init

### DIFF
--- a/garrysmod/lua/includes/extensions/client/panel/scriptedpanels.lua
+++ b/garrysmod/lua/includes/extensions/client/panel/scriptedpanels.lua
@@ -20,7 +20,7 @@ function vgui.Exists( classname )
 	return PanelFactory[ classname ] != nil
 end
 
-function vgui.Create( classname, parent, name )
+function vgui.Create( classname, parent, name, ... )
 
 	-- Is this a user-created panel?
 	if ( PanelFactory[ classname ] ) then
@@ -38,7 +38,7 @@ function vgui.Create( classname, parent, name )
 
 		-- Call the Init function if we have it
 		if ( panel.Init ) then
-			panel:Init()
+			panel:Init( ... )
 		end
 
 		panel:Prepare()


### PR DESCRIPTION
This PR makes it possible to pass varargs from [`vgui.Create`](https://wiki.facepunch.com/gmod/vgui.Create) to [`Panel:Init`](https://wiki.facepunch.com/gmod/PANEL:Init) for custom (user-created) panels.

Passing arguments to Panel:Init can be quite useful in a few cases, generally when the goal is to allow changing some behavior in the Init function without it being really necessary to separate these different behaviors into individual functions.

It would be possible to define a custom init function for the panel and call that after `vgui.Create`, but I don't see a reason why a cleaner solution like this shouldn't exist.

Thanks :)