### PR TITLE
Added ENT.Information support + 2 fixes for NPC content icons

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenticon.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenticon.lua
@@ -349,12 +349,12 @@ spawnmenu.AddContentType( "npc", function( container, obj )
 	icon:SetColor( Color( 244, 164, 96, 255 ) )
 
 	-- Generate a nice tooltip with extra info.
-	local NPCinfo = weapons.Get( obj.spawnname )
+	local NPCinfo = scripted_ents.Get( obj.spawnname )
 	local toolTip = language.GetPhrase( obj.nicename )
 	if ( !NPCinfo ) then NPCinfo = list.Get( "NPC" )[ obj.spawnname ] end
 	if ( NPCinfo ) then
 		toolTip = toolTip .. "\n"
-		-- TODO: Some kind of description?
+		if ( NPCinfo.Information and NPCinfo.Information != "" ) then toolTip = toolTip .. "\n" .. NPCinfo.Information end
 		if ( NPCinfo.Author and NPCinfo.Author != "" ) then toolTip = toolTip .. "\n" .. language.GetPhrase( "entityinfo.author" ) .. " " .. NPCinfo.Author end
 	end
 


### PR DESCRIPTION
Here is a list of changes:
- Added support for `Information` variable similar to non-NPC entities, this fulfills the `TODO: Some kind of description?`
- Fixed `Author` field applying even when the NPC doesn't have it, this was creating an empty line.
- Fixed retrieving using `weapons.Get` which didn't properly get the NPC table, it now uses `scripted_ents.Get`, this also allows people to set the `Author` and `Information` variable directly inside the NPC rather than in its spawnlist definition.

Before:
![image](https://github.com/user-attachments/assets/ef8511ec-74b3-43d8-9978-fe90c3c7fa13)

After:
![image](https://github.com/user-attachments/assets/084ce8d5-427c-4c26-b17f-f86924ee3ddd)

