### PR TITLE
Loading screen cleanup/tweaks

### DIFF
--- a/garrysmod/html/loading.css
+++ b/garrysmod/html/loading.css
@@ -150,17 +150,5 @@ body.dark
 	height: 128px;
 	background: #666;
 	margin-right: 16px;
-}
-.server_info #serverGamemode img
-{
-	vertical-align: text-top;
-	margin-left: 8px;
-	margin-top: 6px;
-	width: 26px;
-	height: 26px;
-}
-
-.server_info #serverGamemode img.hidden
-{
-	display: none;
+	float: left;
 }

--- a/garrysmod/html/loading.html
+++ b/garrysmod/html/loading.html
@@ -21,7 +21,7 @@
 				<div class="text">
 					<div id="serverName">A really long server name will be here that will be too long to fit on the loading screen</div>
 					<div id="serverMap">gm_hilldirt</div>
-					<div id="serverGamemode"><span>Snadbox</span><img class="hidden" onerror="this.classList.add('hidden');"/></div>
+					<div id="serverGamemode">Snadbox</div>
 				</div>
 			</div>
 
@@ -50,13 +50,10 @@
 			function GameDetails( servername, serverurl, mapname, maxplayers, steamid, gamemode, volume, lang, gamemodeNice )
 			{
 				var mapImg = "asset://mapimage/" + mapname;
-				var gmImg = "../gamemodes/" + gamemode + "/icon24.png";
 				
 				document.querySelector("#serverName").innerText = servername;
 				document.querySelector("#serverMap").innerText = mapname;
-				document.querySelector("#serverGamemode span").innerText = gamemodeNice;
-				document.querySelector("#serverGamemode img").classList.remove("hidden");
-				document.querySelector("#serverGamemode img").setAttribute( "src", gmImg );
+				document.querySelector("#serverGamemode").innerText = gamemodeNice;
 				document.querySelector("#mapimg").setAttribute( "src", mapImg );
 				document.body.style.backgroundImage = "url('" + mapImg + "')";
 


### PR DESCRIPTION
I've made a few tweaks to the loading screen html/css. 

Mostly to clean up some code, remove redundant bits, etc. Developed and tested in Awesomium to ensure compatibility.

For visual changes:
- If the server name is too long to fit the user's screen width, it will now use "..." ellipsis at the end of the screen instead of a hard cut
- ~The gamemode name will have the gamemode icon next to it. If the icon does not exist it will just have no icon, which is how it is currently. Having this in the loading screen shows developers how they can easily do it on their own loading screen, and having it on the right means no change to text alignment.~