### PR TITLE
Sort favourite servers at the top of the server list

### DIFF
--- a/garrysmod/html/css/menu/Servers.css
+++ b/garrysmod/html/css/menu/Servers.css
@@ -245,6 +245,11 @@ H1 small
 	background-color: #F1F6FF;
 }
 
+.serverlist .server.fav + .server:not(.fav)
+{
+	border-top: 2px solid rgba(102, 170, 255, 0.5);
+}
+
 .serverlist .empty
 {
 	color: #777;

--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -160,12 +160,15 @@ function ControllerServers( $scope, $element, $rootScope, $location )
 		if ( gm.OrderByMain == order )
 		{
 			gm.OrderReverse = !gm.OrderReverse;
-			return;
+		} 
+		else
+		{
+			gm.OrderReverse = false;
 		}
 
 		gm.OrderByMain = order;
-		gm.OrderBy = [ order, 'recommended', 'ping', 'address' ];
-		gm.OrderReverse = false;
+		gm.OrderBy = [ (gm.OrderReverse?"+":"-")+'favorite', order, 'recommended', 'ping', 'address' ];
+		
 	}
 
 	$scope.GamemodeName = function( gm )
@@ -380,7 +383,7 @@ function GetGamemode( name, type )
 		server_offset:	0,
 		sort_players:	0,
 		OrderByMain:	'recommended',
-		OrderBy:		[ 'recommended', 'ping', 'address' ],
+		OrderBy:		[ '-favorite', 'recommended', 'ping', 'address' ],
 		info:			GetGamemodeInfo( name ),
 		FilterFlags:	{},
 		HasPreferFlags:	false

--- a/garrysmod/html/template/servers.html
+++ b/garrysmod/html/template/servers.html
@@ -130,7 +130,7 @@
 						<div id="placeholder_pre" style="height: {{CurrentGamemode.server_offset * 22}}px"></div>
 
 						<div ng-repeat="server in CurrentGamemode.servers | orderBy: CurrentGamemode.OrderBy : CurrentGamemode.OrderReverse | filter: serverFilter | startFrom : CurrentGamemode.server_offset | limitTo : ServersPerPage"
-							class="server {{ ServerClass( server ) }} {{IfElse( CurrentGamemode.Selected == server, 'activeserver', '' )}}" ng-mouseup="SelectServer( server, $event )" >
+							class="server {{ ServerClass( server ) }} {{IfElse( CurrentGamemode.Selected == server, 'activeserver', '' )}} {{IfElse( server.favorite, 'fav', '' )}}" ng-mouseup="SelectServer( server, $event )" >
 
 							<name>
 								<a class='favbutton {{IfElse( server.favorite, "favorited", "" )}}' ng-click="ToggleFavorite( server );$event.stopPropagation();"></a>


### PR DESCRIPTION
Favourited servers will now show at the top of the server list. They will still follow the sort options, but within that favourites grouping. 
A small divider is shown between the last favourite server and the first non-favourite server to assist visually, however the servers are still all part of the same listing so there isn't an issue with multiple scrollbars or anything like that.

Works in Awesomium and CEF86.

![image](https://github.com/user-attachments/assets/efcd1cee-f6dc-407d-bc36-61a80a5c9721)
