### PR TITLE
[TTT] fix players sometimes being revealed as dead when they chat/voicechat right as they die

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/cl_voice.lua
+++ b/garrysmod/gamemodes/base/gamemode/cl_voice.lua
@@ -29,7 +29,7 @@ function PANEL:Setup( ply )
 	self.LabelName:SetText( ply:Nick() )
 	self.Avatar:SetPlayer( ply )
 	
-	self.Color = team.GetColor( ply:Team() )
+	self.Color = hook.Run("GetTeamColor", ply)
 	
 	self:InvalidateLayout()
 

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_voice.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_voice.lua
@@ -49,6 +49,15 @@ local function RoleChatRecv()
 end
 net.Receive("TTT_RoleChat", RoleChatRecv)
 
+function GM:GetTeamColor(ent)
+   -- don't reveal that a player has died when they happen to chat or voicechat at the moment of death
+   if ent:IsPlayer() and ent:IsSpec() and ScoreGroup(ent) == GROUP_NOTFOUND then
+      return hook.Run("GetTeamNumColor", TEAM_TERROR)
+   end
+
+   return BaseClass.GetTeamColor(self, ent)
+end
+
 -- special processing for certain special chat types
 function GM:ChatText(idx, name, text, type)
 


### PR DESCRIPTION
sometimes when a player sends a text chat right as they die, their name will appear as yellow, which confirms their death

also sometimes when a player voicechats right as they die, their voicechat ui will use a yellow background for a split second, which confirms their death