### PR TITLE
Updated deprecated CPanel calls

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stool_cl.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stool_cl.lua
@@ -14,7 +14,7 @@ function ToolObj:RebuildControlPanel( ... )
 	local cPanel = controlpanel.Get( self.Mode )
 	if ( !cPanel ) then ErrorNoHalt( "Couldn't find control panel to rebuild!" ) return end
 
-	cPanel:ClearControls()
+	cPanel:Clear()
 	self.BuildCPanel( cPanel, ... )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/axis.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/axis.lua
@@ -219,13 +219,43 @@ local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description = "#tool.axis.help" } )
+	CPanel:Help( "#tool.axis.help" )
 
-	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "axis", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	-- Presets
+	local presets = vgui.Create( "ControlPresets", CPanel )
+	presets:SetPreset( "axis" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	CPanel:AddPanel( presets )
 
-	CPanel:AddControl( "Slider", { Label = "#tool.forcelimit", Command = "axis_forcelimit", Type = "Float", Min = 0, Max = 50000, Help = true } )
-	CPanel:AddControl( "Slider", { Label = "#tool.torquelimit", Command = "axis_torquelimit", Type = "Float", Min = 0, Max = 50000, Help = true } )
-	CPanel:AddControl( "Slider", { Label = "#tool.hingefriction", Command = "axis_hingefriction", Type = "Float", Min = 0, Max = 200, Help = true } )
-	CPanel:AddControl( "CheckBox", { Label = "#tool.nocollide", Command = "axis_nocollide", Help = true } )
+	-- Force limit
+	local forceLimit = CPanel:NumSlider( "#tool.forcelimit", "axis_forcelimit", 0, 50000, 2 )
+	local forceLimitDefault = GetConVar( "axis_forcelimit" )
+	CPanel:ControlHelp( "#tool.forcelimit" .. ".help" )
+	if ( forceLimitDefault ) then
+		forceLimit:SetDefaultValue( forceLimitDefault:GetDefault() )
+	end
+
+	-- Torque limit
+	local torqueLimit = CPanel:NumSlider( "#tool.torquelimit", "axis_torquelimit", 0, 50000, 2 )
+	local torqueLimitDefault = GetConVar( "axis_torquelimit" )
+	CPanel:ControlHelp( "#tool.torquelimit" .. ".help" )
+	if ( torqueLimitDefault ) then
+		torqueLimit:SetDefaultValue( torqueLimitDefault:GetDefault() )
+	end
+
+	-- Hinge friction
+	local hingeFriction = CPanel:NumSlider( "#tool.hingefriction", "axis_hingefriction", 0, 200, 2 )
+	local hingeFrictionDefault = GetConVar( "axis_hingefriction" )
+	CPanel:ControlHelp( "#tool.hingefriction" .. ".help" )
+	if ( hingeFrictionDefault ) then
+		hingeFriction:SetDefaultValue( hingeFrictionDefault:GetDefault() )
+	end
+
+	-- No collide
+	CPanel:CheckBox( "#tool.nocollide", "axis_nocollide" )
+	CPanel:ControlHelp( "#tool.nocollide" .. ".help" )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/balloon.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/balloon.lua
@@ -218,15 +218,42 @@ local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description = "#tool.balloon.help" } )
+	CPanel:Help( "#tool.balloon.help" )
 
-	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "balloon", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	-- Presets
+	local presets = vgui.Create( "ControlPresets", CPanel )
+	presets:SetPreset( "balloon" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	CPanel:AddPanel( presets )
 
-	CPanel:AddControl( "Slider", { Label = "#tool.balloon.ropelength", Type = "Float", Command = "balloon_ropelength", Min = 5, Max = 1000 } )
-	CPanel:AddControl( "Slider", { Label = "#tool.balloon.force", Type = "Float", Command = "balloon_force", Min = -1000, Max = 2000, Help = true } )
-	CPanel:AddControl( "Color", { Label = "#tool.balloon.color", Red = "balloon_r", Green = "balloon_g", Blue = "balloon_b" } )
+	-- Rope length
+	local ropeLength = CPanel:NumSlider( "#tool.balloon.ropelength", "balloon_ropelength", 5, 1000, 2 )
+	local ropeLengthDefault = GetConVar( "balloon_ropelength" )
+	if ( ropeLengthDefault ) then
+		ropeLength:SetDefaultValue( ropeLengthDefault:GetDefault() )
+	end
 
-	CPanel:AddControl( "PropSelect", { Label = "#tool.balloon.model", ConVar = "balloon_model", Height = 0, ModelsTable = list.Get( "BalloonModels" ) } )
+	-- Balloon force
+	local balloonForce = CPanel:NumSlider( "#tool.balloon.force", "balloon_force", -1000, 2000, 2 )
+	local balloonForceDefault = GetConVar( "balloon_force" )
+	CPanel:ControlHelp( "#tool.balloon.force" .. ".help" )
+	if ( balloonForceDefault ) then
+		balloonForce:SetDefaultValue( balloonForceDefault:GetDefault() )
+	end
+
+	local color = vgui.Create( "CtrlColor", CPanel )
+	color:SetLabel( "#tool.balloon.color" )
+	color:SetConVarR( "balloon_r" )
+	color:SetConVarG( "balloon_g" )
+	color:SetConVarB( "balloon_b" )
+	CPanel:AddPanel( color )
+
+	local model = vgui.Create( "PropSelect", CPanel )
+	model:ControlValues( { label = "#tool.balloon.model", convar = "balloon_model", height = 0, modelstable = list.Get( "BalloonModels" ) } )
+	CPanel:AddPanel( model )
 
 end
 

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/ballsocket.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/ballsocket.lua
@@ -91,12 +91,35 @@ local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description = "#tool.ballsocket.help" } )
+	CPanel:Help( "#tool.ballsocket.help" )
 
-	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "ballsocket", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	-- Presets
+	local presets = vgui.Create( "ControlPresets", CPanel )
+	presets:SetPreset( "ballsocket" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	CPanel:AddPanel( presets )
 
-	CPanel:AddControl( "Slider", { Label = "#tool.forcelimit", Command = "ballsocket_forcelimit", Type = "Float", Min = 0, Max = 50000, Help = true } )
-	--CPanel:AddControl( "Slider", { Label = "#tool.torquelimit", Command = "ballsocket_torquelimit", Type = "Float", Min = 0, Max = 50000, Help = true } )
-	CPanel:AddControl( "CheckBox", { Label = "#tool.nocollide", Command = "ballsocket_nocollide", Help = true } )
+	-- Force limit
+	local forceLimit = CPanel:NumSlider( "#tool.forcelimit", "ballsocket_forcelimit", 0, 50000, 2 )
+	local forceLimitDefault = GetConVar( "ballsocket_forcelimit" )
+	CPanel:ControlHelp( "#tool.forcelimit" .. ".help" )
+	if ( forceLimitDefault ) then
+		forceLimit:SetDefaultValue( forceLimitDefault:GetDefault() )
+	end
+
+	-- Torque limit
+	--[[local torqueLimit = CPanel:NumSlider( "#tool.torquelimit", "ballsocket_torquelimit", 0, 50000, 2 )
+	local torqueLimitDefault = GetConVar( "ballsocket_torquelimit" )
+	CPanel:ControlHelp( "#tool.torquelimit" .. ".help" )
+	if ( torqueLimitDefault ) then
+		torqueLimit:SetDefaultValue( torqueLimitDefault:GetDefault() )
+	end]]--
+
+	-- No collide
+	CPanel:CheckBox( "#tool.nocollide", "ballsocket_nocollide" )
+	CPanel:ControlHelp( "#tool.nocollide" .. ".help" )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/button.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/button.lua
@@ -171,17 +171,34 @@ local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description = "#tool.button.desc" } )
+	CPanel:Help( "#tool.button.desc" )
 
-	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "button", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	-- Presets
+	local presets = vgui.Create( "ControlPresets", CPanel )
+	presets:SetPreset( "button" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	CPanel:AddPanel( presets )
 
-	CPanel:AddControl( "Numpad", { Label = "#tool.button.key", Command = "button_keygroup" } )
+	-- Key
+	local numpad = vgui.Create( "CtrlNumPad", CPanel )
+	numpad:SetConVar1( "button_keygroup" )
+	numpad:SetLabel1( "#tool.button.key" )
+	CPanel:AddPanel( numpad )
 
-	CPanel:AddControl( "TextBox", { Label = "#tool.button.text", Command = "button_description", MaxLenth = "20" } )
+	-- Description
+	CPanel:TextEntry( "#tool.button.text", "button_description" )
 
-	CPanel:AddControl( "CheckBox", { Label = "#tool.button.toggle", Command = "button_toggle", Help = true } )
+	-- Toggle
+	CPanel:CheckBox( "#tool.button.toggle", "button_toggle" )
+	CPanel:ControlHelp( "#tool.button.toggle" .. ".help" )
 
-	CPanel:AddControl( "PropSelect", { Label = "#tool.button.model", ConVar = "button_model", Height = 0, Models = list.Get( "ButtonModels" ) } )
+	-- Model
+	local model = vgui.Create( "PropSelect", CPanel )
+	model:ControlValues( { label = "#tool.button.model", convar = "button_model", height = 0, models = list.Get( "ButtonModels" ) } )
+	CPanel:AddPanel( model )
 
 end
 

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/camera.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/camera.lua
@@ -141,10 +141,26 @@ local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "camera", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	-- Presets
+	local presets = vgui.Create( "ControlPresets", CPanel )
+	presets:SetPreset( "camera" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	CPanel:AddPanel( presets )
 
-	CPanel:AddControl( "Numpad", { Label = "#tool.camera.key", Command = "camera_key" } )
-	CPanel:AddControl( "CheckBox", { Label = "#tool.camera.static", Command = "camera_locked", Help = true } )
-	CPanel:AddControl( "CheckBox", { Label = "#tool.toggle", Command = "camera_toggle" } )
+	-- Key
+	local numpad = vgui.Create( "CtrlNumPad", CPanel )
+	numpad:SetConVar1( "camera_key" )
+	numpad:SetLabel1( "#tool.camera.key" )
+	CPanel:AddPanel( numpad )
+
+	-- Static
+	CPanel:CheckBox( "#tool.camera.static", "camera_locked" )
+	CPanel:ControlHelp( "#tool.camera.static" .. ".help" )
+
+	-- Toggle
+	CPanel:CheckBox( "#tool.toggle", "camera_toggle" )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/colour.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/colour.lua
@@ -94,14 +94,35 @@ local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description = "#tool.colour.desc" } )
+	CPanel:Help( "#tool.colour.desc" )
 
 	CPanel:ToolPresets( "colour", ConVarsDefault )
 
 	CPanel:ColorPicker( "#tool.colour.color", "colour_r", "colour_g", "colour_b", "colour_a" )
 
-	CPanel:AddControl( "ListBox", { Label = "#tool.colour.mode", Options = list.Get( "RenderModes" ) } )
-	CPanel:AddControl( "ListBox", { Label = "#tool.colour.fx", Options = list.Get( "RenderFX" ) } )
+	-- Render modes
+	local renderMode = vgui.Create( "CtrlListBox", CPanel )
+	for k, v in pairs( list.Get( "RenderModes" ) ) do
+		renderMode:AddOption( k, v )
+	end
+	local renderModeLabel = vgui.Create( "DLabel", CPanel )
+	renderModeLabel:SetText( "#tool.colour.mode" )
+	renderModeLabel:SetDark( true )
+	renderMode:SetHeight( 25 )
+	renderMode:Dock( TOP )
+	CPanel:AddItem( renderModeLabel, renderMode )
+
+	-- Render FX
+	local renderFX = vgui.Create( "CtrlListBox", CPanel )
+	for k, v in pairs( list.Get( "RenderFX" ) ) do
+		renderFX:AddOption( k, v )
+	end
+	local renderFXLabel = vgui.Create( "DLabel", CPanel )
+	renderFXLabel:SetText( "#tool.colour.fx" )
+	renderFXLabel:SetDark( true )
+	renderFX:SetHeight( 25 )
+	renderFX:Dock( TOP )
+	CPanel:AddItem( renderFXLabel, renderFX )
 
 end
 

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/duplicator.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/duplicator.lua
@@ -139,11 +139,14 @@ if ( CLIENT ) then
 	--
 	function TOOL.BuildCPanel( CPanel, tool )
 
-		CPanel:ClearControls()
+		CPanel:Clear()
 
-		CPanel:AddControl( "Header", { Description = "#tool.duplicator.desc" } )
+		CPanel:Help( "#tool.duplicator.desc" )
 
-		CPanel:AddControl( "Button", { Text = "#tool.duplicator.showsaves", Command = "dupe_show" } )
+		local dupeShow = vgui.Create( "DButton", CPanel )
+		function dupeShow:DoClick() LocalPlayer():ConCommand( "dupe_show" ) end
+		dupeShow:SetText( "#tool.duplicator.showsaves" )
+		CPanel:AddItem( dupeShow, nil )
 
 		if ( !tool && IsValid( LocalPlayer() ) ) then tool = LocalPlayer():GetTool( "duplicator" ) end
 		if ( !tool || !tool.CurrentDupeName ) then return end
@@ -151,15 +154,17 @@ if ( CLIENT ) then
 		local info = "Name: " .. tool.CurrentDupeName
 		info = info .. "\nEntities: " .. tool.CurrentDupeEntCount
 
-		CPanel:AddControl( "Label", { Text = info } )
+		CPanel:Help( info )
 
 		if ( tool.CurrentDupeWSIDs && #tool.CurrentDupeWSIDs > 0 ) then
-			CPanel:AddControl( "Label", { Text = "Required workshop content:" } )
+			CPanel:Help( "Required workshop content:" )
 			for _, wsid in pairs( tool.CurrentDupeWSIDs ) do
 				local subbed = ""
 				if ( steamworks.IsSubscribed( wsid ) ) then subbed = " (Subscribed)" end
-				local b = CPanel:AddControl( "Button", { Text = wsid .. subbed } )
+				local b = vgui.Create( "DButton", CPanel )
+				b:SetText( wsid .. subbed )
 				b.DoClick = function( s, ... ) steamworks.ViewFile( wsid ) end
+				CPanel:AddItem( b, nil )
 				steamworks.FileInfo( wsid, function( result )
 					if ( !IsValid( b ) ) then return end
 					b:SetText( result.title .. subbed )
@@ -168,9 +173,14 @@ if ( CLIENT ) then
 		end
 
 		if ( tool.CurrentDupeCanSave ) then
-			local b = CPanel:AddControl( "Button", { Text = "#dupes.savedupe", Command = "dupe_save" } )
+			local b = vgui.Create( "DButton", CPanel )
+			function b:DoClick() LocalPlayer():ConCommand( "dupe_save" ) end
+			b:SetText( "#dupes.savedupe" )
+			CPanel:AddItem( b, nil )
 			hook.Add( "DupeSaveUnavailable", b, function() b:Remove() end )
 		end
+
+		CPanel:InvalidateLayout()
 
 	end
 

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/dynamite.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/dynamite.lua
@@ -162,16 +162,46 @@ local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description = "#tool.dynamite.help" } )
+	CPanel:Help( "#tool.dynamite.help" )
 
