### PR TITLE
TTT: Fix C4/Radio sounds not playing outside of PAS

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
@@ -249,7 +249,7 @@ function ENT:Explode(tr)
       util.Effect("Explosion", effect, true, true)
       util.Effect("HelicopterMegaBomb", effect, true, true)
 
-      timer.Simple(0.1, function() sound.Play(c4boom, pos, 100, 100) end)
+      self:BroadcastSound(c4boom, 100)
 
       -- extra push
       local phexp = ents.Create("env_physexplosion")
@@ -351,7 +351,7 @@ function ENT:Think()
       end
 
       if SERVER then
-         sound.Play(beep, self:GetPos(), amp, 100)
+         self:BroadcastSound(beep, amp)
       end
 
       local btime = (etime - CurTime()) / 30
@@ -360,7 +360,7 @@ function ENT:Think()
 end
 
 function ENT:Defusable()
-	return self:GetArmed()
+   return self:GetArmed()
 end
 
 -- Timer configuration handlign

--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_radio.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_radio.lua
@@ -192,7 +192,8 @@ function ENT:PlayDelayedSound(snd, ampl, last)
          snd = table.Random(snd)
       end
 
-      sound.Play(snd, self:GetPos(), ampl)
+      self:BroadcastSound(snd, ampl)
+
       self.Playing = not last
 
       --print("Playing", snd, last)
@@ -200,10 +201,9 @@ function ENT:PlayDelayedSound(snd, ampl, last)
 end
 
 function ENT:PlaySound(snd)
-   local pos = self:GetPos()
    local this = self
    if simplesounds[snd] then
-      sound.Play(table.Random(simplesounds[snd]), pos)
+      self:BroadcastSound(table.Random(simplesounds[snd]))
    elseif gunsounds[snd] then
       local gunsound = gunsounds[snd]
       local times = math.random(gunsound.times[1], gunsound.times[2])

--- a/garrysmod/gamemodes/terrortown/gamemode/entity.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/entity.lua
@@ -16,3 +16,11 @@ function meta:IsExplosive()
    local kv = self:GetKeyValues()["ExplodeDamage"]
    return self:Health() > 0 and kv and kv > 0
 end
+
+-- Some sounds are important enough that they shouldn't be affected by CPASAttenuationFilter
+function meta:BroadcastSound(snd, lvl, pitch, vol, channel, flags, dsp)
+   local rf = RecipientFilter()
+   rf:AddAllPlayers()
+
+   self:EmitSound(snd, lvl, pitch, vol, channel, flags, dsp, rf)
+end

--- a/garrysmod/gamemodes/terrortown/gamemode/entity.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/entity.lua
@@ -19,8 +19,27 @@ end
 
 -- Some sounds are important enough that they shouldn't be affected by CPASAttenuationFilter
 function meta:BroadcastSound(snd, lvl, pitch, vol, channel, flags, dsp)
+   lvl = lvl or 75
+
    local rf = RecipientFilter()
-   rf:AddAllPlayers()
+
+   if lvl == 0 then
+      rf:AddAllPlayers()
+   else
+      -- Overriding the PAS filter means this will no longer check if players
+      -- are within audible range before sending them the sound message.
+      -- Instead, we reimplement this check in lua.
+      local pos = self:GetPos()
+
+      local attenuation = lvl > 50 and 20.0 / (lvl - 50) or 4.0
+      local maxAudible = math.min(2500, 2000 / attenuation)
+
+      for _, ply in player.Iterator() do
+         if (ply:EyePos() - pos):Length() > maxAudible then continue end
+
+         rf:AddPlayer(ply)
+      end
+   end
 
    self:EmitSound(snd, lvl, pitch, vol, channel, flags, dsp, rf)
 end


### PR DESCRIPTION
Same issue as #957, but I've made a video to better demonstrate the problem here: https://www.youtube.com/watch?v=6nweYCxRAQ4

If you'd like to reproduce this yourself:
- The map can be downloaded [here](https://steamcommunity.com/sharedfiles/filedetails/?id=3422213891), and the vmf can be downloaded [here](https://drive.google.com/file/d/1Enipyc7vp78z7WyvNjv1RDlnmoR6LLx-/view?usp=sharing).
- Make sure you launch the map c4test in a **multiplayer** game.
- Any sound played within one trollface zone will not be audible from the other trollface zone.
- This is done with hint/skip and areaportals, and as such there are plenty of cases in real maps where this also happens.

Luckily the fix for this has become much simpler since #957 was made, thanks to the _filter_ option that was added to Entity:EmitSound.

This PR fixes 3 things that I feel would benefit most from this change:
- The C4 beep, because dying to a C4 you couldn't hear sucks immensely. (Definitely counts as a C4 nerf unfortunately, maybe tweak C4_MINIMUM_TIME to compensate?)
- Radio sounds, which should make the radio a bit less useless.
- The C4 explosion, to fix cases where people's screens are shaken but no explosion sound is played. (The timer for this sound had to be removed so that the C4 entity can be used before it's removed. As far as I can tell it wasn't there to fix anything, but if it's absolutely necessary to keep it then I can try and find a workaround.)

This _could_ be done with gunshots and death screams as well (maybe dependent on SWEP.IsSilent for gunshots?), but that's a much more radical change to gameplay that I'd rather let @svdm decide on.