### PR TITLE
Fix middle-clicking links breaking menu

### DIFF
--- a/garrysmod/html/js/menu/menuApp.js
+++ b/garrysmod/html/js/menu/menuApp.js
@@ -40,3 +40,12 @@ App.filter( 'startFrom', function()
 		return input.slice( start );
 	}
 } );
+
+document.addEventListener('DOMContentLoaded', function()
+{
+	//Prevent middle-clicking links from trying to open in new tab
+	document.body.onauxclick = function(e)
+	{
+		e.preventDefault();
+	};
+} );


### PR DESCRIPTION
In CEF (x86-64), middle-clicking links tries to open them in a new tab, which overrides the current tab, which breaks the menu. This bug is described in https://github.com/Facepunch/garrysmod-issues/issues/6104

This pull request fixes it by preventing middle-click's event from firing in the menu pages. 