-	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "dynamite", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	-- Presets
+	local presets = vgui.Create( "ControlPresets", CPanel )
+	presets:SetPreset( "dynamite" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	CPanel:AddPanel( presets )
 
-	CPanel:AddControl( "Numpad", { Label = "#tool.dynamite.explode", Command = "dynamite_group" } )
-	CPanel:AddControl( "Slider", { Label = "#tool.dynamite.damage", Command = "dynamite_damage", Type = "Float", Min = 0, Max = 500, Help = true } )
-	CPanel:AddControl( "Slider", { Label = "#tool.dynamite.delay", Command = "dynamite_delay", Type = "Float", Min = 0, Max = 10, Help = true } )
-	CPanel:AddControl( "CheckBox", { Label = "#tool.dynamite.remove", Command = "dynamite_remove" } )
+	-- Explode key
+	local numpad = vgui.Create( "CtrlNumPad", CPanel )
+	numpad:SetConVar1( "dynamite_group" )
+	numpad:SetLabel1( "#tool.dynamite.explode" )
+	CPanel:AddPanel( numpad )
 
-	CPanel:AddControl( "PropSelect", { Label = "#tool.dynamite.model", ConVar = "dynamite_model", Height = 0, Models = list.Get( "DynamiteModels" ) } )
+	-- Damage
+	local damage = CPanel:NumSlider( "#tool.dynamite.damage", "dynamite_damage", 0, 500, 2 )
+	local damageDefault = GetConVar( "dynamite_damage" )
+	CPanel:ControlHelp( "#tool.dynamite.damage" .. ".help" )
+	if ( damageDefault ) then
+		damage:SetDefaultValue( damageDefault:GetDefault() )
+	end
+
+	-- Delay
+	local delay = CPanel:NumSlider( "#tool.dynamite.delay", "dynamite_delay", 0, 10, 2 )
+	local delayDefault = GetConVar( "dynamite_delay" )
+	CPanel:ControlHelp( "#tool.dynamite.delay" .. ".help" )
+	if ( delayDefault ) then
+		delay:SetDefaultValue( delayDefault:GetDefault() )
+	end
+
+	-- Remove
+	CPanel:CheckBox( "#tool.dynamite.remove", "dynamite_remove" )
+
+	-- Model
+	local model = vgui.Create( "PropSelect", CPanel )
+	model:ControlValues( { label = "#tool.dynamite.model", convar = "dynamite_model", height = 0, models = list.Get( "DynamiteModels" ) } )
+	CPanel:AddPanel( model )
 
 end
 

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/editentity.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/editentity.lua
@@ -36,7 +36,7 @@ function TOOL:Think()
 		local CPanel = controlpanel.Get( "editentity" )
 		if ( !CPanel ) then return end
 
-		CPanel:ClearControls()
+		CPanel:Clear()
 		self.BuildCPanel( CPanel, CurrentEditing )
 
 	end
@@ -49,6 +49,7 @@ function TOOL.BuildCPanel( CPanel, ent )
 	control:SetEntity( ent )
 	control:SetSize( 10, 500 )
 
-	CPanel:AddPanel( control )
+	CPanel:AddItem( control, nil )
+	self:InvalidateLayout()
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/elastic.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/elastic.lua
@@ -107,17 +107,63 @@ local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description = "#tool.elastic.help" } )
+	CPanel:Help( "#tool.elastic.help" )
 
-	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "elastic", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	-- Presets
+	local presets = vgui.Create( "ControlPresets", CPanel )
+	presets:SetPreset( "elastic" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	CPanel:AddPanel( presets )
 
-	CPanel:AddControl( "Slider", { Label = "#tool.elastic.constant", Command = "elastic_constant", Type = "Float", Min = 0, Max = 4000, Help = true } )
-	CPanel:AddControl( "Slider", { Label = "#tool.elastic.damping", Command = "elastic_damping", Type = "Float", Min = 0, Max = 50, Help = true } )
-	CPanel:AddControl( "Slider", { Label = "#tool.elastic.rdamping", Command = "elastic_rdamping", Type = "Float", Min = 0, Max = 1, Help = true } )
-	CPanel:AddControl( "CheckBox", { Label = "#tool.elastic.stretchonly", Command = "elastic_stretch_only", Help = true } )
+	-- Constant
+	local constant = CPanel:NumSlider( "#tool.elastic.constant", "elastic_constant", 0, 4000, 2 )
+	local constantDefault = GetConVar( "elastic_constant" )
+	CPanel:ControlHelp( "#tool.elastic.constant" .. ".help" )
+	if ( constantDefault ) then
+		constant:SetDefaultValue( constantDefault:GetDefault() )
+	end
 
-	CPanel:AddControl( "Slider", { Label = "#tool.elastic.width", Command = "elastic_width", Type = "Float", Min = 0, Max = 20 } )
-	CPanel:AddControl( "RopeMaterial", { Label = "#tool.elastic.material", ConVar = "elastic_material" } )
-	CPanel:AddControl( "Color", { Label = "#tool.elastic.color", Red = "elastic_color_r", Green = "elastic_color_g", Blue = "elastic_color_b" } )
+	-- Damping
+	local damping = CPanel:NumSlider( "#tool.elastic.damping", "elastic_damping", 0, 50, 2 )
+	local dampingDefault = GetConVar( "elastic_damping" )
+	CPanel:ControlHelp( "#tool.elastic.damping" .. ".help" )
+	if ( dampingDefault ) then
+		damping:SetDefaultValue( dampingDefault:GetDefault() )
+	end
+
+	-- RDamping
+	local rdamping = CPanel:NumSlider( "#tool.elastic.rdamping", "elastic_rdamping", 0, 1, 2 )
+	local rdampingDefault = GetConVar( "elastic_rdamping" )
+	CPanel:ControlHelp( "#tool.elastic.rdamping" .. ".help" )
+	if ( rdampingDefault ) then
+		rdamping:SetDefaultValue( rdampingDefault:GetDefault() )
+	end
+
+	-- Stretch only
+	CPanel:CheckBox( "#tool.elastic.stretchonly", "elastic_stretch_only" )
+	CPanel:ControlHelp( "#tool.elastic.stretchonly" .. ".help" )
+
+	-- Width
+	local width = CPanel:NumSlider( "#tool.elastic.width", "elastic_width", 0, 20, 2 )
+	local widthDefault = GetConVar( "elastic_width" )
+	if ( widthDefault ) then
+		width:SetDefaultValue( widthDefault:GetDefault() )
+	end
+
+	-- Material
+	local material = vgui.Create( "RopeMaterial", CPanel )
+	material:SetConVar( "elastic_material" )
+	CPanel:AddPanel( material )
+
+	-- Color
+	local color = vgui.Create( "CtrlColor", CPanel )
+	color:SetLabel( "#tool.elastic.color" )
+	color:SetConVarR( "elastic_color_r" )
+	color:SetConVarG( "elastic_color_g" )
+	color:SetConVarB( "elastic_color_b" )
+	CPanel:AddPanel( color )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/emitter.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/emitter.lua
@@ -184,17 +184,43 @@ local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description = "#tool.emitter.desc" } )
+	CPanel:Help( "#tool.emitter.desc" )
 
-	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "emitter", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	-- Presets
+	local presets = vgui.Create( "ControlPresets", CPanel )
+	presets:SetPreset( "emitter" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	CPanel:AddPanel( presets )
 
-	CPanel:AddControl( "Numpad", { Label = "#tool.emitter.key", Command = "emitter_key" } )
+	-- Key
+	local numpad = vgui.Create( "CtrlNumPad", CPanel )
+	numpad:SetConVar1( "emitter_key" )
+	numpad:SetLabel1( "#tool.emitter.key" )
+	CPanel:AddPanel( numpad )
 
-	CPanel:AddControl( "Slider", { Label = "#tool.emitter.delay", Command = "emitter_delay", Type = "Float", Min = 0.01, Max = 2 } )
-	CPanel:AddControl( "Slider", { Label = "#tool.emitter.scale", Command = "emitter_scale", Type = "Float", Min = 0, Max = 6, Help = true } )
+	-- Delay
+	local delay = CPanel:NumSlider( "#tool.emitter.delay", "emitter_delay", 0.01, 2, 2 )
+	local delayDefault = GetConVar( "emitter_delay" )
+	if ( delayDefault ) then
+		delay:SetDefaultValue( delayDefault:GetDefault() )
+	end
 
-	CPanel:AddControl( "Checkbox", { Label = "#tool.emitter.toggle", Command = "emitter_toggle" } )
-	CPanel:AddControl( "Checkbox", { Label = "#tool.emitter.starton", Command = "emitter_starton" } )
+	-- Scale
+	local scale = CPanel:NumSlider( "#tool.emitter.scale", "emitter_scale", 0, 6, 2 )
+	local scaleDefault = GetConVar( "emitter_scale" )
+	CPanel:ControlHelp( "#tool.emitter.scale" .. ".help" )
+	if ( scaleDefault ) then
+		scale:SetDefaultValue( scaleDefault:GetDefault() )
+	end
+
+	-- Toggle
+	CPanel:CheckBox( "#tool.emitter.toggle", "emitter_toggle" )
+
+	-- Start on
+	CPanel:CheckBox( "#tool.emitter.starton", "emitter_starton" )
 
 	local matselect = CPanel:MatSelect( "emitter_effect", nil, true, 0.25, 0.25 )
 	for k, v in pairs( list.Get( "EffectType" ) ) do

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/eyeposer.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/eyeposer.lua
@@ -295,7 +295,7 @@ end
 
 function TOOL.BuildCPanel( CPanel, hasEntity )
 
-	CPanel:AddControl( "Header", { Description = "#tool.eyeposer.desc" } )
+	CPanel:Help( "#tool.eyeposer.desc" )
 
 	if ( hasEntity ) then
 
@@ -325,10 +325,15 @@ function TOOL.BuildCPanel( CPanel, hasEntity )
 			surface.DrawRect( w / 2 - 2, h / 2 - 2, 5, 5 )
 		end
 
-		CPanel:AddControl( "Slider", { Label = "#tool.eyeposer.strabismus", Command = "eyeposer_strabismus", Type = "Float", Min = -1, Max = 1, Default = 0 } )
+		-- Strabismus
+		local strabismus = CPanel:NumSlider( "#tool.eyeposer.strabismus", "eyeposer_strabismus", -1, 1, 2 )
+		strabismus:SetDefaultValue( 0 )
 
 	end
 
-	CPanel:AddControl( "Slider", { Label = "#tool.eyeposer.size_eyes", Command = "r_eyesize", Type = "Float", Min = -0.5, Max = 2, Help = true, Default = 0 } )
+	-- Eyes size
+	local size = CPanel:NumSlider( "#tool.eyeposer.size_eyes", "r_eyesize", -0.5, 2, 2 )
+	CPanel:ControlHelp( "#tool.eyeposer.size_eyes" .. ".help" )
+	size:SetDefaultValue( 0 )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/faceposer.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/faceposer.lua
@@ -176,11 +176,18 @@ local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel, faceEntity )
 
-	CPanel:AddControl( "Header", { Description = "#tool.faceposer.desc" } )
+	CPanel:Help( "#tool.faceposer.desc" )
 
 	if ( !IsValid( faceEntity ) || faceEntity:GetFlexNum() == 0 ) then return end
 
-	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "face", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	-- Presets
+	local presets = vgui.Create( "ControlPresets", CPanel )
+	presets:SetPreset( "face" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	CPanel:AddPanel( presets )
 
 	local QuickFace = vgui.Create( "MatSelect", CPanel )
 	QuickFace:SetItemWidth( 64 )
@@ -335,10 +342,19 @@ function TOOL.BuildCPanel( CPanel, faceEntity )
 
 	CPanel:AddItem( QuickFace )
 
-	CPanel:AddControl( "Slider", { Label = "#tool.faceposer.scale", Command = "faceposer_scale", Type = "Float", Min = -5, Max = 5, Help = true, Default = 1 } ):SetHeight( 16 )
-	CPanel:AddControl( "Button", { Text = "#tool.faceposer.randomize", Command = "faceposer_randomize" } )
+	-- Scale
+	local size = CPanel:NumSlider( "#tool.faceposer.scale", "faceposer_scale", -5, 5, 2 )
+	CPanel:ControlHelp( "#tool.faceposer.scale" .. ".help" )
+	size:SetDefaultValue( 1 )
+	size:SetHeight( 16 )
 
-	local filter = CPanel:AddControl( "TextBox", { Label = "#spawnmenu.quick_filter_tool" } )
+	-- Randomize
+	local randomize = vgui.Create( "DButton", CPanel )
+	function randomize:DoClick() LocalPlayer():ConCommand( "faceposer_randomize" ) end
+	randomize:SetText( "#tool.faceposer.randomize" )
+	CPanel:AddPanel( randomize )
+
+	local filter = CPanel:TextEntry( "#spawnmenu.quick_filter_tool", nil )
 	filter:SetUpdateOnType( true )
 
 	-- Group flex controllers by their type..

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/finger.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/finger.lua
@@ -571,11 +571,18 @@ local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel, ent, hand )
 
-	CPanel:AddControl( "Header", { Description = "#tool.finger.desc" } )
+	CPanel:Help( "#tool.finger.desc" )
 
 	if ( !IsValid( ent ) ) then return end
 
-	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "finger", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	-- Presets
+	local presets = vgui.Create( "ControlPresets", CPanel )
+	presets:SetPreset( "finger" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	CPanel:AddPanel( presets )
 
 	SetupFingers( ent )
 
@@ -584,9 +591,11 @@ function TOOL.BuildCPanel( CPanel, ent, hand )
 	-- Detect mitten hands
 	local NumVars = table.Count( ent.FingerIndex )
 
-	CPanel:AddControl( "fingerposer", { hand = hand, numvars = NumVars } )
+	local fingerPoser = vgui.Create( "fingerposer", CPanel )
+	fingerPoser:ControlValues( { hand = hand, numvars = NumVars } )
+	CPanel:AddPanel( fingerPoser )
 
-	CPanel:AddControl( "Checkbox", { Label = "#tool.finger.restrict_axis", Command = "finger_restrict" } )
+	CPanel:CheckBox( "#tool.finger.restrict_axis", "finger_restrict" )
 
 end
 

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/hoverball.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/hoverball.lua
@@ -219,17 +219,59 @@ local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description = "#tool.hoverball.help" } )
+	CPanel:Help( "#tool.hoverball.help" )
 
-	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "hoverball", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	-- Presets
+	local presets = vgui.Create( "ControlPresets", CPanel )
+	presets:SetPreset( "hoverball" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	CPanel:AddPanel( presets )
 
-	CPanel:AddControl( "Numpad", { Label = "#tool.hoverball.up", Command = "hoverball_keyup", Label2 = "#tool.hoverball.down", Command2 = "hoverball_keydn" } )
-	CPanel:AddControl( "Numpad", { Label = "#tool.toggle", Command = "hoverball_keyon" } )
-	CPanel:AddControl( "Slider", { Label = "#tool.hoverball.speed", Command = "hoverball_speed", Type = "Float", Min = 0, Max = 20, Help = true } )
-	CPanel:AddControl( "Slider", { Label = "#tool.hoverball.resistance", Command = "hoverball_resistance", Type = "Float", Min = 0, Max = 10, Help = true } )
-	CPanel:AddControl( "Slider", { Label = "#tool.hoverball.strength", Command = "hoverball_strength", Type = "Float", Min = 0.1, Max = 10, Help = true } )
+	-- Key up
+	local keyup = vgui.Create( "CtrlNumPad", CPanel )
+	keyup:SetConVar1( "hoverball_keyup" )
+	keyup:SetConVar2( "hoverball_keydn" )
+	keyup:SetLabel1( "#tool.hoverball.up" )
+	keyup:SetLabel2( "#tool.hoverball.down" )
+	CPanel:AddPanel( keyup )
 
-	CPanel:AddControl( "PropSelect", { Label = "#tool.hoverball.model", ConVar = "hoverball_model", Models = list.Get( "HoverballModels" ), Height = 0 } )
+	-- Key toggle
+	local keytoggle = vgui.Create( "CtrlNumPad", CPanel )
+	keytoggle:SetConVar1( "hoverball_keyon" )
+	keytoggle:SetLabel1( "#tool.toggle" )
+	CPanel:AddPanel( keytoggle )
+
+	-- Speed
+	local speed = CPanel:NumSlider( "#tool.hoverball.speed", "hoverball_speed", 0, 20, 2 )
+	local speedDefault = GetConVar( "hoverball_speed" )
+	CPanel:ControlHelp( "#tool.hoverball.speed" .. ".help" )
+	if ( speedDefault ) then
+		speed:SetDefaultValue( speedDefault:GetDefault() )
+	end
+
+	-- Resistance
+	local resistance = CPanel:NumSlider( "#tool.hoverball.resistance", "hoverball_resistance", 0, 10, 2 )
+	local resistanceDefault = GetConVar( "hoverball_resistance" )
+	CPanel:ControlHelp( "#tool.hoverball.resistance" .. ".help" )
+	if ( resistanceDefault ) then
+		resistance:SetDefaultValue( resistanceDefault:GetDefault() )
+	end
+
+	-- Strength
+	local strength = CPanel:NumSlider( "#tool.hoverball.strength", "hoverball_strength", 0.1, 10, 2 )
+	local strengthDefault = GetConVar( "hoverball_strength" )
+	CPanel:ControlHelp( "#tool.hoverball.strength" .. ".help" )
+	if ( strengthDefault ) then
+		strength:SetDefaultValue( strengthDefault:GetDefault() )
+	end
+
+	-- Model
+	local model = vgui.Create( "PropSelect", CPanel )
+	model:ControlValues( { label = "#tool.hoverball.model", convar = "hoverball_model", models = list.Get( "HoverballModels" ), height = 0 } )
+	CPanel:AddPanel( model )
 
 end
 

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/hydraulic.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/hydraulic.lua
@@ -227,18 +227,65 @@ local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description = "#tool.hydraulic.help" } )
+	CPanel:Help( "#tool.hydraulic.help" )
 
