### PR TITLE
[TTT] Update the Magneto stick to use the HL2DM viewmodel used in sandbox that has c_hands support

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
@@ -12,13 +12,15 @@ if CLIENT then
 
    SWEP.DrawCrosshair       = false
    SWEP.ViewModelFlip       = false
+   SWEP.ViewModelFOV        = 54
 end
 
 SWEP.Base                   = "weapon_tttbase"
 
 SWEP.AutoSpawnable          = false
 
-SWEP.ViewModel              = Model("models/weapons/v_stunbaton.mdl")
+SWEP.UseHands               = true
+SWEP.ViewModel              = Model("models/weapons/c_stunstick.mdl")
 SWEP.WorldModel             = Model("models/weapons/w_stunbaton.mdl")
 
 SWEP.Primary.ClipSize       = -1


### PR DESCRIPTION
Changes the magneto stick to use the hl2dm stunstick model instead of the hl2beta model so that it has proper c_hands support 

before 
https://github.com/user-attachments/assets/abf71291-c7fa-440a-8051-454b944ce64d

after
https://github.com/user-attachments/assets/64694194-4db8-44d3-9837-55d4e676c538

