### PR TITLE
Return nil on file.Read not found instead of no value (as wiki suggests)

### DIFF
--- a/garrysmod/lua/includes/extensions/file.lua
+++ b/garrysmod/lua/includes/extensions/file.lua
@@ -7,7 +7,7 @@ function file.Read( filename, path )
 	if ( path == nil || path == false ) then path = "DATA" end
 
 	local f = file.Open( filename, "rb", path )
-	if ( !f ) then return end
+	if ( !f ) then return nil end
 
 	local str = f:Read( f:Size() )
 


### PR DESCRIPTION
https://wiki.facepunch.com/gmod/file.Read suggests that the return data should be `The data from the file as a string, or nil if the file isn't found.`

print(type(file.Read("a.txt", "DATA")))
> no value

This results in unexpected behaviour, for example trying to tonumber the results of file.Read will error, while this function can normally handle nil values - it cant handle no values.

print(file.Read("a.txt", "DATA")) -- nil
print(file.Read("a.txt", "DATA")==nil) -- true
tonumber(nil) -- nil (no error)
tonumber(file.Read("a.txt", "DATA")) -- bad argument #1 to 'tonumber' (value expected)