### PR TITLE
Make `PLAYER:LimitHit` server only

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/player_extension.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/player_extension.lua
@@ -90,12 +90,6 @@ function meta:AddCount( str, ent )
 
 end
 
-function meta:LimitHit( str )
-
-	self:SendLua( string.format( 'hook.Run("LimitHit",%q)', str ) )
-
-end
-
 function meta:AddCleanup( type, ent )
 
 	cleanup.Add( self, type, ent )
@@ -115,6 +109,12 @@ function meta:GetTool( mode )
 end
 
 if ( SERVER ) then
+
+	function meta:LimitHit( str )
+
+		self:SendLua( string.format( 'hook.Run("LimitHit",%q)', str ) )
+
+	end
 
 	function meta:SendHint( str, delay )
 


### PR DESCRIPTION
This function never worked on the client anyway and never will. It should be made server only to avoid confusion.