### PR TITLE
Add vpairs iterator

### DIFF
--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -550,6 +550,19 @@ local function getKeys( tbl )
 end
 
 --[[---------------------------------------------------------
+	A Value Pairs function (vpairs)
+		A custom iterator similar to ipairs, but it returns 
+		the value first, followed by the key.
+-----------------------------------------------------------]]
+function vpairs(t)
+  local i = 0
+  return function()
+    i = i + 1
+    return t[i], i
+  end
+end
+
+--[[---------------------------------------------------------
 	A Pairs function
 		Sorted by TABLE KEY
 -----------------------------------------------------------]]


### PR DESCRIPTION
I noticed that most of the time when using ``ipairs`` (even in the garrysmod repository) people just ignore/not use the index (key), so I decided to “rid” us of it.

Just look at example
```lua
local files = file.Find("test/*", "DATA")

for filename in vpairs(files) do
  print(filename:GetExtensionFromFilename())
end

-- Basically you can also get the index, but it's useless, you can just use ipairs, but still
for filename, index in vpairs(files) do
  print(index, filename:GetExtensionFromFilename())
end
```

```lua
for v in vpairs({"a", "b", "c"}) do
  print(v)
end
--- Output:
---   a
---   b
---   c

for v in vpairs({"a", nil, "b"}) do
  print(v)
end
--- Output:
---   a
```
Let's make the code cleaner!