### PR TITLE
TTT: Close player volume slider along with scoreboard

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -173,7 +173,7 @@ function PANEL:SetPlayer(ply)
 
    self.voice.DoRightClick = function()
       if IsValid(ply) and ply != LocalPlayer() then
-         self:ShowMicVolumeSlider()
+         self.voice.volume = self:ShowMicVolumeSlider()
       end
    end
 
@@ -320,14 +320,6 @@ function PANEL:DoRightClick()
    menu:Open()
 end
 
-local frame
-local function HideVolume()
-   if IsValid(frame) then
-      frame:Close()
-   end
-end
-hook.Add("ScoreboardHide", "TTT_HideVolume", HideVolume)
-
 function PANEL:ShowMicVolumeSlider()
    local width = 300
    local height = 50
@@ -344,7 +336,7 @@ function PANEL:ShowMicVolumeSlider()
 
 
    -- Frame for the slider
-   frame = vgui.Create("DFrame")
+   local frame = vgui.Create("DFrame")
    frame:SetPos(x, y)
    frame:SetSize(width, height)
    frame:MakePopup()
@@ -357,7 +349,7 @@ function PANEL:ShowMicVolumeSlider()
    end
 
    -- Automatically close after 10 seconds (something may have gone wrong)
-   timer.Create("TTT_CloseVolumeSlider", 10, 1, HideVolume)
+   timer.Simple(10, function() if IsValid(frame) then frame:Close() end end)
 
 
    -- "Player volume"
@@ -418,6 +410,22 @@ function PANEL:ShowMicVolumeSlider()
 
       draw.RoundedBox(100, 0, 0, sliderHeight, sliderHeight, Color(255, 255, 255, 255))
    end
+
+   return frame
 end
+
+local function HideVolumePanels()
+   if not IsValid(sboard_panel) then return end
+
+   for _, grp in ipairs(sboard_panel.ply_groups) do
+      for _, ply in pairs(grp.rows) do
+         if IsValid(ply.voice.volume) then
+            ply.voice.volume:Close()
+            ply.voice.volume = nil
+         end
+      end
+   end
+end
+hook.Add("ScoreboardHide", "TTT_HideVolumePanels", HideVolumePanels)
 
 vgui.Register( "TTTScorePlayerRow", PANEL, "DButton" )

--- a/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -321,6 +321,13 @@ function PANEL:DoRightClick()
 end
 
 local frame
+local function HideVolume()
+   if IsValid(frame) then
+      frame:Close()
+   end
+end
+hook.Add("ScoreboardHide", "TTT_HideVolume", HideVolume)
+
 function PANEL:ShowMicVolumeSlider()
    local width = 300
    local height = 50
@@ -350,7 +357,7 @@ function PANEL:ShowMicVolumeSlider()
    end
 
    -- Automatically close after 10 seconds (something may have gone wrong)
-   timer.Create("TTT_CloseVolumeSlider", 10, 1, function() if IsValid(frame) then frame:Close() end end)
+   timer.Create("TTT_CloseVolumeSlider", 10, 1, HideVolume)
 
 
    -- "Player volume"
@@ -412,12 +419,5 @@ function PANEL:ShowMicVolumeSlider()
       draw.RoundedBox(100, 0, 0, sliderHeight, sliderHeight, Color(255, 255, 255, 255))
    end
 end
-
-local function HideVolume()
-   if IsValid(frame) then
-      frame:Close()
-   end
-end
-hook.Add("ScoreboardHide", "TTT_HideVolume", HideVolume)
 
 vgui.Register( "TTTScorePlayerRow", PANEL, "DButton" )

--- a/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -320,7 +320,7 @@ function PANEL:DoRightClick()
    menu:Open()
 end
 
-
+local frame
 function PANEL:ShowMicVolumeSlider()
    local width = 300
    local height = 50
@@ -337,7 +337,7 @@ function PANEL:ShowMicVolumeSlider()
 
 
    -- Frame for the slider
-   local frame = vgui.Create("DFrame")
+   frame = vgui.Create("DFrame")
    frame:SetPos(x, y)
    frame:SetSize(width, height)
    frame:MakePopup()
@@ -350,7 +350,7 @@ function PANEL:ShowMicVolumeSlider()
    end
 
    -- Automatically close after 10 seconds (something may have gone wrong)
-   timer.Simple(10, function() if IsValid(frame) then frame:Close() end end)
+   timer.Create("TTT_CloseVolumeSlider", 10, 1, function() if IsValid(frame) then frame:Close() end end)
 
 
    -- "Player volume"
@@ -408,9 +408,16 @@ function PANEL:ShowMicVolumeSlider()
          )
          draw.DrawText(textValue, "cool_small", sliderHeight / 2, -20, Color(255, 255, 255, 255), TEXT_ALIGN_CENTER)
       end
-      
+
       draw.RoundedBox(100, 0, 0, sliderHeight, sliderHeight, Color(255, 255, 255, 255))
    end
 end
+
+local function HideVolume()
+   if IsValid(frame) then
+      frame:Close()
+   end
+end
+hook.Add("ScoreboardHide", "TTT_HideVolume", HideVolume)
 
 vgui.Register( "TTTScorePlayerRow", PANEL, "DButton" )


### PR DESCRIPTION
If the player volume slider is open when the scoreboard closes, it will remain stuck on the screen until you either mess with the slider or wait 10 seconds for it to autoclose.

This adds a hook to make it close when letting go of tab.