-	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "hydraulic", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	-- Presets
+	local presets = vgui.Create( "ControlPresets", CPanel )
+	presets:SetPreset( "hydraulic" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	CPanel:AddPanel( presets )
 
-	CPanel:AddControl( "Numpad", { Label = "#tool.hydraulic.controls", Command = "hydraulic_group" } )
-	CPanel:AddControl( "Slider", { Label = "#tool.hydraulic.addlength", Command = "hydraulic_addlength", Type = "Float", Min = -1000, Max = 1000, Help = true } )
-	CPanel:AddControl( "Slider", { Label = "#tool.hydraulic.speed", Command = "hydraulic_speed", Type = "Float", Min = 0, Max = 50, Help = true } )
-	CPanel:AddControl( "CheckBox", { Label = "#tool.hydraulic.fixed", Command = "hydraulic_fixed", Help = true } )
-	CPanel:AddControl( "CheckBox", { Label = "#tool.toggle", Command = "hydraulic_toggle", Help = true } )
+	-- Control
+	local control = vgui.Create( "CtrlNumPad", CPanel )
+	control:SetConVar1( "hydraulic_group" )
+	control:SetLabel1( "#tool.hydraulic.controls" )
+	CPanel:AddPanel( control )
 
-	CPanel:AddControl( "Slider", { Label = "#tool.hydraulic.width", Command = "hydraulic_width", Type = "Float", Min = 0, Max = 5 } )
-	CPanel:AddControl( "RopeMaterial", { Label = "#tool.hydraulic.material", ConVar = "hydraulic_material" } )
-	CPanel:AddControl( "Color", { Label = "#tool.hydraulic.color", Red = "hydraulic_color_r", Green = "hydraulic_color_g", Blue = "hydraulic_color_b" } )
+	-- Add length
+	local addLength = CPanel:NumSlider( "#tool.hydraulic.addlength", "hydraulic_addlength", -1000, 1000, 2 )
+	local addLengthDefault = GetConVar( "hydraulic_addlength" )
+	CPanel:ControlHelp( "#tool.hydraulic.addlength" .. ".help" )
+	if ( addLengthDefault ) then
+		addLength:SetDefaultValue( addLengthDefault:GetDefault() )
+	end
+
+	-- Speed
+	local speed = CPanel:NumSlider( "#tool.hydraulic.speed", "hydraulic_speed", 0, 50, 2 )
+	local speedDefault = GetConVar( "hydraulic_speed" )
+	CPanel:ControlHelp( "#tool.hydraulic.speed" .. ".help" )
+	if ( speedDefault ) then
+		speed:SetDefaultValue( speedDefault:GetDefault() )
+	end
+
+	-- Fixed
+	CPanel:CheckBox( "#tool.hydraulic.fixed", "hydraulic_fixed" )
+	CPanel:ControlHelp( "#tool.hydraulic.fixed" .. ".help" )
+
+	-- Toggle
+	CPanel:CheckBox( "#tool.toggle", "hydraulic_toggle" )
+	CPanel:ControlHelp( "#tool.toggle" .. ".help" )
+
+	-- Width
+	local width = CPanel:NumSlider( "#tool.hydraulic.width", "hydraulic_width", 0, 5, 2 )
+	local widthDefault = GetConVar( "hydraulic_width" )
+	if ( widthDefault ) then
+		width:SetDefaultValue( widthDefault:GetDefault() )
+	end
+
+	-- Rope material
+	local material = vgui.Create( "RopeMaterial", CPanel )
+	material:SetConVar( "hydraulic_material" )
+	CPanel:AddPanel( material )
+
+	-- Color
+	local color = vgui.Create( "CtrlColor", CPanel )
+	color:SetLabel( "#tool.hydraulic.color" )
+	color:SetConVarR( "hydraulic_color_r" )
+	color:SetConVarG( "hydraulic_color_g" )
+	color:SetConVarB( "hydraulic_color_b" )
+	CPanel:AddPanel( color )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/inflator.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/inflator.lua
@@ -142,6 +142,6 @@ end
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description = "#tool.inflator.desc" } )
+	CPanel:Help( "#tool.inflator.desc" )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/lamp.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/lamp.lua
@@ -237,20 +237,56 @@ local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description = "#tool.lamp.desc" } )
+	CPanel:Help( "#tool.lamp.desc" )
 
-	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "lamp", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	-- Presets
+	local presets = vgui.Create( "ControlPresets", CPanel )
+	presets:SetPreset( "lamp" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	CPanel:AddPanel( presets )
 
-	CPanel:AddControl( "Numpad", { Label = "#tool.lamp.key", Command = "lamp_key" } )
+	-- Key
+	local numpad = vgui.Create( "CtrlNumPad", CPanel )
+	numpad:SetConVar1( "lamp_key" )
+	numpad:SetLabel1( "#tool.lamp.key" )
+	CPanel:AddPanel( numpad )
 
-	CPanel:AddControl( "Slider", { Label = "#tool.lamp.fov", Command = "lamp_fov", Type = "Float", Min = 10, Max = 170 } )
-	CPanel:AddControl( "Slider", { Label = "#tool.lamp.distance", Command = "lamp_distance", Min = 64, Max = 2048 } )
-	CPanel:AddControl( "Slider", { Label = "#tool.lamp.brightness", Command = "lamp_brightness", Type = "Float", Min = 0, Max = 8 } )
+	-- Field of view
+	local fov = CPanel:NumSlider( "#tool.lamp.fov", "lamp_fov", 10, 170, 2 )
+	local fovDefault = GetConVar( "lamp_fov" )
+	if ( fovDefault ) then
+		fov:SetDefaultValue( fovDefault:GetDefault() )
+	end
 
-	CPanel:AddControl( "Checkbox", { Label = "#tool.lamp.toggle", Command = "lamp_toggle" } )
+	-- Distance
+	local distance = CPanel:NumSlider( "#tool.lamp.distance", "lamp_distance", 64, 2048, 2 )
+	local distanceDefault = GetConVar( "lamp_distance" )
+	if ( distanceDefault ) then
+		distance:SetDefaultValue( distanceDefault:GetDefault() )
+	end
 
-	CPanel:AddControl( "Color", { Label = "#tool.lamp.color", Red = "lamp_r", Green = "lamp_g", Blue = "lamp_b" } )
+	-- Brightness
+	local brightness = CPanel:NumSlider( "#tool.lamp.brightness", "lamp_brightness", 0, 8, 2 )
+	local brightnessDefault = GetConVar( "lamp_brightness" )
+	if ( brightnessDefault ) then
+		brightness:SetDefaultValue( brightnessDefault:GetDefault() )
+	end
 
+	-- Toggle
+	CPanel:CheckBox( "#tool.lamp.toggle", "lamp_toggle" )
+
+	-- Color
+	local color = vgui.Create( "CtrlColor", CPanel )
+	color:SetLabel( "#tool.lamp.color" )
+	color:SetConVarR( "lamp_r" )
+	color:SetConVarG( "lamp_g" )
+	color:SetConVarB( "lamp_b" )
+	CPanel:AddPanel( color )
+
+	-- Material
 	local MatSelect = CPanel:MatSelect( "lamp_texture", nil, false, 0.33, 0.33 )
 	MatSelect.Height = 4
 
@@ -258,7 +294,10 @@ function TOOL.BuildCPanel( CPanel )
 		MatSelect:AddMaterial( v.Name or k, k )
 	end
 
-	CPanel:AddControl( "PropSelect", { Label = "#tool.lamp.model", ConVar = "lamp_model", Height = 0, Models = list.Get( "LampModels" ) } )
+	-- Model
+	local model = vgui.Create( "PropSelect", CPanel )
+	model:ControlValues( { label = "#tool.lamp.model", convar = "lamp_model", height = 0, models = list.Get( "LampModels" ) } )
+	CPanel:AddPanel( model )
 
 end
 

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/light.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/light.lua
@@ -216,18 +216,53 @@ local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description = "#tool.light.desc" } )
+	CPanel:Help( "#tool.light.desc" )
 
-	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "light", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	-- Presets
+	local presets = vgui.Create( "ControlPresets", CPanel )
+	presets:SetPreset( "light" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	CPanel:AddPanel( presets )
 
-	CPanel:AddControl( "Numpad", { Label = "#tool.light.key", Command = "light_key", ButtonSize = 22 } )
+	-- Key
+	local numpad = vgui.Create( "CtrlNumPad", CPanel )
+	numpad:SetConVar1( "light_key" )
+	numpad:SetLabel1( "#tool.light.key" )
+	CPanel:AddPanel( numpad )
 
-	CPanel:AddControl( "Slider", { Label = "#tool.light.ropelength", Command = "light_ropelength", Type = "Float", Min = 0, Max = 256 } )
-	CPanel:AddControl( "Slider", { Label = "#tool.light.brightness", Command = "light_brightness", Type = "Int", Min = -6, Max = 6 } )
-	CPanel:AddControl( "Slider", { Label = "#tool.light.size", Command = "light_size", Type = "Float", Min = 0, Max = 1024 } )
+	-- Rope length
+	local length = CPanel:NumSlider( "#tool.light.ropelength", "light_ropelength", 0, 256, 2 )
+	local lengthDefault = GetConVar( "light_ropelength" )
+	if ( lengthDefault ) then
+		length:SetDefaultValue( lengthDefault:GetDefault() )
+	end
 
-	CPanel:AddControl( "Checkbox", { Label = "#tool.light.toggle", Command = "light_toggle" } )
+	-- Brightness
+	local brightness = CPanel:NumSlider( "#tool.light.brightness", "light_brightness", -6, 6, 0 )
+	local brightnessDefault = GetConVar( "light_brightness" )
+	if ( brightnessDefault ) then
+		brightness:SetDefaultValue( brightnessDefault:GetDefault() )
+	end
 
-	CPanel:AddControl( "Color", { Label = "#tool.light.color", Red = "light_r", Green = "light_g", Blue = "light_b" } )
+	-- Size
+	local size = CPanel:NumSlider( "#tool.light.size", "light_size", 0, 1024, 2 )
+	local sizeDefault = GetConVar( "light_size" )
+	if ( sizeDefault ) then
+		size:SetDefaultValue( sizeDefault:GetDefault() )
+	end
+
+	-- No collide
+	CPanel:CheckBox( "#tool.light.toggle", "light_toggle" )
+
+	-- Color
+	local color = vgui.Create( "CtrlColor", CPanel )
+	color:SetLabel( "#tool.light.color" )
+	color:SetConVarR( "light_r" )
+	color:SetConVarG( "light_g" )
+	color:SetConVarB( "light_b" )
+	CPanel:AddPanel( color )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/material.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/material.lua
@@ -127,9 +127,9 @@ end
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description = "#tool.material.help" } )
+	CPanel:Help( "#tool.material.help" )
 
-	local filter = CPanel:AddControl( "TextBox", { Label = "#spawnmenu.quick_filter_tool" } )
+	local filter = CPanel:TextEntry( "#spawnmenu.quick_filter_tool", nil )
 	filter:SetUpdateOnType( true )
 
 	-- Remove duplicate materials. table.HasValue is used to preserve material order

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/motor.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/motor.lua
@@ -142,16 +142,62 @@ local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description = "#tool.motor.help" } )
+	CPanel:Help( "#tool.motor.help" )
 
-	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "motor", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	-- Presets
+	local presets = vgui.Create( "ControlPresets", CPanel )
+	presets:SetPreset( "motor" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	CPanel:AddPanel( presets )
 
-	CPanel:AddControl( "Numpad", { Label = "#tool.motor.numpad1", Command = "motor_fwd", Label2 = "#tool.motor.numpad2", Command2 = "motor_bwd" } )
-	CPanel:AddControl( "Slider", { Label = "#tool.motor.torque", Command = "motor_torque", Type = "Float", Min = 0, Max = 10000 } )
-	CPanel:AddControl( "Slider", { Label = "#tool.forcelimit", Command = "motor_forcelimit", Type = "Float", Min = 0, Max = 50000, Help = true } )
-	CPanel:AddControl( "Slider", { Label = "#tool.hingefriction", Command = "motor_friction", Type = "Float", Min = 0, Max = 100, Help = true } )
-	CPanel:AddControl( "Slider", { Label = "#tool.motor.forcetime", Command = "motor_forcetime", Type = "Float", Min = 0, Max = 120, Help = true } )
-	CPanel:AddControl( "CheckBox", { Label = "#tool.nocollide", Command = "motor_nocollide", Help = true } )
-	CPanel:AddControl( "CheckBox", { Label = "#tool.toggle", Command = "motor_toggle", Help = true } )
+	-- Key
+	local numpad = vgui.Create( "CtrlNumPad", CPanel )
+	numpad:SetConVar1( "motor_fwd" )
+	numpad:SetConVar2( "motor_bwd" )
+	numpad:SetLabel1( "#tool.motor.numpad1" )
+	numpad:SetLabel2( "#tool.motor.numpad2" )
+	CPanel:AddPanel( numpad )
+
+	-- Torque
+	local torque = CPanel:NumSlider( "#tool.motor.torque", "motor_torque", 0, 10000, 2 )
+	local torqueDefault = GetConVar( "motor_torque" )
+	if ( torqueDefault ) then
+		torque:SetDefaultValue( torqueDefault:GetDefault() )
+	end
+
+	-- Force limit
+	local forceLimit = CPanel:NumSlider( "#tool.forcelimit", "motor_forcelimit", 0, 50000, 2 )
+	local forceLimitDefault = GetConVar( "motor_forcelimit" )
+	CPanel:ControlHelp( "#tool.forcelimit" .. ".help" )
+	if ( forceLimitDefault ) then
+		forceLimit:SetDefaultValue( forceLimitDefault:GetDefault() )
+	end
+
+	-- Hinge friction
+	local hingeFriction = CPanel:NumSlider( "#tool.hingefriction", "motor_friction", 0, 100, 2 )
+	local hingeFrictionDefault = GetConVar( "motor_friction" )
+	CPanel:ControlHelp( "#tool.hingefriction" .. ".help" )
+	if ( hingeFrictionDefault ) then
+		hingeFriction:SetDefaultValue( hingeFrictionDefault:GetDefault() )
+	end
+
+	-- Force time
+	local forceTime = CPanel:NumSlider( "#tool.motor.forcetime", "motor_forcetime", 0, 120, 2 )
+	local forceTimeDefault = GetConVar( "motor_forcetime" )
+	CPanel:ControlHelp( "#tool.motor.forcetime" .. ".help" )
+	if ( forceTimeDefault ) then
+		forceTime:SetDefaultValue( forceTimeDefault:GetDefault() )
+	end
+
+	-- No collide
+	CPanel:CheckBox( "#tool.nocollide", "motor_nocollide" )
+	CPanel:ControlHelp( "#tool.nocollide" .. ".help" )
+
+	-- Toggle
+	CPanel:CheckBox( "#tool.toggle", "motor_toggle" )
+	CPanel:ControlHelp( "#tool.toggle" .. ".help" )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/muscle.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/muscle.lua
@@ -239,18 +239,65 @@ local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description = "#tool.muscle.help" } )
+	CPanel:Help( "#tool.muscle.help" )
 
