### PR TITLE
Optimize widgets (but better)

### DIFF
--- a/garrysmod/lua/entities/widget_arrow.lua
+++ b/garrysmod/lua/entities/widget_arrow.lua
@@ -51,10 +51,12 @@ function ENT:OverlayRender()
 		render.SetMaterial( matArrow )
 	end
 
+	local pos = self:GetPos()
+
 	render.DepthRange( 0, 0.01 )
-	render.DrawBeam( self:GetPos(), self:GetPos() + fwd * size, 2, 1, 0, Color( c.r, c.g, c.b, c.a * 0.1 ) )
+	render.DrawBeam( pos, pos + fwd * size, 2, 1, 0, Color( c.r, c.g, c.b, c.a * 0.1 ) )
 	render.DepthRange( 0, 1 * self:GetPriority() )
-	render.DrawBeam( self:GetPos(), self:GetPos() + fwd * size, 2, 1, 0, Color( c.r, c.g, c.b, c.a ) )
+	render.DrawBeam( pos, pos + fwd * size, 2, 1, 0, c )
 	render.DepthRange( 0, 1 )
 
 end
@@ -90,9 +92,6 @@ function ENT:DragThink( pl, mv, dist )
 end
 
 function ENT:ArrowDragged( pl, mv, dist )
-
-	-- MsgN( dist )
-
 end
 
 function ENT:GetGrabPos( Pos, Forward )

--- a/garrysmod/lua/entities/widget_axis.lua
+++ b/garrysmod/lua/entities/widget_axis.lua
@@ -9,12 +9,6 @@ DEFINE_BASECLASS( "widget_arrow" )
 
 local widget_axis_arrow = { Base = "widget_arrow" }
 
-function widget_axis_arrow:Initialize()
-
-	BaseClass.Initialize( self )
-
-end
-
 function widget_axis_arrow:SetupDataTables()
 
 	BaseClass.SetupDataTables( self )
@@ -37,12 +31,6 @@ scripted_ents.Register( widget_axis_arrow, "widget_axis_arrow" )
 DEFINE_BASECLASS( "widget_disc" )
 
 local widget_axis_disc = { Base = "widget_disc" }
-
-function widget_axis_disc:Initialize()
-
-	BaseClass.Initialize( self )
-
-end
 
 function widget_axis_disc:SetupDataTables()
 
@@ -123,11 +111,8 @@ function ENT:SetPriority( x )
 
 end
 
-function ENT:Draw()
+function ENT:OverlayRender()
 end
 
 function ENT:OnArrowDragged( num, dist, pl, mv )
-
-	-- MsgN( num, dist, pl, mv )
-
 end

--- a/garrysmod/lua/entities/widget_disc.lua
+++ b/garrysmod/lua/entities/widget_disc.lua
@@ -23,7 +23,8 @@ function ENT:PressedShouldDraw( widget ) return widget == self end
 
 function ENT:OverlayRender()
 
-	local fwd = self:GetAngles():Forward()
+	local angles = self:GetAngles()
+	local fwd = angles:Forward()
 	local size = self:GetSize()
 
 	local c = self:GetColor()
@@ -34,14 +35,15 @@ function ENT:OverlayRender()
 		c.b = c.b * 0.5
 	end
 
-	local ang = self:GetAngles().roll - 90
+	local pos = self:GetPos()
+	local ang = angles.roll - 90
 
 	render.DepthRange( 0, 0.01 )
 	render.SetMaterial( matDiscAlpha )
-	render.DrawQuadEasy( self:GetPos(), fwd, size, size, Color( c.r, c.g, c.b, c.a * 0.2 ), ang )
+	render.DrawQuadEasy( pos, fwd, size, size, Color( c.r, c.g, c.b, c.a * 0.2 ), ang )
 	render.DepthRange( 0, 1 )
 	render.SetMaterial( matDisc )
-	render.DrawQuadEasy( self:GetPos(), fwd, size, size, Color( c.r, c.g, c.b, c.a ), ang )
+	render.DrawQuadEasy( pos, fwd, size, size, Color( c.r, c.g, c.b, c.a ), ang )
 	render.DepthRange( 0, 1 )
 
 end
