### PR TITLE
Fix spawnmenu sorting bad tool names

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/toolpanel.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/toolpanel.lua
@@ -189,6 +189,7 @@ function PANEL:AddCategory( name, catName, tItems )
 	local tools = {}
 	for k, v in pairs( tItems ) do
 		local name = v.Text or v.ItemName or v.Controls or v.Command or tostring( k )
+		if ( name:StartsWith( "#" ) ) then name = name:sub( 2 ) end
 		tools[ language.GetPhrase( name ) ] = v
 	end
 


### PR DESCRIPTION
If a tool's name is set to a language phrase that is never registered, the spawnmenu sorts the tool incorrectly but still displays it correctly.

Addon creators likely didn't notice this since the `Panel:SetText()` method will automatically remove the `#` if the inputted string starts with one.

So if `TOOL.Name = "#Buoyancy"` and the language phrase is never registered, the panel still shows it correctly as `"Buoyancy"` but the spawnmenu sorts it incorrectly to the top of the category (`#` sorts alphabetically before `A`).

![image](https://github.com/user-attachments/assets/b9af9308-f5dc-4d59-9bbc-22d816823a7f)
![image](https://github.com/user-attachments/assets/078a10fb-5160-4f73-91bc-e3687c19191b)

A fix is by replicating the `Panel:SetText()` behavior by removing the `#` if the tool name starts with one, which is already done by the spawnmenu [when searching for tools](https://github.com/Facepunch/garrysmod/blob/4bf2cff85b52ec46436973d175cfec8f0e6becf3/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/toolpanel.lua#L94-L96).