### PR TITLE
Fix indentation of the gamemode list items

### DIFF
--- a/garrysmod/html/css/menu/NavBar.css
+++ b/garrysmod/html/css/menu/NavBar.css
@@ -232,7 +232,7 @@ UL.gamemode_list LI
 	margin: 3px;
 	border-radius: 0;
 	background-color: #eee;
-	margin: 0 2px 2px 0;
+	margin: 0 0 2px 0;
 }
 
 UL.gamemode_list LI:hover


### PR DESCRIPTION
In the gamemode selection menu, the gamemodes have a 2px right margin from the panel. This makes the outline appear larger on the right than in other places (3px vs 5px)

### Before
![image](https://github.com/user-attachments/assets/a5d274bb-e7a8-4afa-b95a-a24a20bc55af)
### After
![image](https://github.com/user-attachments/assets/6ec4e1ed-e1fc-412b-a515-fb7e55aa704c)
