### PR TITLE
Add RunFile function to compile and execute Lua files with argumens

### DIFF
--- a/garrysmod/lua/includes/util.lua
+++ b/garrysmod/lua/includes/util.lua
@@ -186,6 +186,22 @@ function IncludeCS( filename )
 	return include( filename )
 end
 
+--[[---------------------------------------------------------
+	Compiles and runs the given file with given arguments
+	Returns the return values of the file
+-----------------------------------------------------------]]
+function RunFile( filename, ... )
+
+	local func = CompileFile( filename, true )
+	if ( !func ) then return end
+
+	local rets, n = table.Pack( xpcall( func, ErrorNoHaltWithStack, ... ) )
+	if ( rets[1] == false ) then return end
+
+	return unpack( rets, 2, n )
+
+end
+
 -- Globals
 FORCE_STRING	= 1
 FORCE_NUMBER	= 2


### PR DESCRIPTION
It's annoying that `include` does not accept arguments when running files, this is probably because of autorefresh will be annoying to deal with if it accepted arguments, but it comes handy when all you need is having local env instead of polluting the global table to go over not being able to pass arguments