### PR TITLE
Add tool copying

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/toolpanel.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/toolpanel.lua
@@ -202,6 +202,11 @@ function PANEL:AddCategory( name, catName, tItems )
 			spawnmenu.ActivateTool( button.Name )
 
 		end
+		item.DoRightClick = function( button )
+			local menu = DermaMenu()
+			menu:AddOption( "#spawnmenu.menu.copy", function() SetClipboardText( button.Name ) end ):SetIcon( "icon16/page_copy.png" )
+			menu:Open()
+		end
 
 		item.ControlPanelBuildFunction	= v.CPanelFunction
 		item.Command					= v.Command


### PR DESCRIPTION
Right-clicking opens the DermaMenu with the option to copy the ItemName of the tool.

![gmod_A0anipuJQ3](https://github.com/user-attachments/assets/2fa95dde-8b1c-4932-ac81-523189472cc6)