@@ -53,11 +55,12 @@ function ENT:TestCollision( startpos, delta, isbox, extents )
 
 	local fwd = self:GetAngles():Forward()
 	local size = self:GetSize() * 0.5
+	local pos = self:GetPos()
 
-	local hitpos = util.IntersectRayWithPlane( startpos, delta:GetNormalized(), self:GetPos(), fwd )
+	local hitpos = util.IntersectRayWithPlane( startpos, delta:GetNormalized(), pos, fwd )
 	if ( !hitpos ) then return end
 
-	local dist = self:GetPos():Distance( hitpos )
+	local dist = pos:Distance( hitpos )
 	if ( dist > size ) then return end
 	if ( dist < size * 0.9 ) then return end
 
@@ -81,9 +84,6 @@ function ENT:DragThink( pl, mv, dist )
 end
 
 function ENT:ArrowDragged( pl, mv, dist )
-
-	-- MsgN( dist )
-
 end
 
 function ENT:GetGrabPos( Pos, Forward )

--- a/garrysmod/lua/includes/modules/widget.lua
+++ b/garrysmod/lua/includes/modules/widget.lua
@@ -5,6 +5,7 @@
 --
 
 widgets = {}
+widgets.Entities = {}
 
 --
 -- Holds the currently hovered widget
@@ -17,7 +18,14 @@ widgets.HoveredPos = vector_origin
 --
 widgets.Pressed = nil
 
-local function UpdateHovered( pl, mv )
+local tr = {}
+local trace = {
+	output = tr,
+	filter = widgets.Entities,
+	whitelist = true,
+}
+
+local function UpdateHovered( pl )
 
 	if ( !IsValid( pl ) ) then return end
 
@@ -26,54 +34,38 @@ local function UpdateHovered( pl, mv )
 		return
 	end
 
-	local OldHovered = pl:GetHoveredWidget()
-	pl:SetHoveredWidget( NULL )
-	
 	local eyePos = pl:EyePos()
 	local aimVector = pl:GetAimVector()
 	aimVector:Mul( 256 )
 	aimVector:Add( eyePos )
-	
-	local trace =
-	{
-		start	= eyePos,
-		endpos	= aimVector,
-		filter	= function( ent )
 
-			return IsValid( ent ) && ent:IsWidget()
-
-		end
-	}
+	trace.start = eyePos
+	trace.endpos = aimVector
 
 --	debugoverlay.Line( trace.start, trace.endpos, 0.5 )
 
 	widgets.Tracing = true
-	local tr = util.TraceLine( trace )
+	util.TraceLine( trace )
 	widgets.Tracing = false
 
-	if ( !IsValid( tr.Entity ) ) then return end
-	if ( tr.Entity:IsWorld() ) then return end
-	if ( !tr.Entity:IsWidget() ) then return end
+	if ( !IsValid( tr.Entity ) || tr.Entity:IsWorld() ) then
+		pl:SetHoveredWidget( NULL )
+		return
+	end
 
 --	debugoverlay.Cross( tr.HitPos, 1, 60 )
-
-	if ( OldHovered != tr.Entity ) then
-
-		-- On hover changed? why bother?
-
-	end
 
 	pl:SetHoveredWidget( tr.Entity )
 	pl.WidgetHitPos = tr.HitPos
 
+	return tr.Entity
+
 end
 
-local function UpdateButton( pl, mv, btn, mousebutton )
+local function UpdateButton( pl, mv, btn, mousebutton, hvr, prs )
 
 	local now = mv:KeyDown( btn )
 	local was = mv:KeyWasDown( btn )
-	local hvr = pl:GetHoveredWidget()
-	local prs = pl:GetPressedWidget()
 
 	if ( now && !was && IsValid( hvr ) ) then
 		hvr:OnPress( pl, mousebutton, mv )
@@ -82,8 +74,8 @@ local function UpdateButton( pl, mv, btn, mousebutton )
 	if ( !now && was && IsValid( prs ) ) then
 		prs:OnRelease( pl, mousebutton, mv )
 	end
-end
 
+end
 
 --
 -- The idea here is to have exactly the same
@@ -91,12 +83,11 @@ end
 --
 function widgets.PlayerTick( pl, mv )
 