-	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "muscle", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	-- Presets
+	local presets = vgui.Create( "ControlPresets", CPanel )
+	presets:SetPreset( "muscle" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	CPanel:AddPanel( presets )
 
-	CPanel:AddControl( "Numpad", { Label = "#tool.muscle.numpad", Command = "muscle_group" } )
-	CPanel:AddControl( "Slider", { Label = "#tool.muscle.length", Command = "muscle_addlength", Type = "Float", Min = -1000, Max = 1000, Help = true } )
-	CPanel:AddControl( "Slider", { Label = "#tool.muscle.period", Command = "muscle_period", Type = "Float", Min = 0, Max = 10, Help = true } )
-	CPanel:AddControl( "CheckBox", { Label = "#tool.muscle.fixed", Command = "muscle_fixed", Help = true } )
-	CPanel:AddControl( "CheckBox", { Label = "#tool.muscle.starton", Command = "muscle_starton", Help = true } )
+	-- Key
+	local numpad = vgui.Create( "CtrlNumPad", CPanel )
+	numpad:SetConVar1( "muscle_group" )
+	numpad:SetLabel1( "#tool.muscle.numpad" )
+	CPanel:AddPanel( numpad )
 
-	CPanel:AddControl( "Slider", { Label = "#tool.muscle.width", Command = "muscle_width", Type = "Float", Min = 0, Max = 5 } )
-	CPanel:AddControl( "RopeMaterial", { Label = "#tool.muscle.material", ConVar = "muscle_material" } )
-	CPanel:AddControl( "Color", { Label = "#tool.muscle.color", Red = "muscle_color_r", Green = "muscle_color_g", Blue = "muscle_color_b" } )
+	-- Length
+	local length = CPanel:NumSlider( "#tool.muscle.length", "muscle_addlength", -1000, 1000, 2 )
+	local lengthDefault = GetConVar( "muscle_addlength" )
+	CPanel:ControlHelp( "#tool.muscle.length" .. ".help" )
+	if ( lengthDefault ) then
+		length:SetDefaultValue( lengthDefault:GetDefault() )
+	end
+
+	-- Period
+	local period = CPanel:NumSlider( "#tool.muscle.period", "muscle_period", 0, 10, 2 )
+	local periodDefault = GetConVar( "muscle_period" )
+	CPanel:ControlHelp( "#tool.muscle.period" .. ".help" )
+	if ( periodDefault ) then
+		period:SetDefaultValue( periodDefault:GetDefault() )
+	end
+
+	-- Fixed
+	CPanel:CheckBox( "#tool.muscle.fixed", "muscle_fixed" )
+	CPanel:ControlHelp( "#tool.muscle.fixed" .. ".help" )
+
+	-- Start on
+	CPanel:CheckBox( "#tool.muscle.starton", "muscle_starton" )
+	CPanel:ControlHelp( "#tool.muscle.starton" .. ".help" )
+
+	-- Width
+	local width = CPanel:NumSlider( "#tool.muscle.width", "muscle_width", 0, 5, 2 )
+	local widthDefault = GetConVar( "muscle_width" )
+	if ( widthDefault ) then
+		width:SetDefaultValue( widthDefault:GetDefault() )
+	end
+
+	-- Rope material
+	local material = vgui.Create( "RopeMaterial", CPanel )
+	material:SetConVar( "muscle_material" )
+	CPanel:AddPanel( material )
+
+	-- Color
+	local color = vgui.Create( "CtrlColor", CPanel )
+	color:SetLabel( "#tool.muscle.color" )
+	color:SetConVarR( "muscle_color_r" )
+	color:SetConVarG( "muscle_color_g" )
+	color:SetConVarB( "muscle_color_b" )
+	CPanel:AddPanel( color )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/nocollide.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/nocollide.lua
@@ -103,6 +103,6 @@ end
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description = "#tool.nocollide.desc" } )
+	CPanel:Help( "#tool.nocollide.desc" )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/paint.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/paint.lua
@@ -147,12 +147,22 @@ function TOOL.BuildCPanel( CPanel )
 
 	table.sort( Options )
 
-	local listbox = CPanel:AddControl( "ListBox", { Label = "#tool.paint.texture", Height = 17 + table.Count( Options ) * 17 } )
+	local listbox = vgui.Create( "DListView" )
+	listbox:SetMultiSelect( false )
+	listbox:AddColumn( "#tool.paint.texture" )
+	listbox:SetTall( 17 + table.Count( Options ) * 17 )
+	listbox:SortByColumn( 1, false )
+	function listbox:OnRowSelected( LineID, Line )
+		for k, v in pairs( Line.data ) do
+			RunConsoleCommand( k, v )
+		end
+	end
 	for k, decal in ipairs( Options ) do
 		local line = listbox:AddLine( decal )
 		line.data = { paint_decal = decal, gmod_tool = "paint" }
 
 		if ( GetConVarString( "paint_decal" ) == tostring( decal ) ) then line:SetSelected( true ) end
 	end
+	CPanel:AddItem( listbox )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/physprop.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/physprop.lua
@@ -40,11 +40,29 @@ local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "physprop", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	-- Presets
+	local presets = vgui.Create( "ControlPresets", CPanel )
+	presets:SetPreset( "physprop" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	CPanel:AddPanel( presets )
 
-	CPanel:AddControl( "ListBox", { Label = "#tool.physprop.material", Options = list.Get( "PhysicsMaterials" ) } )
+	-- Property
+	local property = vgui.Create( "CtrlListBox", CPanel )
+	for k, v in pairs( list.Get( "PhysicsMaterials" ) ) do
+		property:AddOption( k, v )
+	end
+	local propertyLabel = vgui.Create( "DLabel", CPanel )
+	propertyLabel:SetText( "#tool.physprop.material" )
+	propertyLabel:SetDark( true )
+	property:SetHeight( 25 )
+	property:Dock( TOP )
+	CPanel:AddItem( propertyLabel, property )
 
-	CPanel:AddControl( "CheckBox", { Label = "#tool.physprop.gravity", Command = "physprop_gravity_toggle" } )
+	-- Gravity
+	CPanel:CheckBox( "#tool.physprop.gravity", "physprop_gravity_toggle" )
 
 end
 

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/pulley.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/pulley.lua
@@ -107,15 +107,47 @@ local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description = "#tool.pulley.help" } )
+	CPanel:Help( "#tool.pulley.help" )
 
-	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "pulley", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	-- Presets
+	local presets = vgui.Create( "ControlPresets", CPanel )
+	presets:SetPreset( "pulley" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	CPanel:AddPanel( presets )
 
-	CPanel:AddControl( "Slider", { Label = "#tool.forcelimit", Command = "pulley_forcelimit", Type = "Float", Min = 0, Max = 1000, Help = true } )
-	CPanel:AddControl( "CheckBox", { Label = "#tool.pulley.rigid", Command = "pulley_rigid", Help = true } )
+	-- Force limit
+	local forceLimit = CPanel:NumSlider( "#tool.forcelimit", "pulley_forcelimit", 0, 1000, 2 )
+	local forceLimitDefault = GetConVar( "pulley_forcelimit" )
+	CPanel:ControlHelp( "#tool.forcelimit" .. ".help" )
+	if ( forceLimitDefault ) then
+		forceLimit:SetDefaultValue( forceLimitDefault:GetDefault() )
+	end
 
-	CPanel:AddControl( "Slider", { Label = "#tool.pulley.width", Command = "pulley_width", Type = "Float", Min = 0, Max = 10 } )
-	CPanel:AddControl( "RopeMaterial", { Label = "#tool.pulley.material", ConVar = "pulley_material" } )
-	CPanel:AddControl( "Color", { Label = "#tool.pulley.color", Red = "pulley_color_r", Green = "pulley_color_g", Blue = "pulley_color_b" } )
+	-- No collide
+	CPanel:CheckBox( "#tool.pulley.rigid", "pulley_rigid" )
+	CPanel:ControlHelp( "#tool.pulley.rigid" .. ".help" )
+
+	-- Width
+	local width = CPanel:NumSlider( "#tool.pulley.width", "pulley_width", 0, 10, 2 )
+	local widthDefault = GetConVar( "pulley_width" )
+	if ( widthDefault ) then
+		width:SetDefaultValue( widthDefault:GetDefault() )
+	end
+
+	-- Rope material
+	local material = vgui.Create( "RopeMaterial", CPanel )
+	material:SetConVar( "pulley_material" )
+	CPanel:AddPanel( material )
+
+	-- Color
+	local color = vgui.Create( "CtrlColor", CPanel )
+	color:SetLabel( "#tool.pulley.color" )
+	color:SetConVarR( "pulley_color_r" )
+	color:SetConVarG( "pulley_color_g" )
+	color:SetConVarB( "pulley_color_b" )
+	CPanel:AddPanel( color )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/remover.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/remover.lua
@@ -98,6 +98,6 @@ end
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description = "#tool.remover.desc" } )
+	CPanel:Help( "#tool.remover.desc" )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/rope.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/rope.lua
@@ -178,18 +178,55 @@ local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description = "#tool.rope.help" } )
+	CPanel:Help( "#tool.rope.help" )
 
-	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "rope", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	-- Presets
+	local presets = vgui.Create( "ControlPresets", CPanel )
+	presets:SetPreset( "rope" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	CPanel:AddPanel( presets )
 
-	CPanel:AddControl( "Slider", { Label = "#tool.forcelimit", Command = "rope_forcelimit", Type = "Float", Min = 0, Max = 1000, Help = true } )
-	CPanel:AddControl( "Slider", { Label = "#tool.rope.addlength", Command = "rope_addlength", Type = "Float", Min = -500, Max = 500, Help = true } )
+	-- Force limit
+	local forceLimit = CPanel:NumSlider( "#tool.forcelimit", "rope_forcelimit", 0, 1000, 2 )
+	local forceLimitDefault = GetConVar( "rope_forcelimit" )
+	CPanel:ControlHelp( "#tool.forcelimit" .. ".help" )
+	if ( forceLimitDefault ) then
+		forceLimit:SetDefaultValue( forceLimitDefault:GetDefault() )
+	end
 
-	CPanel:AddControl( "CheckBox", { Label = "#tool.rope.rigid", Command = "rope_rigid", Help = true } )
+	-- Add length
+	local addLength = CPanel:NumSlider( "#tool.rope.addlength", "rope_addlength", -500, 500, 2 )
+	local addLengthDefault = GetConVar( "rope_addlength" )
+	CPanel:ControlHelp( "#tool.rope.addlength" .. ".help" )
+	if ( addLengthDefault ) then
+		addLength:SetDefaultValue( addLengthDefault:GetDefault() )
+	end
 
-	CPanel:AddControl( "Slider", { Label = "#tool.rope.width", Command = "rope_width", Type = "Float", Min = 0, Max = 10 } )
-	CPanel:AddControl( "RopeMaterial", { Label = "#tool.rope.material", ConVar = "rope_material" } )
+	-- Rigid
+	CPanel:CheckBox( "#tool.rope.rigid", "rope_rigid" )
+	CPanel:ControlHelp( "#tool.rope.rigid" .. ".help" )
 
-	CPanel:AddControl( "Color", { Label = "#tool.rope.color", Red = "rope_color_r", Green = "rope_color_g", Blue = "rope_color_b" } )
+	-- Width
+	local width = CPanel:NumSlider( "#tool.rope.width", "rope_width", 0, 10, 2 )
+	local widthDefault = GetConVar( "rope_width" )
+	if ( widthDefault ) then
+		width:SetDefaultValue( widthDefault:GetDefault() )
+	end
+
+	-- Rope material
+	local material = vgui.Create( "RopeMaterial", CPanel )
+	material:SetConVar( "rope_material" )
+	CPanel:AddPanel( material )
+
+	-- Color
+	local color = vgui.Create( "CtrlColor", CPanel )
+	color:SetLabel( "#tool.rope.color" )
+	color:SetConVarR( "rope_color_r" )
+	color:SetConVarG( "rope_color_g" )
+	color:SetConVarB( "rope_color_b" )
+	CPanel:AddPanel( color )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/slider.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/slider.lua
@@ -187,13 +187,35 @@ local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description = "#tool.slider.help" } )
+	CPanel:Help( "#tool.slider.help" )
 
-	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "slider", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	-- Presets
+	local presets = vgui.Create( "ControlPresets", CPanel )
+	presets:SetPreset( "slider" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	CPanel:AddPanel( presets )
 
-	CPanel:AddControl( "Slider", { Label = "#tool.slider.width", Command = "slider_width", Type = "Float", Min = 0, Max = 10 } )
-	CPanel:AddControl( "RopeMaterial", { Label = "#tool.slider.material", ConVar = "slider_material" } )
+	-- Width
+	local width = CPanel:NumSlider( "#tool.slider.width", "slider_width", 0, 10, 2 )
+	local widthDefault = GetConVar( "slider_width" )
+	if ( widthDefault ) then
+		width:SetDefaultValue( widthDefault:GetDefault() )
+	end
 
-	CPanel:AddControl( "Color", { Label = "#tool.slider.color", Red = "slider_color_r", Green = "slider_color_g", Blue = "slider_color_b" } )
+	-- Rope material
+	local material = vgui.Create( "RopeMaterial", CPanel )
+	material:SetConVar( "slider_material" )
+	CPanel:AddPanel( material )
+
+	-- Color
+	local color = vgui.Create( "CtrlColor", CPanel )
+	color:SetLabel( "#tool.slider.color" )
+	color:SetConVarR( "slider_color_r" )
+	color:SetConVarG( "slider_color_g" )
+	color:SetConVarB( "slider_color_b" )
+	CPanel:AddPanel( color )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/thruster.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/thruster.lua
@@ -222,26 +222,69 @@ local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description = "#tool.thruster.desc" } )
+	CPanel:Help( "#tool.thruster.desc" )
 
-	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "thruster", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	-- Presets
+	local presets = vgui.Create( "ControlPresets", CPanel )
+	presets:SetPreset( "thruster" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	CPanel:AddPanel( presets )
 
-	CPanel:AddControl( "Numpad", { Label = "#tool.thruster.forward", Command = "thruster_keygroup", Label2 = "#tool.thruster.back", Command2 = "thruster_keygroup_back" } )
+	-- Movement
+	local numpad = vgui.Create( "CtrlNumPad", CPanel )
+	numpad:SetConVar1( "thruster_keygroup" )
+	numpad:SetConVar2( "thruster_keygroup_back" )
+	numpad:SetLabel1( "#tool.thruster.forward" )
+	numpad:SetLabel2( "#tool.thruster.back" )
+	CPanel:AddPanel( numpad )
 
-	CPanel:AddControl( "Slider", { Label = "#tool.thruster.force", Command = "thruster_force", Type = "Float", Min = 1, Max = 10000 } )
-
-	local combo = CPanel:AddControl( "ListBox", { Label = "#tool.thruster.effect" } )
-	for k, v in pairs( list.Get( "ThrusterEffects" ) ) do
-		combo:AddOption( k, { thruster_effect = v.thruster_effect } )
+	-- Force
+	local force = CPanel:NumSlider( "#tool.thruster.force", "thruster_force", 1, 10000, 2 )
+	local forceDefault = GetConVar( "thruster_force" )
+	if ( forceDefault ) then
+		force:SetDefaultValue( forceDefault:GetDefault() )
 	end
 
-	CPanel:AddControl( "ListBox", { Label = "#tool.thruster.sound", Options = list.Get( "ThrusterSounds" ) } )
+	-- Effect
+	local effect = vgui.Create( "CtrlListBox", CPanel )
+	local effectLabel = vgui.Create( "DLabel", CPanel )
+	for k, v in pairs( list.Get( "ThrusterEffects" ) ) do
+		effect:AddOption( k, { thruster_effect = v.thruster_effect } )
+	end
+	effectLabel:SetText( "#tool.thruster.effect" )
+	effectLabel:SetDark( true )
+	effect:SetHeight( 25 )
+	effect:Dock( TOP )
+	CPanel:AddItem( effectLabel, effect )
 
-	CPanel:AddControl( "CheckBox", { Label = "#tool.thruster.toggle", Command = "thruster_toggle" } )
-	CPanel:AddControl( "CheckBox", { Label = "#tool.thruster.collision", Command = "thruster_collision" } )
-	CPanel:AddControl( "CheckBox", { Label = "#tool.thruster.damagable", Command = "thruster_damageable" } )
+	-- Sound
+	local sound = vgui.Create( "CtrlListBox", CPanel )
+	local soundLabel = vgui.Create( "DLabel", CPanel )
+	for k, v in pairs( list.Get( "ThrusterSounds" ) ) do
+		sound:AddOption( k, v )
+	end
+	soundLabel:SetText( "#tool.thruster.sound" )
+	soundLabel:SetDark( true )
+	sound:SetHeight( 25 )
+	sound:Dock( TOP )
+	CPanel:AddItem( soundLabel, sound )
 
-	CPanel:AddControl( "PropSelect", { Label = "#tool.thruster.model", ConVar = "thruster_model", Height = 0, Models = list.Get( "ThrusterModels" ) } )
+	-- Toggle
+	CPanel:CheckBox( "#tool.thruster.toggle", "thruster_toggle" )
+
+	-- Collision
+	CPanel:CheckBox( "#tool.thruster.collision", "thruster_collision" )
+
+	-- Damagable
+	CPanel:CheckBox( "#tool.thruster.damagable", "thruster_damageable" )
+
+	-- Model
+	local model = vgui.Create( "PropSelect", CPanel )
+	model:ControlValues( { label = "#tool.thruster.model", convar = "thruster_model", height = 0, models = list.Get( "ThrusterModels" ) } )
+	CPanel:AddPanel( model )
 
 end
 

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/trails.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/trails.lua
@@ -146,11 +146,25 @@ local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description = "#tool.trails.desc" } )
+	CPanel:Help( "#tool.trails.desc" )
 
