### PR TITLE
Fix `team.GetColor()`

### DIFF
--- a/garrysmod/lua/includes/modules/team.lua
+++ b/garrysmod/lua/includes/modules/team.lua
@@ -174,9 +174,7 @@ end
 
 function GetColor( index )
 
-	if ( !TeamInfo[index] ) then return DefaultColor end
-
-	local color = TeamInfo[index].Color
+	local color = TeamInfo[index] && TeamInfo[index].Color || DefaultColor
 	return Color( color.r, color.g, color.b, color.a )
 
 end


### PR DESCRIPTION
`team.GetColor(plyWithoutTeamColor)` returns the color itself, not a copy of it. As a result, if you somehow manipulate the color, it will change everywhere.