### PR TITLE
Rounding out the news panel

### DIFF
--- a/garrysmod/html/css/menu/Menu.css
+++ b/garrysmod/html/css/menu/Menu.css
@@ -277,6 +277,7 @@ loading
 	background: #666;
 	margin-left: 3px;
 	box-shadow: 0 0 10px 1px rgba( 0, 0, 0, 0.4 );
+	border-radius: 3px;
 	cursor: hand;
 }
 .news_buttons div.new
@@ -296,6 +297,7 @@ loading
 {
 	background: #333;
 	background-size: cover;
+	border-radius: 8px;
 	margin-right: 0px;
 	margin-left: auto;
 	box-shadow: 0 0 10px 1px rgba( 0, 0, 0, 0.4 );
@@ -318,6 +320,7 @@ loading
 .news_item div
 {
 	background: rgba( 0, 0, 0, 0.4 );
+	border-radius: 0 0 8px 8px;
 	display: block;
 	color: #fff;
 	padding: 5px;


### PR DESCRIPTION
The interface looks more harmonious. In the old version, almost all rectangular menu items are rounded, and only the news section has right angles

### Before
![gmod_UYmG4GMGsh](https://github.com/user-attachments/assets/29f96dfc-7a1a-4c8c-b082-47de6852a7fd)
### After
![gmod_3Miw6bkjce](https://github.com/user-attachments/assets/01a6192d-c562-4e98-8dfc-5363feb18524)