-	UpdateHovered( pl, mv )
-
-	UpdateButton( pl, mv, IN_ATTACK, 1 )
-	UpdateButton( pl, mv, IN_ATTACK2, 2 )
-
+	local hvr = UpdateHovered( pl )
 	local prs = pl:GetPressedWidget()
+
+	UpdateButton( pl, mv, IN_ATTACK, 1, hvr, prs )
+	UpdateButton( pl, mv, IN_ATTACK2, 2, hvr, prs )
 
 	if ( IsValid( prs ) ) then
 		prs:PressedThinkInternal( pl, mv )
@@ -104,41 +95,29 @@ function widgets.PlayerTick( pl, mv )
 
 end
 
-
 ---
 ---  Render the widgets!
 ---
 
-local RenderList = {}
+--
+-- Function stub for backwards compatibility
+--
+function widgets.RenderMe() end
 
-function widgets.RenderMe( ent )
+local function RenderWidgets()
 
-	--
-	-- The pressed widget gets to decide what should draw
-	--
-	if ( LocalPlayer() && IsValid(LocalPlayer():GetPressedWidget()) ) then
-
-		if ( !LocalPlayer():GetPressedWidget():PressedShouldDraw( ent ) ) then
-			return
-		end
-
-	end
-
-
-	table.insert( RenderList, ent )
-
-end
-
-hook.Add( "PostDrawEffects", "RenderWidgets", function()
-
-	--
-	-- Don't do anything if we don't have widgets to render!
-	--
-	if ( #RenderList == 0 ) then return end
+	local pl = LocalPlayer()
+	local prs = pl:GetPressedWidget()
+	local prsValid = IsValid( prs )
 
 	cam.Start3D( EyePos(), EyeAngles() )
 
-		for k, v in ipairs( RenderList ) do
+		for _, v in ipairs( widgets.Entities ) do
+
+			--
+			-- The pressed widget gets to decide what should draw
+			--
+			if ( prsValid && !prs:PressedShouldDraw( v ) ) then continue end
 
 			v:OverlayRender()
 
@@ -146,15 +125,45 @@ hook.Add( "PostDrawEffects", "RenderWidgets", function()
 
 	cam.End3D()
 
-	RenderList = {}
+end
+
+hook.Add( "OnEntityCreated", "CreateWidgets", function( ent )
+
+	timer.Simple( 0.001, function()
+
+		if ( !ent:IsWidget() ) then return end
+
+		table.insert( widgets.Entities, ent )
+		hook.Add( "PlayerTick", "TickWidgets", widgets.PlayerTick )
+
+		if ( CLIENT ) then
+			hook.Add( "PostDrawEffects", "RenderWidgets", RenderWidgets )
+		end
+
+	end )
 
 end )
 
+hook.Add( "EntityRemoved", "RemoveWidgets", function( ent )
 
-hook.Add( "PlayerTick", "TickWidgets", function( pl, mv ) widgets.PlayerTick( pl, mv ) end )
+	if ( !ent:IsWidget() ) then return end
 
+	for k, v in next, widgets.Entities do
+		if ( v == ent ) then
+			table.remove( widgets.Entities, k )
+			break
+		end
+	end
 
+	if ( #widgets.Entities == 0 ) then
+		hook.Remove( "PlayerTick", "TickWidgets" )
 
+		if ( CLIENT ) then
+			hook.Remove( "PostDrawEffects", "RenderWidgets" )
+		end
+	end
+
+end )
 
 local ENTITY = FindMetaTable( "Entity" )
 


### PR DESCRIPTION
Based on (and supersedes) #915
Closes [#2902](https://github.com/Facepunch/garrysmod-issues/issues/2902)

In addition to the changes made in the original PR, the following improvements have been made:
- The filter function now uses a whitelist table instead of a function
- The hooks handling widget processing are only added when widgets are in use
- `widgets.RenderMe` is no longer necessary (its logic has been optimized and moved into the rendering hook directly) and has been stubbed out. I'm not sure if any addons that call this function even exist, so any suggestions on whether it should be kept functional, removed entirely, or kept stubbed out would be appreciated
- All widget entities have had some amount of extra optimization done (mostly just reusing variables more often)

The widget system still won't be particularly performant, but it runs at least decently faster now, and manually removing the system entirely should no longer be necessary for a performance boost.