### PR TITLE
Avatar quality improvement

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/cl_scoreboard.lua
+++ b/garrysmod/gamemodes/base/gamemode/cl_scoreboard.lua
@@ -70,7 +70,7 @@ local PLAYER_LINE = {
 
 		self.Player = pl
 
-		self.Avatar:SetPlayer( pl )
+		self.Avatar:SetPlayer( pl, 64 )
 
 		self:Think( self )
 


### PR DESCRIPTION
The avatar has a size of 32x32, and with an empty argument it pumps up a 32x32 image of standart, which has a blur, hence the quality is lost. If you put a 64px picture on a 32px avatar, then sharpness is added, and the blur effect disappears.

**Before**
![gmod_e1455uviSs](https://github.com/user-attachments/assets/5546c9fc-c472-4ea2-8894-54147a2d7e46)

**After**
![gmod_sGWXlfppqe](https://github.com/user-attachments/assets/95fc1db2-1aa2-42b3-b14c-6cd13755d356)