-	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "trails", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	-- Presets
+	local presets = vgui.Create( "ControlPresets", CPanel )
+	presets:SetPreset( "trails" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	CPanel:AddPanel( presets )
 
-	CPanel:AddControl( "Color", { Label = "#tool.trails.color", Red = "trails_r", Green = "trails_g", Blue = "trails_b", Alpha = "trails_a" } )
+	-- Color
+	local color = vgui.Create( "CtrlColor", CPanel )
+	color:SetLabel( "#tool.trails.color" )
+	color:SetConVarR( "trails_r" )
+	color:SetConVarG( "trails_g" )
+	color:SetConVarB( "trails_b" )
+	color:SetConVarA( "trails_a" )
+	CPanel:AddPanel( color )
 
 	CPanel:NumSlider( "#tool.trails.length", "trails_length", 0, 10, 2 )
 	CPanel:NumSlider( "#tool.trails.startsize", "trails_startsize", 0, 128, 2 )

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/weld.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/weld.lua
@@ -288,11 +288,26 @@ local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description = "#tool.weld.help" } )
+	CPanel:Help( "#tool.weld.help" )
 
-	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "weld", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	-- Presets
+	local presets = vgui.Create( "ControlPresets", CPanel )
+	presets:SetPreset( "weld" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	CPanel:AddPanel( presets )
 
-	CPanel:AddControl( "Slider", { Label = "#tool.forcelimit", Command = "weld_forcelimit", Type = "Float", Min = 0, Max = 1000, Help = true } )
-	CPanel:AddControl( "CheckBox", { Label = "#tool.nocollide", Command = "weld_nocollide" } )
+	-- Force limit
+	local forceLimit = CPanel:NumSlider( "#tool.forcelimit", "weld_forcelimit", 0, 1000, 2 )
+	local forceLimitDefault = GetConVar( "weld_forcelimit" )
+	CPanel:ControlHelp( "#tool.forcelimit" .. ".help" )
+	if ( forceLimitDefault ) then
+		forceLimit:SetDefaultValue( forceLimitDefault:GetDefault() )
+	end
+
+	-- No collide
+	CPanel:CheckBox( "#tool.nocollide", "weld_nocollide" )
 
 end

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/wheel.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/wheel.lua
@@ -247,20 +247,56 @@ local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description = "#tool.wheel.desc" } )
+	CPanel:Help( "#tool.wheel.desc" )
 
