### PR TITLE
net.Write65533String because net.WriteString's limit of 65532 characters is not enough!

### DIFF
--- a/garrysmod/lua/includes/extensions/net.lua
+++ b/garrysmod/lua/includes/extensions/net.lua
@@ -183,6 +183,62 @@ function net.ReadTable( seq )
 
 end
 
+local function bitsToChar( b1, b2, b3, b4, b5, b6, b7, b8 )
+
+	local asciiValue = bit.bor( bit.lshift(b1, 7), bit.lshift(b2, 6), bit.lshift(b3, 5), bit.lshift(b4, 4),
+								bit.lshift(b5, 3), bit.lshift(b6, 2), bit.lshift(b7, 1), b8 )
+
+	return string.char( asciiValue )
+
+end
+
+function net.Write65533String( str )
+
+	local inputLen = #str
+
+	if inputLen ~= 65533 then
+
+		error( string.format( "Trying to send a 65533 string that isn't actually 65533! (%s)", inputLen ) )
+
+	end
+
+	for i = 1, inputLen do
+
+		local asciiValue = string.byte( str, i )
+
+		for j = 7, 0, -1 do
+
+			net.WriteBit( bit.band( bit.rshift( asciiValue, j ), 1 ) )
+
+		end
+
+	end
+
+end
+
+function net.Read65533String()
+
+	local chars = {}
+
+	for i = 1, 65533 do
+
+		local bit1 = net.ReadBit()
+		local bit2 = net.ReadBit()
+		local bit3 = net.ReadBit()
+		local bit4 = net.ReadBit()
+		local bit5 = net.ReadBit()
+		local bit6 = net.ReadBit()
+		local bit7 = net.ReadBit()
+		local bit8 = net.ReadBit()
+
+		chars[i] = bitsToChar( bit1, bit2, bit3, bit4, bit5, bit6, bit7, bit8 )
+
+	end
+
+	return table.concat( chars )
+
+end
+
 net.WriteVars =
 {
 	[TYPE_NIL]			= function ( t, v )	net.WriteUInt( t, 8 )								end,


### PR DESCRIPTION
net.WriteString has a limit of 65532 characters and sometimes, that's just not enough, and you need just an extra byte. If we're going to be filling the net message to it's maximum size, why do we need to waste a byte for a null terminator?

Introducing: `net.Write65533String` & `net.Read65533String`

An alternative approach would be not wasting a byte on a null terminator with net.WriteString when the size is 65533

Usage example (SV&CL)
```
util.AddNetworkString("please_sir_may_I_have_some_more")

concommand.Add("test_long_string", function()
    local strbuildtbl = {}
    for i = 1, 65533 do
        local randomChar = string.char(math.random(32, 126))
        strbuildtbl[i] = randomChar
    end
    local longStr = table.concat(strbuildtbl)

    net.Start("please_sir_may_I_have_some_more")
    net.Write65533String(longStr) -- net.WriteString would NEVER dream of writing a string this long!
    net.Broadcast()
end)

net.Receive("please_sir_may_I_have_some_more", function(len)
	print(net.Read65533String())
end)
```