### PR TITLE
Add list.GetEntry

### DIFF
--- a/garrysmod/lua/includes/modules/list.lua
+++ b/garrysmod/lua/includes/modules/list.lua
@@ -13,6 +13,19 @@ function Get( listid )
 
 end
 
+function GetEntry( listid, key )
+
+	local list = GetForEdit( listid )
+	local value = list[ key ]
+
+	if ( istable( value ) ) then
+		value = table.Copy( value )
+	end
+
+	return value
+
+end
+
 function GetForEdit( listid, nocreate )
 
 	local list = Lists[ listid ]


### PR DESCRIPTION
Dramatically more efficient if you've got a big list and the thing you want might not even be on it