### PR TITLE
Micro-optimize Workshop Mount VGUI

### DIFF
--- a/garrysmod/lua/menu/mount/vgui/addon_rocket.lua
+++ b/garrysmod/lua/menu/mount/vgui/addon_rocket.lua
@@ -30,29 +30,29 @@ function PANEL:Think()
 end
 ]]
 
-function PANEL:Paint()
+function PANEL:Paint( wide, tall )
 
-	if ( !self.Material ) then return end
+	local matAddonIcon = self.Material
+	if ( !matAddonIcon ) then return end
 
-	local angle = 0
+	local size = self.Size
+	local sizeDouble = self.Size * 2
 
 	DisableClipping( true )
 
+		wide = wide * 0.5
+		tall = tall * 0.5
+
 		surface.SetDrawColor( 255, 255, 255, 255 )
 		surface.SetMaterial( matWorkshopRocket )
-		surface.DrawTexturedRectRotated( self:GetWide() * 0.5, self:GetTall() * 0.5, self.Size * 2, self.Size * 2, angle )
+		surface.DrawTexturedRectRotated( wide, tall, sizeDouble, sizeDouble, 0 )
 
-		if ( self.Material ) then
-
-			surface.SetMaterial( self.Material )
-			surface.DrawTexturedRectRotated( self:GetWide() * 0.5, self:GetTall() * 0.5, self.Size, self.Size, angle )
-
-		end
+		surface.SetMaterial( matAddonIcon )
+		surface.DrawTexturedRectRotated( wide, tall, size, size, 0 )
 
 	DisableClipping( false )
 
 end
-
 
 function PANEL:Charging( id, iImageID )
 
@@ -66,11 +66,5 @@ function PANEL:Charging( id, iImageID )
 		self.Material = AddonMaterial( name )
 
 	end)
-
-end
-
-function PANEL:Blast()
-
-	self:Remove()
 
 end

--- a/garrysmod/lua/menu/mount/vgui/workshop.lua
+++ b/garrysmod/lua/menu/mount/vgui/workshop.lua
@@ -2,6 +2,7 @@
 PANEL.Base = "DPanel"
 
 local wsFont
+
 if ( system.IsLinux() ) then
 	wsFont = "DejaVu Sans"
 elseif ( system.IsWindows() ) then
@@ -45,24 +46,24 @@ function PANEL:Init()
 	self.TotalsLabel:SetVisible( false )
 	self.TotalsLabel:SetTextColor( Color( 255, 255, 255, 50 ) )
 
-	self:SetDrawProgress( false )
-
 	self.Progress = 0
 	self.TotalProgress = 0
 
+	self:SetDrawProgress( false )
+
 end
 
-function PANEL:PerformLayout()
+function PANEL:PerformLayout( wide )
 
 	self:SetSize( 500, 80 )
 	self:Center()
 	self:AlignBottom( 16 )
 
 	self.ProgressLabel:SetSize( 100, 20 )
-	self.ProgressLabel:SetPos( self:GetWide() - 100, 40 )
+	self.ProgressLabel:SetPos( wide - 100, 40 )
 
 	self.TotalsLabel:SetSize( 100, 20 )
-	self.TotalsLabel:SetPos( self:GetWide() - 100, 60 )
+	self.TotalsLabel:SetPos( wide - 100, 60 )
 
 end
 
@@ -74,7 +75,7 @@ end
 
 function PANEL:PrepareDownloading()
 
-	if ( self.Rocket ) then self.Rocket:Remove() end
+	if ( IsValid( self.Rocket ) ) then self.Rocket:Remove() end
 
 	self.Rocket = self:Add( pnlRocket )
 	self.Rocket:Dock( LEFT )
@@ -88,12 +89,13 @@ function PANEL:StartDownloading( id, iImageID, title, iSize )
 	self.Label:SetText( language.GetPhrase( "ugc.downloadingX" ):format( title ) )
 
 	self.Rocket:Charging( id, iImageID )
-	self:SetDrawProgress( true )
+
 	self.ProgressLabel:Show()
 	self.ProgressLabel:SetText( "" )
 
 	self.TotalsLabel:Show()
 
+	self:SetDrawProgress( true )
 	self:UpdateProgress( 0, iSize )
 
 end
@@ -116,32 +118,37 @@ function PANEL:SetMessage( msg )
 
 end
 
-function PANEL:Paint()
+local boxColor = Color( 50, 50, 50, 255 )
+local progressBarColor = Color( 255, 255, 255, 200 )
+local progressBarOutlineColor = Color( 0, 0, 0, 150 )
+
+function PANEL:Paint( wide, tall )
 
 	DisableClipping( true )
-		draw.RoundedBox( 4, -1, -1, self:GetWide() + 2, self:GetTall() + 2, color_black )
+		draw.RoundedBox( 4, -1, -1, wide + 2, tall + 2, color_black )
 	DisableClipping( false )
 
-	draw.RoundedBox( 4, 0, 0, self:GetWide(), self:GetTall(), Color( 50, 50, 50, 255 ) )
+	draw.RoundedBox( 4, 0, 0, wide, tall, boxColor )
 
 	surface.SetDrawColor( 0, 0, 0, 100 )
 	surface.SetMaterial( matProgressCog )
-	surface.DrawTexturedRectRotated( 0, 32, 64 * 4, 64 * 4, SysTime() * -20 )
+	surface.DrawTexturedRectRotated( 0, 32, 256, 256, SysTime() * -20 )
 
 	if ( self:GetDrawProgress() ) then
 
 		-- Overall progress
-		local off = 0
-		local w = (self:GetWide() - 64 - 64 - 100)
+		local w = wide - 228
 		local x = 80
 
-		draw.RoundedBox( 4, x + 32 + off, 44 + 18, w, 10, Color( 0, 0, 0, 150 ) )
-		draw.RoundedBox( 4, x + 33 + off, 45 + 18, w * math.Clamp( self.TotalProgress, 0.05, 1 ) - 2, 8, Color( 255, 255, 255, 200 ) )
+		draw.RoundedBox( 4, x + 32, 62, w, 10, progressBarOutlineColor )
+		draw.RoundedBox( 4, x + 33, 63, w * math.Clamp( self.TotalProgress, 0.05, 1 ) - 2, 8, progressBarColor )
 
 		-- Current file Progress
-		if ( self.Progress >= 0 ) then
-			draw.RoundedBox( 4, x + 32, 40, w, 15, Color( 0, 0, 0, 150 ) )
-			draw.RoundedBox( 4, x + 33, 41, w * math.Clamp( self.Progress, 0.05, 1 ) - 2, 15-2, Color( 255, 255, 255, 200 ) )
+		local currentProgress = self.Progress
+
+		if ( currentProgress >= 0 ) then
+			draw.RoundedBox( 4, x + 32, 40, w, 15, progressBarOutlineColor )
+			draw.RoundedBox( 4, x + 33, 41, w * math.Clamp( currentProgress, 0.05, 1 ) - 2, 13, progressBarColor )
 		end
 
 	end


### PR DESCRIPTION
I was checking the code for these vgui's and I saw that some things could be optimized.

- Removes a few redundant calls (especially ones in Paint methods). This reduces the amount of `__index` calls
- Removes unnecessary arithmetic operations (like `15-2` for example, lol)
- Caches colors outside of Paint methods (to not spam create garbage)

Bonus: Removes un-used Blast method from workshop rocket vgui!!!