### PR TITLE
Add "Assert" Global Function

### DIFF
--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -438,7 +438,7 @@ function Assert( expression, errorMessage, errorLevel, noHalt, ... )
 
     if ( errorMessage ) then
         if ( ... ) then
-            errorMessage = format( errorMessage, ... )
+            errorMessage = Format( errorMessage, ... )
         end
     else
         errorMessage = "assertion failed!"

--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -423,6 +423,37 @@ function Either( iff, aa, bb )
 	return bb
 end
 
+--[[---------------------------------------------------------
+	Custom assert with more features
+-----------------------------------------------------------]]
+local ProtectedCall = ProtectedCall
+local Format = Format
+local error = error
+
+function Assert( expression, errorMessage, errorLevel, noHalt, ... )
+
+    if ( expression ) then
+        return expression, errorMessage, errorLevel, noHalt, ...
+    end
+
+    if ( errorMessage ) then
+        if ( ... ) then
+            errorMessage = format( errorMessage, ... )
+        end
+    else
+        errorMessage = "assertion failed!"
+    end
+
+    errorLevel = errorLevel or 1
+
+    if noHalt then
+        ProtectedCall( error, errorMessage, errorLevel + 2 )
+    else
+        error( errorMessage, errorLevel + 1 )
+    end
+
+end
+
 --
 -- You can use this function to add your own CLASS_ var.
 -- Adding in this way will ensure your CLASS_ doesn't collide with another


### PR DESCRIPTION
A custom assert function that has more features. Unlike the default `assert` function, this function allows you to provide a level to which the error is thrown at. It also has a `noHalt` argument to make the error not halt the code. The varargs are now used to format the error message.

Allowing to provide an error level will allow us to make it actually point to the faulting file, whereas the default `assert` only throws the error at stack level 1, making it seem like we caused the error.

For those with cases that need the error to not halt, or need to format the error message, this function has it built in for convenience, keeping it looking nice and clean.

On a successful assertion, it behaves the same as `assert`, returning all of the arguments.