### PR TITLE
Fixing ragdoll spawning with wrong faces in Sandbox.

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/commands.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/commands.lua
@@ -113,6 +113,11 @@ function GMODSpawnRagdoll( ply, model, iSkin, strBody )
 		gamemode.Call( "PlayerSpawnedRagdoll", ply, model, e )
 	end
 
+	-- Fix the wrong face (https://github.com/Facepunch/garrysmod-issues/issues/6146)
+	for i=1, e:GetFlexNum() do
+		e:SetFlexWeight( i, 0.0 )
+	end
+
 	DoPropSpawnedEffect( e )
 
 	undo.Create( "Ragdoll" )


### PR DESCRIPTION
Hello everyone.

A couple of weeks ago, I raised an issue about [ragdolls spawning with wrong face in Sandbox](https://github.com/Facepunch/garrysmod-issues/issues/6146) (it may have flown under the radar, I'm still curious about if you too experience this problem).

This pull request fixes the problem, although **I have no clue on what causes it in the first place**; so this is more of patch than a fix...

If someone with more knowledge and access to the closed-source GMod is willing to take the time to investigate, I encourage you. :)