-	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "wheel", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	-- Presets
+	local presets = vgui.Create( "ControlPresets", CPanel )
+	presets:SetPreset( "wheel" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	CPanel:AddPanel( presets )
 
-	CPanel:AddControl( "Numpad", { Label = "#tool.wheel.forward", Command = "wheel_fwd", Label2 = "#tool.wheel.reverse", Command2 = "wheel_bck" } )
+	-- Key
+	local numpad = vgui.Create( "CtrlNumPad", CPanel )
+	numpad:SetConVar1( "wheel_fwd" )
+	numpad:SetConVar2( "wheel_bck" )
+	numpad:SetLabel1( "#tool.wheel.forward" )
+	numpad:SetLabel2( "#tool.wheel.reverse" )
+	CPanel:AddPanel( numpad )
 
-	CPanel:AddControl( "Slider", { Label = "#tool.wheel.torque", Command = "wheel_torque", Type = "Float", Min = 10, Max = 10000 } )
-	CPanel:AddControl( "Slider", { Label = "#tool.wheel.forcelimit", Command = "wheel_forcelimit", Type = "Float", Min = 0, Max = 50000 } )
-	CPanel:AddControl( "Slider", { Label = "#tool.wheel.friction", Command = "wheel_friction", Type = "Float", Min = 0, Max = 100 } )
+	-- Torque
+	local torque = CPanel:NumSlider( "#tool.wheel.torque", "wheel_torque", 10, 10000, 2 )
+	local torqueDefault = GetConVar( "wheel_torque" )
+	if ( torqueDefault ) then
+		torque:SetDefaultValue( torqueDefault:GetDefault() )
+	end
 
-	CPanel:AddControl( "CheckBox", { Label = "#tool.wheel.nocollide", Command = "wheel_nocollide" } )
-	CPanel:AddControl( "CheckBox", { Label = "#tool.wheel.toggle", Command = "wheel_toggle" } )
+	-- Force limit
+	local forceLimit = CPanel:NumSlider( "#tool.wheel.forcelimit", "wheel_forcelimit", 0, 50000, 2 )
+	local forceLimitDefault = GetConVar( "wheel_forcelimit" )
+	if ( forceLimitDefault ) then
+		forceLimit:SetDefaultValue( forceLimitDefault:GetDefault() )
+	end
 
-	CPanel:AddControl( "PropSelect", { Label = "#tool.wheel.model", ConVar = "wheel_model", Height = 0, Models = list.Get( "WheelModels" ) } )
+	-- Friction
+	local friction = CPanel:NumSlider( "#tool.wheel.friction", "wheel_friction", 0, 100, 2 )
+	local frictionDefault = GetConVar( "wheel_friction" )
+	if ( frictionDefault ) then
+		friction:SetDefaultValue( frictionDefault:GetDefault() )
+	end
+
+	-- No collide
+	CPanel:CheckBox( "#tool.wheel.nocollide", "wheel_nocollide" )
+
+	-- Toggle
+	CPanel:CheckBox( "#tool.wheel.toggle", "wheel_toggle" )
+
+	-- Model
+	local model = vgui.Create( "PropSelect", CPanel )
+	model:ControlValues( { label = "#tool.wheel.model", convar = "wheel_model", height = 0, models = list.Get( "WheelModels" ) } )
+	CPanel:AddPanel( model )
 
 end
 

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/winch.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/winch.lua
@@ -202,17 +202,59 @@ local ConVarsDefault = TOOL:BuildConVarList()
 
 function TOOL.BuildCPanel( CPanel )
 
-	CPanel:AddControl( "Header", { Description = "#tool.winch.help" } )
+	CPanel:Help( "#tool.winch.help" )
 
-	CPanel:AddControl( "ComboBox", { MenuButton = 1, Folder = "winch", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	-- Presets
+	local presets = vgui.Create( "ControlPresets", CPanel )
+	presets:SetPreset( "winch" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	CPanel:AddPanel( presets )
 
-	CPanel:AddControl( "Numpad", { Label = "#tool.winch.forward", Command = "winch_fwd_group", Label2 = "#tool.winch.backward", Command2 = "winch_bwd_group" } )
+	-- Key
+	local numpad = vgui.Create( "CtrlNumPad", CPanel )
+	numpad:SetConVar1( "winch_fwd_group" )
+	numpad:SetConVar2( "winch_bwd_group" )
+	numpad:SetLabel1( "#tool.winch.forward" )
+	numpad:SetLabel2( "#tool.winch.backward" )
+	CPanel:AddPanel( numpad )
 
-	CPanel:AddControl( "Slider", { Label = "#tool.winch.fspeed", Command = "winch_fwd_speed", Type = "Float", Min = 0, Max = 1000, Help = true } )
-	CPanel:AddControl( "Slider", { Label = "#tool.winch.bspeed", Command = "winch_bwd_speed", Type = "Float", Min = 0, Max = 1000, Help = true } )
-	CPanel:AddControl( "Slider", { Label = "#tool.winch.width", Command = "winch_rope_width", Type = "Float", Min = 0, Max = 10 } )
+	-- Forward speed
+	local forwardSpeed = CPanel:NumSlider( "#tool.winch.fspeed", "winch_fwd_speed", 0, 1000, 2 )
+	local forwardSpeedDefault = GetConVar( "winch_fwd_speed" )
+	CPanel:ControlHelp( "#tool.winch.fspeed" .. ".help" )
+	if ( forwardSpeedDefault ) then
+		forwardSpeed:SetDefaultValue( forwardSpeedDefault:GetDefault() )
+	end
 
-	CPanel:AddControl( "RopeMaterial", { Label = "#tool.winch.material", ConVar = "winch_rope_material" } )
-	CPanel:AddControl( "Color", { Label = "#tool.winch.color", Red = "winch_color_r", Green = "winch_color_g", Blue = "winch_color_b" } )
+	-- Backward speed
+	local backwardSpeed = CPanel:NumSlider( "#tool.winch.bspeed", "winch_bwd_speed", 0, 1000, 2 )
+	local backwardSpeedDefault = GetConVar( "winch_bwd_speed" )
+	CPanel:ControlHelp( "#tool.winch.bspeed" .. ".help" )
+	if ( backwardSpeedDefault ) then
+		backwardSpeed:SetDefaultValue( backwardSpeedDefault:GetDefault() )
+	end
+
+	-- Width
+	local width = CPanel:NumSlider( "#tool.winch.width", "winch_rope_width", 0, 10, 2 )
+	local widthDefault = GetConVar( "winch_rope_width" )
+	if ( widthDefault ) then
+		width:SetDefaultValue( widthDefault:GetDefault() )
+	end
+
+	-- Rope material
+	local material = vgui.Create( "RopeMaterial", CPanel )
+	material:SetConVar( "winch_rope_material" )
+	CPanel:AddPanel( material )
+
+	-- Color
+	local color = vgui.Create( "CtrlColor", CPanel )
+	color:SetLabel( "#tool.winch.color" )
+	color:SetConVarR( "winch_color_r" )
+	color:SetConVarG( "winch_color_g" )
+	color:SetConVarB( "winch_color_b" )
+	CPanel:AddPanel( color )
 
 end

--- a/garrysmod/lua/autorun/utilities_menu.lua
+++ b/garrysmod/lua/autorun/utilities_menu.lua
@@ -19,7 +19,7 @@ end
 
 local function ServerSettings( pnl )
 
-	pnl:AddControl( "Header", { Description = "#utilities.serversettings" } )
+	pnl:Help( "#utilities.serversettings" )
 
 	local ConVarsDefault = {
 		hostname = "Garry's Mod",
@@ -40,36 +40,81 @@ local function ServerSettings( pnl )
 		g_ragdoll_maxcount = "32",
 		sv_timeout = "65"
 	}
-	pnl:AddControl( "ComboBox", { MenuButton = 1, Folder = "util_server", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
 
-	pnl:AddControl( "TextBox", { Label = "#utilities.hostname", Command = "hostname", WaitForEnter = "1" } )
-	pnl:AddControl( "TextBox", { Label = "#utilities.password", Command = "sv_password", WaitForEnter = "1" } )
+	local presets = vgui.Create( "ControlPresets", pnl )
+	presets:SetPreset( "util_server" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	pnl:AddPanel( presets )
 
-	pnl:AddControl( "CheckBox", { Label = "#utilities.kickerrornum", Command = "sv_kickerrornum" } )
-	pnl:AddControl( "CheckBox", { Label = "#utilities.allowcslua", Command = "sv_allowcslua" } )
-	pnl:AddControl( "CheckBox", { Label = "#utilities.sticktoground", Command = "sv_sticktoground", Help = true } )
-	pnl:AddControl( "CheckBox", { Label = "#utilities.epickupallowed", Command = "sv_playerpickupallowed" } )
-	pnl:AddControl( "CheckBox", { Label = "#utilities.falldamage", Command = "mp_falldamage" } )
-	pnl:AddControl( "CheckBox", { Label = "#utilities.gmod_suit", Command = "gmod_suit" } )
+	pnl:TextEntry( "#utilities.hostname", "hostname" )
+	pnl:TextEntry( "#utilities.password", "sv_password" )
+
+	pnl:CheckBox( "#utilities.kickerrornum", "sv_kickerrornum" )
+	pnl:CheckBox( "#utilities.allowcslua", "sv_allowcslua" )
+	pnl:CheckBox( "#utilities.sticktoground", "sv_sticktoground" )
+	pnl:ControlHelp( "#utilities.sticktoground" .. ".help" )
+	pnl:CheckBox( "#utilities.epickupallowed", "sv_playerpickupallowed" )
+	pnl:CheckBox( "#utilities.falldamage", "mp_falldamage" )
+	pnl:CheckBox( "#utilities.gmod_suit", "gmod_suit" )
 
 	-- Fun convars
-	pnl:AddControl( "Slider", { Label = "#utilities.gravity", Type = "Integer", Command = "sv_gravity", Min = "-500", Max = "1000" } )
-	pnl:AddControl( "Slider", { Label = "#utilities.friction", Type = "Integer", Command = "sv_friction", Min = "0", Max = "16" } ) -- Float
-	pnl:AddControl( "Slider", { Label = "#utilities.timescale", Type = "Float", Command = "phys_timescale", Min = "0", Max = "2" } )
-	pnl:AddControl( "Slider", { Label = "#utilities.deployspeed", Type = "Float", Command = "sv_defaultdeployspeed", Min = "0.1", Max = "10" } )
-	pnl:AddControl( "Slider", { Label = "#utilities.noclipspeed", Type = "Integer", Command = "sv_noclipspeed", Min = "1", Max = "10" } ) -- Switch this and friction back to Float once Sliders don't reset the convar from 8 to 8.00, etc
-	pnl:AddControl( "Slider", { Label = "#utilities.maxammo", Type = "Integer", Command = "gmod_maxammo", Min = "0", Max = "9999", Help = true } )
-	pnl:AddControl( "Slider", { Label = "#utilities.max_ragdolls", Type = "Integer", Command = "g_ragdoll_maxcount", Min = "0", Max = "128" } )
+	local gravity = pnl:NumSlider( "#utilities.gravity", "sv_gravity", -500, 1000, 0 )
+	local gravityDefault = GetConVar( "sv_gravity" )
+	if ( gravityDefault ) then
+		gravity:SetDefaultValue( gravityDefault:GetDefault() )
+	end
+	local friction = pnl:NumSlider( "#utilities.friction", "sv_friction", 0, 16, 2 )
+	local frictionDefault = GetConVar( "sv_friction" )
+	if ( frictionDefault ) then
+		friction:SetDefaultValue( frictionDefault:GetDefault() )
+	end
+	local timescale = pnl:NumSlider( "#utilities.timescale", "phys_timescale", 0, 2, 2 )
+	local timescaleDefault = GetConVar( "phys_timescale" )
+	if ( timescaleDefault ) then
+		timescale:SetDefaultValue( timescaleDefault:GetDefault() )
+	end
+	local deployspeed = pnl:NumSlider( "#utilities.deployspeed", "sv_defaultdeployspeed", 0.1, 10, 2 )
+	local deployspeedDefault = GetConVar( "sv_defaultdeployspeed" )
+	if ( deployspeedDefault ) then
+		deployspeed:SetDefaultValue( deployspeedDefault:GetDefault() )
+	end
+	local noclipspeed = pnl:NumSlider( "#utilities.noclipspeed", "sv_noclipspeed", 1, 10, 2 )
+	local noclipspeedDefault = GetConVar( "sv_noclipspeed" )
+	if ( noclipspeedDefault ) then
+		noclipspeed:SetDefaultValue( noclipspeedDefault:GetDefault() )
+	end
+	local maxammo = pnl:NumSlider( "#utilities.maxammo", "gmod_maxammo", 0, 9999, 0 )
+	local maxammoDefault = GetConVar( "gmod_maxammo" )
+	pnl:ControlHelp( "#utilities.maxammo" .. ".help" )
+	if ( maxammoDefault ) then
+		maxammo:SetDefaultValue( maxammoDefault:GetDefault() )
+	end
+	local maxRagdolls = pnl:NumSlider( "#utilities.max_ragdolls", "g_ragdoll_maxcount", 0, 128, 0 )
+	local maxRagdollsDefault = GetConVar( "g_ragdoll_maxcount" )
+	if ( maxRagdollsDefault ) then
+		maxRagdolls:SetDefaultValue( maxRagdollsDefault:GetDefault() )
+	end
 
 	-- Technical convars
-	pnl:AddControl( "Slider", { Label = "#utilities.iterations", Type = "Integer", Command = "gmod_physiterations", Min = "1", Max = "10" } )
-	pnl:AddControl( "Slider", { Label = "#utilities.sv_timeout", Type = "Integer", Command = "sv_timeout", Min = "60", Max = "300" } )
+	local iterations = pnl:NumSlider( "#utilities.iterations", "gmod_physiterations", 1, 10, 0 )
+	local iterationsDefault = GetConVar( "gmod_physiterations" )
+	if ( iterationsDefault ) then
+		iterations:SetDefaultValue( iterationsDefault:GetDefault() )
+	end
+	local timeout = pnl:NumSlider( "#utilities.sv_timeout", "sv_timeout", 60, 300, 0 )
+	local timeoutDefault = GetConVar( "sv_timeout" )
+	if ( timeoutDefault ) then
+		timeout:SetDefaultValue( timeoutDefault:GetDefault() )
+	end
 
 end
 
 local function SandboxClientSettings( pnl )
 
-	pnl:AddControl( "Header", { Description = "#utilities.sandboxsettings_cl" } )
+	pnl:Help( "#utilities.sandboxsettings_cl" )
 
 	local ConVarsDefault = {
 		sbox_search_maxresults = "1024",
@@ -84,12 +129,23 @@ local function SandboxClientSettings( pnl )
 		cl_showhints = "1",
 	}
 
-	pnl:AddControl( "ComboBox", { MenuButton = 1, Folder = "util_sandbox_cl", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	local presets = vgui.Create( "ControlPresets", pnl )
+	presets:SetPreset( "util_sandbox_cl" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	pnl:AddPanel( presets )
 
-	pnl:AddControl( "Slider", { Label = "#utilities.max_results", Type = "Integer", Command = "sbox_search_maxresults", Min = "1024", Max = "8192", Help = true } )
+	local maxresults = pnl:NumSlider( "#utilities.max_results", "sbox_search_maxresults", 1024, 8192, 0 )
+	local maxresultsDefault = GetConVar( "sbox_search_maxresults" )
+	pnl:ControlHelp( "#utilities.max_results" .. ".help" )
+	if ( maxresultsDefault ) then
+		maxresults:SetDefaultValue( maxresultsDefault:GetDefault() )
+	end
 
 	local function AddCheckbox( title, cvar )
-		pnl:AddControl( "CheckBox", { Label = title, Command = cvar } )
+		pnl:CheckBox( title, cvar )
 	end
 
 	AddCheckbox( "#menubar.drawing.hud", "cl_drawhud" )
@@ -106,7 +162,7 @@ end
 
 local function SandboxSettings( pnl )
 
-	pnl:AddControl( "Header", { Description = "#utilities.sandboxsettings" } )
+	pnl:Help( "#utilities.sandboxsettings" )
 
 	local ConVarsDefault = {
 		sbox_persist = "",
@@ -134,25 +190,35 @@ local function SandboxSettings( pnl )
 		} )
 	end
 
-	pnl:AddControl( "ComboBox", { MenuButton = 1, Folder = "util_sandbox", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	local presets = vgui.Create( "ControlPresets", pnl )
+	presets:SetPreset( "util_sandbox" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	pnl:AddPanel( presets )
 
-	pnl:AddControl( "TextBox", { Label = "#persistent_mode", Command = "sbox_persist", WaitForEnter = "1" } )
+	pnl:TextEntry( "#persistent_mode", "sbox_persist" )
 	pnl:ControlHelp( "#persistent_mode.help" ):DockMargin( 16, 4, 16, 8 )
 
-	pnl:AddControl( "CheckBox", { Label = "#enable_weapons", Command = "sbox_weapons" } )
-	pnl:AddControl( "CheckBox", { Label = "#allow_god_mode", Command = "sbox_godmode" } )
+	pnl:CheckBox( "#enable_weapons", "sbox_weapons" )
+	pnl:CheckBox( "#allow_god_mode", "sbox_godmode" )
 
 	pnl:ControlHelp( "#utilities.mp_only" ):DockMargin( 16, 16, 16, 4 )
 
-	pnl:AddControl( "CheckBox", { Label = "#players_damage_players", Command = "sbox_playershurtplayers" } )
-	pnl:AddControl( "CheckBox", { Label = "#allow_noclip", Command = "sbox_noclip" } )
+	pnl:CheckBox( "#players_damage_players", "sbox_playershurtplayers" )
+	pnl:CheckBox( "#allow_noclip", "sbox_noclip" )
 
-	pnl:AddControl( "CheckBox", { Label = "#bone_manipulate_npcs", Command = "sbox_bonemanip_npc" } )
-	pnl:AddControl( "CheckBox", { Label = "#bone_manipulate_players", Command = "sbox_bonemanip_player" } )
-	pnl:AddControl( "CheckBox", { Label = "#bone_manipulate_others", Command = "sbox_bonemanip_misc" } )
+	pnl:CheckBox( "#bone_manipulate_npcs", "sbox_bonemanip_npc" )
+	pnl:CheckBox( "#bone_manipulate_players", "sbox_bonemanip_player" )
+	pnl:CheckBox( "#bone_manipulate_others", "sbox_bonemanip_misc" )
 
 	for id, t in SortedPairsByMemberValue( ConVarsLimits, "label" ) do
-		local ctrl = pnl:AddControl( "Slider", { Label = t.label, Command = t.command, Min = "0", Max = "200" } )
+		local ctrl = pnl:NumSlider( t.label, t.command, 0, 200, 0 )
+		local default = GetConVar( t.command )
+		if ( default ) then
+			ctrl:SetDefaultValue( default:GetDefault() )
+		end
 		ctrl:SetHeight( 16 ) -- This makes the controls all bunched up like how we want
 	end
 
@@ -160,7 +226,7 @@ end
 
 local function PhysgunSettings( pnl )
 
-	pnl:AddControl( "Header", { Description = "#utilities.physgunsettings" } )
+	pnl:Help( "#utilities.physgunsettings" )
 
 	local ConVarsDefault = {
 		physgun_halo = "1",
@@ -172,24 +238,46 @@ local function PhysgunSettings( pnl )
 		physgun_rotation_sensitivity = "0.05",
 		physgun_wheelspeed = "10"
 	}
-	pnl:AddControl( "ComboBox", { MenuButton = 1, Folder = "util_physgun", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	local presets = vgui.Create( "ControlPresets", pnl )
+	presets:SetPreset( "util_physgun" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	pnl:AddPanel( presets )
 
-	pnl:AddControl( "CheckBox", { Label = "#utilities.physgun_halo", Command = "physgun_halo" } )
-	pnl:AddControl( "CheckBox", { Label = "#utilities.physgun_drawbeams", Command = "physgun_drawbeams" } )
-	pnl:AddControl( "CheckBox", { Label = "#menubar.drawing.freeze", Command = "effects_freeze" } )
-	pnl:AddControl( "CheckBox", { Label = "#menubar.drawing.unfreeze", Command = "effects_unfreeze" } )
+	pnl:CheckBox( "#utilities.physgun_halo", "physgun_halo" )
+	pnl:CheckBox( "#utilities.physgun_drawbeams", "physgun_drawbeams" )
+	pnl:CheckBox( "#menubar.drawing.freeze", "effects_freeze" )
+	pnl:CheckBox( "#menubar.drawing.unfreeze", "effects_unfreeze" )
 
-	pnl:AddControl( "Slider", { Label = "#utilities.gm_snapgrid", Type = "Integer", Command = "gm_snapgrid", Min = "0", Max = "128" } )
-	pnl:AddControl( "Slider", { Label = "#utilities.gm_snapangles", Type = "Integer", Command = "gm_snapangles", Min = "5", Max = "90" } )
+	local snapgrid = pnl:NumSlider( "#utilities.gm_snapgrid", "gm_snapgrid", 0, 128, 0 )
+	local snapgridDefault = GetConVar( "gm_snapgrid" )
+	if ( snapgridDefault ) then
+		snapgrid:SetDefaultValue( snapgridDefault:GetDefault() )
+	end
+	local snapangles = pnl:NumSlider( "#utilities.gm_snapangles", "gm_snapangles", 5, 90, 0 )
+	local snapanglesDefault = GetConVar( "gm_snapangles" )
+	if ( snapanglesDefault ) then
+		snapangles:SetDefaultValue( snapanglesDefault:GetDefault() )
+	end
 
-	pnl:AddControl( "Slider", { Label = "#utilities.physgun_rotation_sensitivity", Type = "Float", Command = "physgun_rotation_sensitivity", Min = "0.01", Max = "1" } )
-	pnl:AddControl( "Slider", { Label = "#utilities.physgun_wheelspeed", Type = "Integer", Command = "physgun_wheelspeed", Min = "0", Max = "50" } )
+	local sensitivity = pnl:NumSlider( "#utilities.physgun_rotation_sensitivity", "physgun_rotation_sensitivity", 0.01, 1, 2 )
+	local sensitivityDefault = GetConVar( "physgun_rotation_sensitivity" )
+	if ( sensitivityDefault ) then
+		sensitivity:SetDefaultValue( sensitivityDefault:GetDefault() )
+	end
+	local wheelspeed = pnl:NumSlider( "#utilities.physgun_wheelspeed", "physgun_wheelspeed", 0, 50, 0 )
+	local wheelspeedDefault = GetConVar( "physgun_wheelspeed" )
+	if ( wheelspeedDefault ) then
+		wheelspeed:SetDefaultValue( wheelspeedDefault:GetDefault() )
+	end
 
 end
 
 local function PhysgunSVSettings( pnl )
 
-	pnl:AddControl( "Header", { Description = "#utilities.physgunsvsettings" } )
+	pnl:Help( "#utilities.physgunsvsettings" )
 
 	local ConVarsDefault = {
 		physgun_limited = "0",
@@ -200,22 +288,54 @@ local function PhysgunSVSettings( pnl )
 		physgun_timeToArrive = "0.05",
 		physgun_timeToArriveRagdoll = "0.1"
 	}
-	pnl:AddControl( "ComboBox", { MenuButton = 1, Folder = "util_physgun_sv", Options = { [ "#preset.default" ] = ConVarsDefault }, CVars = table.GetKeys( ConVarsDefault ) } )
+	local presets = vgui.Create( "ControlPresets", pnl )
+	presets:SetPreset( "util_physgun_sv" )
+	presets:AddOption( "#preset.default", ConVarsDefault )
+	for k, v in pairs( table.GetKeys( ConVarsDefault ) ) do
+		presets:AddConVar( v )
+	end
+	pnl:AddPanel( presets )
 
-	pnl:AddControl( "CheckBox", { Label = "#utilities.physgun_limited", Command = "physgun_limited", Help = true } )
+	pnl:CheckBox( "#utilities.physgun_limited", "physgun_limited" )
+	pnl:ControlHelp( "#utilities.physgun_limited" .. ".help" )
 
-	pnl:AddControl( "Slider", { Label = "#utilities.physgun_maxrange", Type = "Integer", Command = "physgun_maxrange", Min = "128", Max = "8192" } )
-	pnl:AddControl( "Slider", { Label = "#utilities.physgun_tpdist", Type = "Integer", Command = "physgun_teleportdistance", Min = "0", Max = "10000" } )
-	pnl:AddControl( "Slider", { Label = "#utilities.physgun_maxspeed", Type = "Integer", Command = "physgun_maxspeed", Min = "0", Max = "10000" } )
-	pnl:AddControl( "Slider", { Label = "#utilities.physgun_maxangular", Type = "Integer", Command = "physgun_maxangular", Min = "0", Max = "10000" } )
-	pnl:AddControl( "Slider", { Label = "#utilities.physgun_timetoarrive", Type = "Float", Command = "physgun_timetoarrive", Min = "0", Max = "2" } )
-	pnl:AddControl( "Slider", { Label = "#utilities.physgun_timetoarriveragdoll", Type = "Float", Command = "physgun_timetoarriveragdoll", Min = "0", Max = "2", Help = true } )
+	local maxrange = pnl:NumSlider( "#utilities.physgun_maxrange", "physgun_maxrange", 128, 8192, 0 )
+	local maxrangeDefault = GetConVar( "physgun_maxrange" )
+	if ( maxrangeDefault ) then
+		maxrange:SetDefaultValue( maxrangeDefault:GetDefault() )
+	end
+	local tpdist = pnl:NumSlider( "#utilities.physgun_tpdist", "physgun_teleportdistance", 0, 10000, 0 )
+	local tpdistDefault = GetConVar( "physgun_teleportdistance" )
+	if ( tpdistDefault ) then
+		tpdist:SetDefaultValue( tpdistDefault:GetDefault() )
+	end
+	local maxspeed = pnl:NumSlider( "#utilities.physgun_maxspeed", "physgun_maxspeed", 0, 10000, 0 )
+	local maxspeedDefault = GetConVar( "physgun_maxspeed" )
+	if ( maxspeedDefault ) then
+		maxspeed:SetDefaultValue( maxspeedDefault:GetDefault() )
+	end
+	local maxangular = pnl:NumSlider( "#utilities.physgun_maxangular", "physgun_maxangular", 0, 10000, 0 )
+	local maxangularDefault = GetConVar( "physgun_maxangular" )
+	if ( maxangularDefault ) then
+		maxangular:SetDefaultValue( maxangularDefault:GetDefault() )
+	end
+	local timetoarrive = pnl:NumSlider( "#utilities.physgun_timetoarrive", "physgun_timetoarrive", 0, 2, 2 )
+	local timetoarriveDefault = GetConVar( "physgun_timetoarrive" )
+	if ( timetoarriveDefault ) then
+		timetoarrive:SetDefaultValue( timetoarriveDefault:GetDefault() )
+	end
+	local timetoarriveragdoll = pnl:NumSlider( "#utilities.physgun_timetoarriveragdoll", "physgun_timetoarriveragdoll", 0, 2, 2 )
+	local timetoarriveragdollDefault = GetConVar( "physgun_timetoarriveragdoll" )
+	pnl:ControlHelp( "#utilities.physgun_timetoarriveragdoll" .. ".help" )
+	if ( timetoarriveragdollDefault ) then
+		timetoarriveragdoll:SetDefaultValue( timetoarriveragdollDefault:GetDefault() )
+	end
 
 end
 
 local function PlayerOptions( pnl )
 
-	pnl:AddControl( "Header", { Description = "#smwidget.playermodel_title" } )
+	pnl:Help( "#smwidget.playermodel_title" )
 
 	pnl:Button( "#smwidget.playermodel_title", "open_playermodel_selector" )
 

--- a/garrysmod/lua/includes/modules/cleanup.lua
+++ b/garrysmod/lua/includes/modules/cleanup.lua
@@ -215,7 +215,7 @@ else
 		local Panel = controlpanel.Get( "User_Cleanup" )
 		if ( IsValid( Panel ) ) then
 			Panel:Clear()
-			Panel:AddControl( "Header", { Description = "#spawnmenu.utilities.cleanup.help" } )
+			Panel:Help( "#spawnmenu.utilities.cleanup.help" )
 			Panel:Button( "#CleanupAll", "gmod_cleanup" )
 
 			for key, val in SortedPairs( cleanup_types_s ) do
@@ -226,7 +226,7 @@ else
 		local AdminPanel = controlpanel.Get( "Admin_Cleanup" )
 		if ( IsValid( AdminPanel ) ) then
 			AdminPanel:Clear()
-			AdminPanel:AddControl( "Header", { Description = "#spawnmenu.utilities.cleanup.help" } )
+			AdminPanel:Help( "#spawnmenu.utilities.cleanup.help" )
 			AdminPanel:Button( "#CleanupAll", "gmod_admin_cleanup" )
 
 			for key, val in SortedPairs( cleanup_types_s ) do

--- a/garrysmod/lua/includes/modules/undo.lua
+++ b/garrysmod/lua/includes/modules/undo.lua
@@ -31,7 +31,7 @@ if ( CLIENT ) then
 		if ( !IsValid( Panel ) ) then return end
 
 		Panel:Clear()
-		Panel:AddControl( "Header", { Description = "#spawnmenu.utilities.undo.help" } )
+		Panel:Help( "#spawnmenu.utilities.undo.help" )
 
 		local ComboBox = Panel:ListBox()
 		ComboBox:SetTall( 500 )

--- a/garrysmod/lua/postprocess/bloom.lua
+++ b/garrysmod/lua/postprocess/bloom.lua
@@ -84,11 +84,12 @@ list.Set( "PostProcess", "#bloom_pp", {
 
 	cpanel = function( CPanel )
 
-		CPanel:AddControl( "Header", { Description = "#bloom_pp.desc" } )
-		CPanel:AddControl( "CheckBox", { Label = "#bloom_pp.enable", Command = "pp_bloom" } )
+		CPanel:Help( "#bloom_pp.desc" )
+		CPanel:CheckBox( "#bloom_pp.enable", "pp_bloom" )
 
-		local params = { Options = {}, CVars = {}, MenuButton = "1", Folder = "bloom" }
-		params.Options[ "#preset.default" ] = {
+		local presets = vgui.Create( "ControlPresets", CPanel )
+		local options = {}
+		options[ "#preset.default" ] = {
 			pp_bloom_passes = "4",
 			pp_bloom_darken = "0.65",
 			pp_bloom_multiply = "1.0",
@@ -99,17 +100,50 @@ list.Set( "PostProcess", "#bloom_pp", {
 			pp_bloom_color_g = "255",
 			pp_bloom_color_b = "255"
 		}
-		params.CVars = table.GetKeys( params.Options[ "#preset.default" ] )
-		CPanel:AddControl( "ComboBox", params )
+		presets:SetPreset( "bloom" )
+		presets:AddOption( "#preset.default", options[ "#preset.default" ] )
+		for k, v in pairs( table.GetKeys( options[ "#preset.default" ] ) ) do
+			presets:AddConVar( v )
+		end
+		CPanel:AddPanel( presets )
 
-		CPanel:AddControl( "Slider", { Label = "#bloom_pp.passes", Command = "pp_bloom_passes", Type = "Integer", Min = "0", Max = "30" } )
-		CPanel:AddControl( "Slider", { Label = "#bloom_pp.darken", Command = "pp_bloom_darken", Type = "Float", Min = "0", Max = "1" } )
-		CPanel:AddControl( "Slider", { Label = "#bloom_pp.multiply", Command = "pp_bloom_multiply", Type = "Float", Min = "0", Max = "5" } )
-		CPanel:AddControl( "Slider", { Label = "#bloom_pp.blurx", Command = "pp_bloom_sizex", Type = "Float", Min = "0", Max = "50" } )
-		CPanel:AddControl( "Slider", { Label = "#bloom_pp.blury", Command = "pp_bloom_sizey", Type = "Float", Min = "0", Max = "50" } )
-		CPanel:AddControl( "Slider", { Label = "#bloom_pp.multiplier", Command = "pp_bloom_color", Type = "Float", Min = "0", Max = "20" } )
+		local passes = CPanel:NumSlider( "#bloom_pp.passes", "pp_bloom_passes", 0, 30, 0 )
+		local passesDefault = GetConVar( "pp_bloom_passes" )
+		if ( passesDefault ) then
+			passes:SetDefaultValue( passesDefault:GetDefault() )
+		end
+		local darken = CPanel:NumSlider( "#bloom_pp.darken", "pp_bloom_darken", 0, 1, 2 )
+		local darkenDefault = GetConVar( "pp_bloom_darken" )
+		if ( darkenDefault ) then
+			darken:SetDefaultValue( darkenDefault:GetDefault() )
+		end
+		local multiply = CPanel:NumSlider( "#bloom_pp.multiply", "pp_bloom_multiply", 0, 5, 2 )
+		local multiplyDefault = GetConVar( "pp_bloom_multiply" )
+		if ( multiplyDefault ) then
+			multiply:SetDefaultValue( multiplyDefault:GetDefault() )
+		end
+		local blurx = CPanel:NumSlider( "#bloom_pp.blurx", "pp_bloom_sizex", 0, 50, 2 )
+		local blurxDefault = GetConVar( "pp_bloom_sizex" )
+		if ( blurxDefault ) then
+			blurx:SetDefaultValue( blurxDefault:GetDefault() )
+		end
+		local blury = CPanel:NumSlider( "#bloom_pp.blury", "pp_bloom_sizey", 0, 50, 2 )
+		local bluryDefault = GetConVar( "pp_bloom_sizey" )
+		if ( bluryDefault ) then
+			blury:SetDefaultValue( bluryDefault:GetDefault() )
+		end
+		local multiplier = CPanel:NumSlider( "#bloom_pp.multiplier", "pp_bloom_color", 0, 20, 2 )
+		local multiplierDefault = GetConVar( "pp_bloom_color" )
+		if ( multiplierDefault ) then
+			multiplier:SetDefaultValue( multiplierDefault:GetDefault() )
+		end
 
-		CPanel:AddControl( "Color", { Label = "#bloom_pp.color", Red = "pp_bloom_color_r", Green = "pp_bloom_color_g", Blue = "pp_bloom_color_b", ShowAlpha = "0", ShowHSV = "1", ShowRGB = "1" } )
+		local color = vgui.Create( "CtrlColor", CPanel )
+		color:SetLabel( "#bloom_pp.color" )
+		color:SetConVarR( "pp_bloom_color_r" )
+		color:SetConVarG( "pp_bloom_color_g" )
+		color:SetConVarB( "pp_bloom_color_b" )
+		CPanel:AddPanel( color )
 
 	end
 

--- a/garrysmod/lua/postprocess/color_modify.lua
+++ b/garrysmod/lua/postprocess/color_modify.lua
@@ -62,21 +62,64 @@ list.Set( "PostProcess", "#colormod_pp", {
 
 	cpanel = function( CPanel )
 
-		CPanel:AddControl( "Header", { Description = "#colormod_pp.desc" } )
-		CPanel:AddControl( "CheckBox", { Label = "#colormod_pp.enable", Command = "pp_colormod" } )
+		CPanel:Help( "#colormod_pp.desc" )
+		CPanel:CheckBox( "#colormod_pp.enable", "pp_colormod" )
 
-		local params = { Options = {}, CVars = {}, MenuButton = "1", Folder = "colormod" }
-		params.Options[ "#preset.default" ] = { pp_colormod_addr = "0", pp_colormod_addg = "0", pp_colormod_addb = "0", pp_colormod_brightness = "0", pp_colormod_contrast = "1", pp_colormod_color = "1", pp_colormod_mulr = "0", pp_colormod_mulg = "0", pp_colormod_mulb = "0", pp_colormod_inv = "0" }
-		params.CVars = table.GetKeys( params.Options[ "#preset.default" ] )
-		CPanel:AddControl( "ComboBox", params )
+		local params = vgui.Create( "ControlPresets", CPanel )
+		local options = {}
+		options[ "#preset.default" ] = { 
+			pp_colormod_addr = "0",
+			pp_colormod_addg = "0",
+			pp_colormod_addb = "0",
+			pp_colormod_brightness = "0",
+			pp_colormod_contrast = "1",
+			pp_colormod_color = "1",
+			pp_colormod_mulr = "0",
+			pp_colormod_mulg = "0",
+			pp_colormod_mulb = "0",
+			pp_colormod_inv = "0"
+		}
+		params:SetPreset( "colormod" )
+		params:AddOption( "#preset.default", options[ "#preset.default" ] )
+		for k, v in pairs( table.GetKeys( options[ "#preset.default" ] ) ) do
+			params:AddConVar( v )
+		end
+		CPanel:AddPanel( params )
 
-		CPanel:AddControl( "Slider", { Label = "#colormod_pp.brightness", Command = "pp_colormod_brightness", Type = "Float", Min = "-2", Max = "2" } )
-		CPanel:AddControl( "Slider", { Label = "#colormod_pp.contrast", Command = "pp_colormod_contrast", Type = "Float", Min = "0", Max = "10" } )
-		CPanel:AddControl( "Slider", { Label = "#colormod_pp.color", Command = "pp_colormod_color", Type = "Float", Min = "0", Max = "5" } )
-		CPanel:AddControl( "Slider", { Label = "#colormod_pp.invert", Command = "pp_colormod_inv", Type = "Float", Min = "0", Max = "1" } )
+		local brightness = CPanel:NumSlider( "#colormod_pp.brightness", "pp_colormod_brightness", -2, 2, 2 )
+		local brightnessDefault = GetConVar( "pp_colormod_brightness" )
+		if ( brightnessDefault ) then
+			brightness:SetDefaultValue( brightnessDefault:GetDefault() )
+		end
+		local contrast = CPanel:NumSlider( "#colormod_pp.contrast", "pp_colormod_contrast", 0, 10, 2 )
+		local contrastDefault = GetConVar( "pp_colormod_contrast" )
+		if ( contrastDefault ) then
+			contrast:SetDefaultValue( contrastDefault:GetDefault() )
+		end
+		local color = CPanel:NumSlider( "#colormod_pp.color", "pp_colormod_color", 0, 5, 2 )
+		local colorDefault = GetConVar( "pp_colormod_color" )
+		if ( colorDefault ) then
+			color:SetDefaultValue( colorDefault:GetDefault() )
+		end
+		local invert = CPanel:NumSlider( "#colormod_pp.invert", "pp_colormod_inv", 0, 1, 2 )
+		local invertDefault = GetConVar( "pp_colormod_inv" )
+		if ( invertDefault ) then
+			invert:SetDefaultValue( invertDefault:GetDefault() )
+		end
 
-		CPanel:AddControl( "Color", { Label = "#colormod_pp.color_add", Red = "pp_colormod_addr", Green = "pp_colormod_addg", Blue = "pp_colormod_addb", ShowAlpha = "0", ShowHSV = "1", ShowRGB = "1" } )
-		CPanel:AddControl( "Color", { Label = "#colormod_pp.color_multiply", Red = "pp_colormod_mulr", Green = "pp_colormod_mulg", Blue = "pp_colormod_mulb", ShowAlpha = "0", ShowHSV = "1", ShowRGB = "1" } )
+		local colorAdd = vgui.Create( "CtrlColor", CPanel )
+		colorAdd:SetLabel( "#colormod_pp.color_add" )
+		colorAdd:SetConVarR( "pp_colormod_addr" )
+		colorAdd:SetConVarG( "pp_colormod_addg" )
+		colorAdd:SetConVarB( "pp_colormod_addb" )
+		CPanel:AddPanel( colorAdd )
+
+		local colorMult = vgui.Create( "CtrlColor", CPanel )
+		colorMult:SetLabel( "#colormod_pp.color_multiply" )
+		colorMult:SetConVarR( "pp_colormod_mulr" )
+		colorMult:SetConVarG( "pp_colormod_mulg" )
+		colorMult:SetConVarB( "pp_colormod_mulb" )
+		CPanel:AddPanel( colorMult )
 
 	end
 

--- a/garrysmod/lua/postprocess/dof.lua
+++ b/garrysmod/lua/postprocess/dof.lua
@@ -73,16 +73,29 @@ list.Set( "PostProcess", "#dof_pp", {
 
 	cpanel = function( CPanel )
 
-		CPanel:AddControl( "Header", { Description = "#dof_pp.desc" } )
-		CPanel:AddControl( "CheckBox", { Label = "#dof_pp.enable", Command = "pp_dof" } )
+		CPanel:Help( "#dof_pp.desc" )
+		CPanel:CheckBox( "#dof_pp.enable", "pp_dof" )
 
-		local params = { Options = {}, CVars = {}, MenuButton = "1", Folder = "dof" }
-		params.Options[ "#preset.default" ] = { pp_dof_initlength = "256", pp_dof_spacing = "512" }
-		params.CVars = table.GetKeys( params.Options[ "#preset.default" ] )
-		CPanel:AddControl( "ComboBox", params )
+		local params = vgui.Create( "ControlPresets", CPanel )
+		local options = {}
+		options[ "#preset.default" ] = { pp_dof_initlength = "256", pp_dof_spacing = "512" }
+		params:SetPreset( "dof" )
+		params:AddOption( "#preset.default", options[ "#preset.default" ] )
+		for k, v in pairs( table.GetKeys( options[ "#preset.default" ] ) ) do
+			params:AddConVar( v )
+		end
+		CPanel:AddPanel( params )
 
-		CPanel:AddControl( "Slider", { Label = "#dof_pp.spacing", Command = "pp_dof_spacing", Type = "Float", Min = "8", Max = "1024" } )
-		CPanel:AddControl( "Slider", { Label = "#dof_pp.start_distance", Command = "pp_dof_initlength", Type = "Float", Min = "9", Max = "1024" } )
+		local spacing = CPanel:NumSlider( "#dof_pp.spacing", "pp_dof_spacing", 8, 1024, 2 )
+		local spacingDefault = GetConVar( "pp_dof_spacing" )
+		if ( spacingDefault ) then
+			spacing:SetDefaultValue( spacingDefault:GetDefault() )
+		end
+		local distance = CPanel:NumSlider( "#dof_pp.start_distance", "pp_dof_initlength", 9, 1024, 2 )
+		local distanceDefault = GetConVar( "pp_dof_initlength" )
+		if ( distanceDefault ) then
+			distance:SetDefaultValue( distanceDefault:GetDefault() )
+		end
 
 	end
 

--- a/garrysmod/lua/postprocess/frame_blend.lua
+++ b/garrysmod/lua/postprocess/frame_blend.lua
@@ -196,18 +196,31 @@ list.Set( "PostProcess", "#frame_blend_pp", {
 
 	cpanel = function( CPanel )
 
-		CPanel:AddControl( "Header", { Description = "#frame_blend_pp.desc" } )
-		CPanel:AddControl( "Header", { Description = "#frame_blend_pp.desc2" } )
+		CPanel:Help( "#frame_blend_pp.desc" )
+		CPanel:Help( "#frame_blend_pp.desc2" )
 
-		CPanel:AddControl( "CheckBox", { Label = "#frame_blend_pp.enable", Command = "pp_fb" } )
+		CPanel:CheckBox( "#frame_blend_pp.enable", "pp_fb" )
 
-		local params = { Options = {}, CVars = {}, MenuButton = "1", Folder = "frame_blend" }
-		params.Options[ "#preset.default" ] = { pp_fb_frames = "16", pp_fb_shutter = "0.5" }
-		params.CVars = table.GetKeys( params.Options[ "#preset.default" ] )
-		CPanel:AddControl( "ComboBox", params )
+		local params = vgui.Create( "ControlPresets", CPanel )
+		local options = {}
+		options[ "#preset.default" ] = { pp_fb_frames = "16", pp_fb_shutter = "0.5" }
+		params:SetPreset( "frame_blend" )
+		params:AddOption( "#preset.default", options[ "#preset.default" ] )
+		for k, v in pairs( table.GetKeys( options[ "#preset.default" ] ) ) do
+			params:AddConVar( v )
+		end
+		CPanel:AddPanel( params )
 
-		CPanel:AddControl( "Slider", { Label = "#frame_blend_pp.frames", Command = "pp_fb_frames", Type = "Int", Min = "3", Max = "64" } )
-		CPanel:AddControl( "Slider", { Label = "#frame_blend_pp.shutter", Command = "pp_fb_shutter", Type = "Float", Min = "0", Max = "0.99" } )
+		local frames = CPanel:NumSlider( "#frame_blend_pp.frames", "pp_fb_frames", 3, 64, 0 )
+		local framesDefault = GetConVar( "pp_fb_frames" )
+		if ( framesDefault ) then
+			frames:SetDefaultValue( framesDefault:GetDefault() )
+		end
+		local shutter = CPanel:NumSlider( "#frame_blend_pp.shutter", "pp_fb_shutter", 0, 0.99, 2 )
+		local shutterDefault = GetConVar( "pp_fb_shutter" )
+		if ( shutterDefault ) then
+			shutter:SetDefaultValue( shutterDefault:GetDefault() )
+		end
 
 	end
 

--- a/garrysmod/lua/postprocess/motion_blur.lua
+++ b/garrysmod/lua/postprocess/motion_blur.lua
@@ -77,17 +77,38 @@ list.Set( "PostProcess", "#motion_blur_pp", {
 
 	cpanel = function( CPanel )
 
-		CPanel:AddControl( "Header", { Description = "#motion_blur_pp.desc" } )
-		CPanel:AddControl( "CheckBox", { Label = "#motion_blur_pp.enable", Command = "pp_motionblur" } )
+		CPanel:Help( "#motion_blur_pp.desc" )
+		CPanel:CheckBox( "#motion_blur_pp.enable", "pp_motionblur" )
 
-		local params = { Options = {}, CVars = {}, MenuButton = "1", Folder = "motionblur" }
-		params.Options[ "#preset.default" ] = { pp_motionblur_addalpha = "0.2", pp_motionblur_delay = "0.05", pp_motionblur_drawalpha = "0.99" }
-		params.CVars = table.GetKeys( params.Options[ "#preset.default" ] )
-		CPanel:AddControl( "ComboBox", params )
+		local params = vgui.Create( "ControlPresets", CPanel )
+		local options = {}
+		options[ "#preset.default" ] = { 
+			pp_motionblur_addalpha = "0.2",
+			pp_motionblur_delay = "0.05",
+			pp_motionblur_drawalpha = "0.99"
+		}
+		params:SetPreset( "motionblur" )
+		params:AddOption( "#preset.default", options[ "#preset.default" ] )
+		for k, v in pairs( table.GetKeys( options[ "#preset.default" ] ) ) do
+			params:AddConVar( v )
+		end
+		CPanel:AddPanel( params )
 
-		CPanel:AddControl( "Slider", { Label = "#motion_blur_pp.add_alpha", Command = "pp_motionblur_addalpha", Type = "Float", Min = "0", Max = "1" } )
-		CPanel:AddControl( "Slider", { Label = "#motion_blur_pp.draw_alpha", Command = "pp_motionblur_drawalpha", Type = "Float", Min = "0", Max = "1" } )
-		CPanel:AddControl( "Slider", { Label = "#motion_blur_pp.delay", Command = "pp_motionblur_delay", Type = "Float", Min = "0", Max = "1" } )
+		local addalpha = CPanel:NumSlider( "#motion_blur_pp.add_alpha", "pp_motionblur_addalpha", 0, 1, 2 )
+		local addalphaDefault = GetConVar( "pp_motionblur_addalpha" )
+		if ( addalphaDefault ) then
+			addalpha:SetDefaultValue( addalphaDefault:GetDefault() )
+		end
+		local drawalpha = CPanel:NumSlider( "#motion_blur_pp.draw_alpha", "pp_motionblur_drawalpha", 0, 1, 2 )
+		local drawalphaDefault = GetConVar( "pp_motionblur_drawalpha" )
+		if ( drawalphaDefault ) then
+			drawalpha:SetDefaultValue( drawalphaDefault:GetDefault() )
+		end
+		local delay = CPanel:NumSlider( "#motion_blur_pp.delay", "pp_motionblur_delay", 0, 1, 2 )
+		local delayDefault = GetConVar( "pp_motionblur_delay" )
+		if ( delayDefault ) then
+			delay:SetDefaultValue( delayDefault:GetDefault() )
+		end
 
 	end
 

--- a/garrysmod/lua/postprocess/overlay.lua
+++ b/garrysmod/lua/postprocess/overlay.lua
@@ -96,14 +96,23 @@ list.Set( "PostProcess", "#overlay_pp", {
 
 	cpanel = function( CPanel )
 
-		CPanel:AddControl( "Header", { Description = "#overlay_pp.desc" } )
+		CPanel:Help( "#overlay_pp.desc" )
 
-		local params = { Options = {}, CVars = {}, MenuButton = "1", Folder = "overlay" }
-		params.Options[ "#preset.default" ] = { pp_mat_overlay_refractamount = "0.3" }
-		params.CVars = table.GetKeys( params.Options[ "#preset.default" ] )
-		CPanel:AddControl( "ComboBox", params )
+		local params = vgui.Create( "ControlPresets", CPanel )
+		local options = {}
+		options[ "#preset.default" ] = { pp_mat_overlay_refractamount = "0.3" }
+		params:SetPreset( "bloom" )
+		params:AddOption( "#preset.default", options[ "#preset.default" ] )
+		for k, v in pairs( table.GetKeys( options[ "#preset.default" ] ) ) do
+			params:AddConVar( v )
+		end
+		CPanel:AddPanel( params )
 
-		CPanel:AddControl( "Slider", { Label = "#overlay_pp.refract", Command = "pp_mat_overlay_refractamount", Type = "Float", Min = "-1", Max = "1" } )
+		local refract = CPanel:NumSlider( "#overlay_pp.refract", "pp_mat_overlay_refractamount", -1, 1, 2 )
+		local refractDefault = GetConVar( "pp_mat_overlay_refractamount" )
+		if ( refractDefault ) then
+			refract:SetDefaultValue( refractDefault:GetDefault() )
+		end
 
 	end
 

--- a/garrysmod/lua/postprocess/sharpen.lua
+++ b/garrysmod/lua/postprocess/sharpen.lua
@@ -38,16 +38,29 @@ list.Set( "PostProcess", "#sharpen_pp", {
 
 	cpanel = function( CPanel )
 
-		CPanel:AddControl( "Header", { Description = "#sharpen_pp.desc" } )
-		CPanel:AddControl( "CheckBox", { Label = "#sharpen_pp.enable", Command = "pp_sharpen" } )
+		CPanel:Help( "#sharpen_pp.desc" )
+		CPanel:CheckBox( "#sharpen_pp.enable", "pp_sharpen" )
 
-		local params = { Options = {}, CVars = {}, MenuButton = "1", Folder = "sharpen" }
-		params.Options[ "#preset.default" ] = { pp_sharpen_distance = "1", pp_sharpen_contrast = "1" }
-		params.CVars = table.GetKeys( params.Options[ "#preset.default" ] )
-		CPanel:AddControl( "ComboBox", params )
+		local params = vgui.Create( "ControlPresets", CPanel )
+		local options = {}
+		options[ "#preset.default" ] = { pp_sharpen_distance = "1", pp_sharpen_contrast = "1" }
+		params:SetPreset( "sharpen" )
+		params:AddOption( "#preset.default", options[ "#preset.default" ] )
+		for k, v in pairs( table.GetKeys( options[ "#preset.default" ] ) ) do
+			params:AddConVar( v )
+		end
+		CPanel:AddPanel( params )
 
-		CPanel:AddControl( "Slider", { Label = "#sharpen_pp.distance", Command = "pp_sharpen_distance", Type = "Float", Min = "-5", Max = "5" } )
-		CPanel:AddControl( "Slider", { Label = "#sharpen_pp.contrast", Command = "pp_sharpen_contrast", Type = "Float", Min = "0", Max = "20" } )
+		local distance = CPanel:NumSlider( "#sharpen_pp.distance", "pp_sharpen_distance", -5, 5, 2 )
+		local distanceDefault = GetConVar( "pp_sharpen_distance" )
+		if ( distanceDefault ) then
+			distance:SetDefaultValue( distanceDefault:GetDefault() )
+		end
+		local contrast = CPanel:NumSlider( "#sharpen_pp.contrast", "pp_sharpen_contrast", 0, 20, 2 )
+		local contrastDefault = GetConVar( "pp_sharpen_contrast" )
+		if ( contrastDefault ) then
+			contrast:SetDefaultValue( contrastDefault:GetDefault() )
+		end
 
 	end
 

--- a/garrysmod/lua/postprocess/sobel.lua
+++ b/garrysmod/lua/postprocess/sobel.lua
@@ -34,15 +34,24 @@ list.Set( "PostProcess", "#sobel_pp", {
 
 	cpanel = function( CPanel )
 
-		CPanel:AddControl( "Header", { Description = "#sobel_pp.desc" } )
-		CPanel:AddControl( "CheckBox", { Label = "#sobel_pp.enable", Command = "pp_sobel" } )
+		CPanel:Help( "#sobel_pp.desc" )
+		CPanel:CheckBox( "#sobel_pp.enable", "pp_sobel" )
 
-		local params = { Options = {}, CVars = {}, MenuButton = "1", Folder = "sobel" }
-		params.Options[ "#preset.default" ] = { pp_sobel_threshold = "0.11" }
-		params.CVars = table.GetKeys( params.Options[ "#preset.default" ] )
-		CPanel:AddControl( "ComboBox", params )
+		local params = vgui.Create( "ControlPresets", CPanel )
+		local options = {}
+		options[ "#preset.default" ] = { pp_sobel_threshold = "0.11" }
+		params:SetPreset( "sobel" )
+		params:AddOption( "#preset.default", options[ "#preset.default" ] )
+		for k, v in pairs( table.GetKeys( options[ "#preset.default" ] ) ) do
+			params:AddConVar( v )
+		end
+		CPanel:AddPanel( params )
 
-		CPanel:AddControl( "Slider", { Label = "#sobel_pp.threshold", Command = "pp_sobel_threshold", Type = "Float", Min = "0", Max = "1" } )
+		local threshold = CPanel:NumSlider( "#sobel_pp.threshold", "pp_sobel_threshold", 0, 1, 2 )
+		local thresholdDefault = GetConVar( "pp_sobel_threshold" )
+		if ( thresholdDefault ) then
+			threshold:SetDefaultValue( thresholdDefault:GetDefault() )
+		end
 
 	end
 

--- a/garrysmod/lua/postprocess/stereoscopy.lua
+++ b/garrysmod/lua/postprocess/stereoscopy.lua
@@ -58,15 +58,24 @@ list.Set( "PostProcess", "#stereoscopy_pp", {
 
 	cpanel = function( CPanel )
 
-		CPanel:AddControl( "Header", { Description = "#stereoscopy_pp.desc" } )
-		CPanel:AddControl( "CheckBox", { Label = "#stereoscopy_pp.enable", Command = "pp_stereoscopy" } )
+		CPanel:Help( "#stereoscopy_pp.desc" )
+		CPanel:CheckBox( "#stereoscopy_pp.enable", "pp_stereoscopy" )
 
-		local params = { Options = {}, CVars = {}, MenuButton = "1", Folder = "stereoscopy" }
-		params.Options[ "#preset.default" ] = { pp_stereoscopy_size = "6" }
-		params.CVars = table.GetKeys( params.Options[ "#preset.default" ] )
-		CPanel:AddControl( "ComboBox", params )
+		local params = vgui.Create( "ControlPresets", CPanel )
+		local options = {}
+		options[ "#preset.default" ] = { pp_stereoscopy_size = "6" }
+		params:SetPreset( "stereoscopy" )
+		params:AddOption( "#preset.default", options[ "#preset.default" ] )
+		for k, v in pairs( table.GetKeys( options[ "#preset.default" ] ) ) do
+			params:AddConVar( v )
+		end
+		CPanel:AddPanel( params )
 
-		CPanel:AddControl( "Slider", { Label = "#stereoscopy_pp.size", Command = "pp_stereoscopy_size", Type = "Float", Min = "0", Max = "10" } )
+		local size = CPanel:NumSlider( "#stereoscopy_pp.size", "pp_stereoscopy_size", 0, 10, 2 )
+		local sizeDefault = GetConVar( "pp_stereoscopy_size" )
+		if ( sizeDefault ) then
+			size:SetDefaultValue( sizeDefault:GetDefault() )
+		end
 
 	end
 

--- a/garrysmod/lua/postprocess/sunbeams.lua
+++ b/garrysmod/lua/postprocess/sunbeams.lua
@@ -57,17 +57,39 @@ list.Set( "PostProcess", "#sunbeams_pp", {
 
 	cpanel = function( CPanel )
 
-		CPanel:AddControl( "Header", { Description = "#sunbeams_pp.desc" } )
-		CPanel:AddControl( "CheckBox", { Label = "#sunbeams_pp.enable", Command = "pp_sunbeams" } )
+		CPanel:Help( "#sunbeams_pp.desc" )
+		CPanel:CheckBox( "#sunbeams_pp.enable", "pp_sunbeams" )
 
-		local params = { Options = {}, CVars = {}, MenuButton = "1", Folder = "sunbeams" }
-		params.Options[ "#preset.default" ] = { pp_sunbeams = "0", pp_sunbeams_darken = "0.95", pp_sunbeams_multiply = "1", pp_sunbeams_sunsize = "0.075" }
-		params.CVars = table.GetKeys( params.Options[ "#preset.default" ] )
-		CPanel:AddControl( "ComboBox", params )
+		local params = vgui.Create( "ControlPresets", CPanel )
+		local options = {}
+		options[ "#preset.default" ] = {
+			pp_sunbeams = "0",
+			pp_sunbeams_darken = "0.95",
+			pp_sunbeams_multiply = "1",
+			pp_sunbeams_sunsize = "0.075"
+		}
+		params:SetPreset( "sunbeams" )
+		params:AddOption( "#preset.default", options[ "#preset.default" ] )
+		for k, v in pairs( table.GetKeys( options[ "#preset.default" ] ) ) do
+			params:AddConVar( v )
+		end
+		CPanel:AddPanel( params )
 
-		CPanel:AddControl( "Slider", { Label = "#sunbeams_pp.multiply", Command = "pp_sunbeams_multiply", Type = "Float", Min = "0", Max = "1" } )
-		CPanel:AddControl( "Slider", { Label = "#sunbeams_pp.darken", Command = "pp_sunbeams_darken", Type = "Float", Min = "0", Max = "1" } )
-		CPanel:AddControl( "Slider", { Label = "#sunbeams_pp.size", Command = "pp_sunbeams_sunsize", Type = "Float", Min = "0.01", Max = "0.25" } )
+		local multiply = CPanel:NumSlider( "#sunbeams_pp.multiply", "pp_sunbeams_multiply", 0, 1, 2 )
+		local multiplyDefault = GetConVar( "pp_sunbeams_multiply" )
+		if ( multiplyDefault ) then
+			multiply:SetDefaultValue( multiplyDefault:GetDefault() )
+		end
+		local darken = CPanel:NumSlider( "#sunbeams_pp.darken", "pp_sunbeams_darken", 0, 1, 2 )
+		local darkenDefault = GetConVar( "pp_sunbeams_darken" )
+		if ( darkenDefault ) then
+			darken:SetDefaultValue( darkenDefault:GetDefault() )
+		end
+		local size = CPanel:NumSlider( "#sunbeams_pp.size", "pp_sunbeams_sunsize", 0.01, 0.25, 2 )
+		local sizeDefault = GetConVar( "pp_sunbeams_sunsize" )
+		if ( sizeDefault ) then
+			size:SetDefaultValue( sizeDefault:GetDefault() )
+		end
 
 	end
 

--- a/garrysmod/lua/postprocess/toytown.lua
+++ b/garrysmod/lua/postprocess/toytown.lua
@@ -48,16 +48,29 @@ list.Set( "PostProcess", "#toytown_pp", {
 
 	cpanel = function( CPanel )
 
-		CPanel:AddControl( "Header", { Description = "#toytown_pp.desc" } )
-		CPanel:AddControl( "CheckBox", { Label = "#toytown_pp.enable", Command = "pp_toytown" } )
+		CPanel:Help( "#toytown_pp.desc" )
+		CPanel:CheckBox( "#toytown_pp.enable", "pp_toytown" )
 
-		local params = { Options = {}, CVars = {}, MenuButton = "1", Folder = "frame_blend" }
-		params.Options[ "#preset.default" ] = { pp_toytown_passes = "3", pp_toytown_size = "0.5" }
-		params.CVars = table.GetKeys( params.Options[ "#preset.default" ] )
-		CPanel:AddControl( "ComboBox", params )
+		local params = vgui.Create( "ControlPresets", CPanel )
+		local options = {}
+		options[ "#preset.default" ] = { pp_toytown_passes = "3", pp_toytown_size = "0.5" }
+		params:SetPreset( "frame_blend" )
+		params:AddOption( "#preset.default", options[ "#preset.default" ] )
+		for k, v in pairs( table.GetKeys( options[ "#preset.default" ] ) ) do
+			params:AddConVar( v )
+		end
+		CPanel:AddPanel( params )
 
-		CPanel:AddControl( "Slider", { Label = "#toytown_pp.passes", Command = "pp_toytown_passes", Type = "Int", Min = "1", Max = "100" } )
-		CPanel:AddControl( "Slider", { Label = "#toytown_pp.height", Command = "pp_toytown_size", Type = "Float", Min = "0", Max = "1" } )
+		local passes = CPanel:NumSlider( "#toytown_pp.passes", "pp_toytown_passes", 1, 100, 0 )
+		local passesDefault = GetConVar( "pp_toytown_passes" )
+		if ( passesDefault ) then
+			passes:SetDefaultValue( passesDefault:GetDefault() )
+		end
+		local size = CPanel:NumSlider( "#toytown_pp.height", "pp_toytown_size", 0, 1, 2 )
+		local sizeDefault = GetConVar( "pp_toytown_size" )
+		if ( sizeDefault ) then
+			size:SetDefaultValue( sizeDefault:GetDefault() )
+		end
 
 	end
 


### PR DESCRIPTION
Hello everyone, I hope you're doing fine. :)

I've noticed base Garry's Mod uses the `AddControl` function for the UI panel creation.

To quote Garry himself in [here](https://github.com/Facepunch/garrysmod/blame/master/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/controlpanel.lua):

> You shouldn't ever really be calling AddControl.
> If you're writing new code - don't call AddControl!! Add stuff directly using the DForm member functions!

Thus, I took the time to update all the `AddControl` calls with their **non-deprecated counterparts** (moreover, it should improve performance).

I did an extensive testing to make sure it doesn't break anything, and it works flawlessly (but of course, feel free to check, I may have made mistakes ;).