### PR TITLE
`math`: Optimize `Distance`, `Clamp`, `Approach`

### DIFF
--- a/garrysmod/lua/includes/extensions/math.lua
+++ b/garrysmod/lua/includes/extensions/math.lua
@@ -54,7 +54,8 @@ function math.Clamp( num, low, high )
 	if ( num < low ) then return low end
 	if ( num > high ) then return high end
 
-	return num
+	-- If the passed number is NaN, return the lowest limit
+	return num ~= num and low or high
 end
 
 --[[---------------------------------------------------------

--- a/garrysmod/lua/includes/extensions/math.lua
+++ b/garrysmod/lua/includes/extensions/math.lua
@@ -51,11 +51,13 @@ end
 	Desc: Clamp value between 2 values
 ------------------------------------------------------------]]
 function math.Clamp( num, low, high )
-	if ( num < low ) then return low end
-	if ( num > high ) then return high end
+	if ( num < low or num ~= num --[[NaN-check]] ) then
+		return low
+	elseif ( num > high ) then
+		return high
+	end
 
-	-- If the passed number is NaN, return the lowest limit
-	return num ~= num and low or num
+	return num
 end
 
 --[[---------------------------------------------------------

--- a/garrysmod/lua/includes/extensions/math.lua
+++ b/garrysmod/lua/includes/extensions/math.lua
@@ -20,7 +20,7 @@ end
 function math.Distance( x1, y1, x2, y2 )
 	local xd = x2 - x1
 	local yd = y2 - y1
-	return math.sqrt( xd * xd + yd * yd )
+	return ( xd * xd + yd * yd ) ^ 0.5
 end
 math.Dist = math.Distance -- Backwards compatibility
 
@@ -47,11 +47,14 @@ function math.IntToBin( int )
 end
 
 --[[---------------------------------------------------------
-	Name: Clamp( in, low, high )
+	Name: Clamp( num, low, high )
 	Desc: Clamp value between 2 values
 ------------------------------------------------------------]]
-function math.Clamp( _in, low, high )
-	return math.min( math.max( _in, low ), high )
+function math.Clamp( num, low, high )
+	if ( num < low ) then return low end
+	if ( num > high ) then return high end
+
+	return num
 end
 
 --[[---------------------------------------------------------
@@ -172,11 +175,13 @@ end
 
 function math.Approach( cur, target, inc )
 	if ( cur < target ) then
-		return math.min( cur + math.abs( inc ), target )
+		cur = cur + ( inc < 0 and -inc or inc )
+		return cur < target and cur or target
 	end
 
 	if ( cur > target ) then
-		return math.max( cur - math.abs( inc ), target )
+		cur = cur - ( inc < 0 and -inc or inc )
+		return cur > target and cur or target
 	end
 
 	return target

--- a/garrysmod/lua/includes/extensions/math.lua
+++ b/garrysmod/lua/includes/extensions/math.lua
@@ -55,7 +55,7 @@ function math.Clamp( num, low, high )
 	if ( num > high ) then return high end
 
 	-- If the passed number is NaN, return the lowest limit
-	return num ~= num and low or high
+	return num ~= num and low or num
 end
 
 --[[---------------------------------------------------------


### PR DESCRIPTION
`Distance`: `math.sqrt( ... )` —> `( ... ) ^ 0.5`

![image](https://github.com/user-attachments/assets/5a357559-88f6-48ac-880d-c9ceca4c215c)
<details> <summary>Benchmark Code</summary>

```lua

times = 64

print( Format( 'branch => %s\niterations => %i', BRANCH, times ) )

function main()

	print( Format( '\njit status => %s', jit.status() ) )

	sum = 0
	avg1 = 0

	local sqrt = math.sqrt

	for i = 1, times do

		util.TimerCycle()

			local x = sqrt( 5 )

		sum = sum + util.TimerCycle()

	end

	avg1 = sum / times
	print( Format( 'math.sqrt\n\t%.8f ms on average (100%%)', sum / times ) )

	sum = 0
	avg2 = 0

	for i = 1, times do

		util.TimerCycle()

			local x = 5 ^ 0.5

		sum = sum + util.TimerCycle()

	end

	avg2 = sum / times
	print( Format( 'pow operator\n\t%.8f ms on average (%.1f%%)', sum / times, ( avg2 * 100 ) / avg1 ) )

end

jit.off()
main()

jit.on()
main()

```
</details>

`Clamp` & `Approach`: Replaced functions with operators, which are faster in action.

![image](https://github.com/user-attachments/assets/e072b5cc-fb6d-4d10-b565-a60e3ebf6229)
![image](https://github.com/user-attachments/assets/3d277645-50e7-4b98-9c36-b434d8314fd3)

Note: Approach becomes a bit slower with enabled JIT if used more than once at the moment (applies to the default branches, but not to `x86-64`)
