### PR TITLE
`env_skypaint` I/O (incl. `color255` inputs)

### DIFF
--- a/bin/garrysmod.fgd
+++ b/bin/garrysmod.fgd
@@ -30,7 +30,7 @@
 [
 	topcolor(color1)		: "Sky Top Color" : "0.2 0.5 1.0" : "The colour of the top of the sky."
 	bottomcolor(color1)		: "Sky Bottom Color" : "0.8 1.0 1.0" : "The colour of the bottom of the sky."
-	fadebias(float)			: "Sky Fade Bias" : "1.0" : "Controls the bias of the fade between top/bottom. (1.0 is even)"
+	fadebias(float)			: "Sky Fade Bias" : "1.0" : "Controls the bias of the fade between top/bottom (1.0 is even)."
 
 	sunsize(float)			: "Sun Size" : "2.0" : "Controls the size of the sun glow."
 	sunnormal(vector)		: "Sun Normal" : "0.4 0.0 0.01" : "The position of the sun, expressed as a normal from the center of the world."
@@ -39,9 +39,9 @@
 		0 : "Custom - Use the Sun Normal to position the sun"
 		1 : "Automatic - Find a env_sun entity and use that"
 	]
-	suncolor(color1)		: "Sun Color" : "0.2 0.1 0.0" : "The color of the sun glow. (this is additive)"
+	suncolor(color1)		: "Sun Color" : "0.2 0.1 0.0" : "The color of the sun glow (this is additive)."
 
-	duskscale(float)		: "Dusk Scale" : "1.0" : "The size of the dusk effect. (colouring of the horizon)"
+	duskscale(float)		: "Dusk Scale" : "1.0" : "The size of the dusk effect (colouring of the horizon)."
 	duskintensity(float)	: "Dusk Intensity" : "1.0" : "How powerful the dusk effect is."
 	duskcolor(color1)		: "Dusk Color" : "1.0 0.2 0.0" : "The color of the dusk effect."
 
@@ -55,9 +55,30 @@
 	starscale(float)		: "Star Scale" : "0.5" : "How big the star texture should be."
 	starfade(float)			: "Star Fade" : "1.0" : "Fade the star texture towards the horizon."
 	starspeed(float)		: "Star Speed" : "0.01" : "How fast the star texture should scroll across the sky."
-	starlayers(float)		: "Star Layers" : "1" : "From 1 to 3, how many layers should the star texture be repated over."
+	starlayers(float)		: "Star Layers" : "1" : "From 1 to 3, how many layers should the star texture be repeated over."
 
 	hdrscale(float)			: "HDR Scale" : "0.66" : "When rendering your skybox in HDR mode, output will be scaled by this amount."
+
+	// Inputs
+	input SetTopColor(color1) : "Sets the colour of the top of the sky."
+	input SetTopColor255(color255) : "Sets the colour of the top of the sky in color255 format."
+	input SetBottomColor(color1) : "Sets the colour of the bottom of the sky."
+	input SetBottomColor255(color255) : "Sets the colour of the bottom of the sky in color255 format."
+	input SetFadeBias(float) : "Controls the bias of the fade between top/bottom (1.0 is even)."
+	input SetSunSize(float) : "Controls the size of the sun glow."
+	input SetSunNormal(vector) : "Sets the position of the sun, expressed as a normal from the center of the world."
+	input SetSunColor(color1) : "Sets the color of the sun glow (this is additive)."
+	input SetSunColor255(color255) : "Sets the color of the sun glow in color255 format (this is additive)."
+	input SetDuskScale(float) : "Sets the size of the dusk effect (colouring of the horizon)."
+	input SetDuskIntensity(float) : "Sets how powerful the dusk effect is."
+	input SetDuskColor(color1) : "Sets the color of the dusk effect."
+	input SetDuskColor255(color255) : "Sets the color of the dusk effect in color255 format."
+	input StarTexture(string) : "Sets the star texture."
+	input StarScale(float) : "Sets how big the star texture should be."
+	input StarFade(float) : "Sets the fading term of the star texture towards the horizon."
+	input StarSpeed(float) : "Sets how fast the star texture should scroll across the sky."
+	input StarLayers(float) : "From 1 to 3, how many layers should the star texture be repeated over."
+	input HDRScale(float) : "Sets the amount by which output will be scaled in HDR mode."
 ]
 
 @PointClass base(Targetname, Parentname, RenderFields, Angles, DXLevelChoice) studio("models/editor/cone_helper.mdl") = beam_spotlight : 

--- a/garrysmod/gamemodes/base/entities/entities/env_skypaint.lua
+++ b/garrysmod/gamemodes/base/entities/entities/env_skypaint.lua
@@ -81,6 +81,59 @@ function ENT:KeyValue( key, value )
 
 end
 
+if ( SERVER ) then
+
+	function ENT:AcceptInput( name, activator, caller, data )
+
+		-- Ensure all inputs are prefixed with "Set"
+		if ( name:sub(1, 3):lower() == "set" ) then
+
+			name = name:sub(4, -1):lower()
+
+			-- Tokenize on whitespace
+			local tokens = {}
+
+			for token in data:gmatch("%S+") do
+				table.insert(tokens, token)
+			end
+
+			if ( #tokens == 3 ) then -- Three tokens: either three floats or three strings
+
+				local s1, s2, s3 = tonumber(tokens[1]), tonumber(tokens[2]), tonumber(tokens[3])
+
+				if ( isnumber(s1) && isnumber(s2) && isnumber(s3) ) then
+
+					-- Interpreted as a Color/Vector
+					local vec = Vector(tonumber(s1), tonumber(s2), tonumber(s3))
+
+					if ( name:sub(-3) == "255" ) then -- Interpret Vector inputs suffixed with "255" as color255
+						self:SetNetworkKeyValue(name:sub(1, -4), vec / 255)
+					else -- Interpret as color1
+						self:SetNetworkKeyValue(name, vec)
+					end
+
+				end
+
+			--[[
+			elseif ( #tokens == 1 ) then
+				-- Single token: either float or string (does not necessitate conversion)
+				local s = tokens[1]
+				self:SetNetworkKeyValue(name, s)
+			--]]
+
+			else
+
+				-- 0 tokens, 1 token, 2 tokens, 4+ tokens, etc.
+				self:SetNetworkKeyValue(name, data)
+
+			end
+
+		end
+
+	end
+
+end
+
 function ENT:Think()
 
 	--


### PR DESCRIPTION
A hacky implementation of `ENT:AcceptInput( ... )` to proxy incoming I/O traffic to existing `ENT:KeyValue( ... )` data table logic.

Historically, `AddOutput` would be used by mappers to change keyvalues on `env_skypaint`, but any `AddOutput` setup requires static string parameter overrides, thus barring them from utilizing entities such as `math_remap`, `math_colorblend` or any other logic entities that dynamically output their own data (`float`, `vector`, `color255`).

These changes keep the old `AddOutput` behavior, but also add `SetVariableName` inputs for all fields, including `color255` inputs for all traditionally `color1` fields (in the form of `SetColorField255` vs. `SetColorField`, both existing and functional).

Given the hacky nature of the implementation, any of `env_skypaint`'s KV pairs accessible via `ENT:SetNetworkKeyValue( ... )` can be set this way, but only the variables that make sense to modify in this manner have been added to the FGD as inputs.