### PR TITLE
Remove metatable deletion ToolObj

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stool.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stool.lua
@@ -168,8 +168,6 @@ for _, val in ipairs( file.Find( SWEP.Folder .. "/stools/*.lua", "LUA" ) ) do
 
 end
 
-ToolObj = nil
-
 if ( SERVER ) then return end
 
 -- Keep the tool list handy


### PR DESCRIPTION
If removed, this makes it possible to create an instrument almost anywhere, useful for modular gamemodes.

If this cannot be done, please explain why.