### PR TITLE
TTT: Fix "CS:S not mounted" warning

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -206,11 +206,7 @@ function GM:Initialize()
       RunConsoleCommand("sv_alltalk", "0")
    end
 
-   local cstrike = false
-   for _, g in ipairs(engine.GetGames()) do
-      if g.folder == 'cstrike' then cstrike = true end
-   end
-   if not cstrike then
+   if not IsMounted("cstrike") then
       ErrorNoHalt("TTT WARNING: CS:S does not appear to be mounted by GMod. Things may break in strange ways. Server admin? Check the TTT readme for help.\n")
    end
 end


### PR DESCRIPTION
engine.GetGames returns a table of games that can potentially be mounted by GMod, not games that are currently mounted, meaning this check will never return an error.

Using IsMounted both fixes this and makes the check much neater.

Before
![cstrikebefore](https://github.com/user-attachments/assets/53d8230d-71d6-4147-9ea5-3bddc8a9bba2)

After
![cstrikeafter](https://github.com/user-attachments/assets/b89616e1-09fe-44f8-b235-feb257fdb4d2)
