### PR TITLE
Net anti-spam protection.

### DIFF
--- a/garrysmod/lua/includes/extensions/net.lua
+++ b/garrysmod/lua/includes/extensions/net.lua
@@ -1,24 +1,33 @@
 
--- TODO: Hack. Move to where color is defined?
-TYPE_COLOR = 255
-
--- TODO: Temp hack, remove meta
+-- This is just enough for the entity index. This however is not perfect
+-- as the entity at given index may have changed during transport.
+-- If this becomes a problem, inclusion of entity's serial will also be necessary
 local MAX_EDICT_BITS = 13
 
+TYPE_COLOR = 255
+
 net.Receivers = {}
+net.ReceiversConfigTime = {}
+
+CreateConVar("sv_net_time", 0.5, {FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED}, "The time in seconds between each net message a player can send.")
+CreateConVar("sv_net_protect", 1, {FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED}, "Whether or not to protect the net messages from spam.")
 
 --
 -- Set up a function to receive network messages
 --
-function net.Receive( name, func )
+function net.Receive( name, func, iTime )
 
 	net.Receivers[ name:lower() ] = func
 
+	if SERVER and iTime then
+		net.ReceiversConfigTime[name:lower()] = iTime
+	end
 end
 
 --
 -- A message has been received from the network..
 --
+
 function net.Incoming( len, client )
 
 	local i = net.ReadHeader()
@@ -33,6 +42,27 @@ function net.Incoming( len, client )
 	-- len includes the 16 bit int which told us the message name
 	--
 	len = len - 16
+
+	if SERVER and GetConVar("sv_net_protect"):GetBool() then
+		net.ReceiversProtectionSpam = net.ReceiversProtectionSpam or {}
+
+		if net.ReceiversProtectionSpam[client:SteamID64()] and net.ReceiversProtectionSpam[client:SteamID64()][strName:lower()] and net.ReceiversProtectionSpam[client:SteamID64()][strName:lower()] > CurTime() then
+			print("Player " .. client:Nick() .. " (" .. client:SteamID() .. ") tried to spam the net message " .. strName .. " too much.")
+
+			return
+		end
+
+		local iTime = net.ReceiversConfigTime and isnumber(net.ReceiversConfigTime[strName:lower()]) and net.ReceiversConfigTime[strName:lower()] or GetConVar("sv_net_time"):GetFloat()
+
+		net.ReceiversProtectionSpam[client:SteamID64()] = net.ReceiversProtectionSpam[client:SteamID64()] or {}
+		net.ReceiversProtectionSpam[client:SteamID64()][strName:lower()] = CurTime() + iTime
+
+		timer.Simple(iTime, function()
+			if IsValid(client) and net.ReceiversProtectionSpam[client:SteamID64()] then
+				net.ReceiversProtectionSpam[client:SteamID64()][strName:lower()] = nil
+			end
+		end)
+	end
 
 	func( len, client )
 

--- a/garrysmod/lua/includes/extensions/net.lua
+++ b/garrysmod/lua/includes/extensions/net.lua
@@ -46,7 +46,8 @@ function net.Incoming( len, client )
 	if SERVER and GetConVar("sv_net_protect"):GetBool() then
 		net.ReceiversProtectionSpam = net.ReceiversProtectionSpam or {}
 
-		if net.ReceiversProtectionSpam[client:SteamID64()] and net.ReceiversProtectionSpam[client:SteamID64()][strName:lower()] and net.ReceiversProtectionSpam[client:SteamID64()][strName:lower()] > CurTime() then
+		local sSteamID64 = client:SteamID64()
+		if net.ReceiversProtectionSpam[sSteamID64] and net.ReceiversProtectionSpam[sSteamID64][strName:lower()] and net.ReceiversProtectionSpam[sSteamID64][strName:lower()] > CurTime() then
 			print("Player " .. client:Nick() .. " (" .. client:SteamID() .. ") tried to spam the net message " .. strName .. " too much.")
 
 			return
@@ -54,12 +55,18 @@ function net.Incoming( len, client )
 
 		local iTime = net.ReceiversConfigTime and isnumber(net.ReceiversConfigTime[strName:lower()]) and net.ReceiversConfigTime[strName:lower()] or GetConVar("sv_net_time"):GetFloat()
 
-		net.ReceiversProtectionSpam[client:SteamID64()] = net.ReceiversProtectionSpam[client:SteamID64()] or {}
-		net.ReceiversProtectionSpam[client:SteamID64()][strName:lower()] = CurTime() + iTime
+		net.ReceiversProtectionSpam[sSteamID64] = net.ReceiversProtectionSpam[sSteamID64] or {}
+		net.ReceiversProtectionSpam[sSteamID64][strName:lower()] = CurTime() + iTime
 
 		timer.Simple(iTime, function()
-			if IsValid(client) and net.ReceiversProtectionSpam[client:SteamID64()] then
-				net.ReceiversProtectionSpam[client:SteamID64()][strName:lower()] = nil
+			if IsValid(client) and net.ReceiversProtectionSpam[sSteamID64] then
+				net.ReceiversProtectionSpam[sSteamID64][strName:lower()] = nil
+
+				if table.Count(net.ReceiversProtectionSpam[sSteamID64]) == 0 then
+					net.ReceiversProtectionSpam[sSteamID64] = nil
+				end
+			elseif net.ReceiversProtectionSpam[sSteamID64] then 
+				net.ReceiversProtectionSpam[sSteamID64] = nil
 			end
 		end)
 	end


### PR DESCRIPTION
**_Hello,_**
After browsing through some addons on steam or online shops/downloads I could see that some developers don't protect their net against spam. 

I'm well aware that the **majority of developers** have protected their nets against spam, which is why I'm proposing to deactivate this protection vis-à-vis a convar (activated as standard). 

The algorithm I've set up only works on the SERVER side, since the CLIENT doesn't need any real protection against spam. 

# Function changed
### net.Incoming
In this function I set up a cooldown to display a message if a lot of nets have been sent in a short time, i.e. 0.5 seconds (Customizable by a convar).

I've created two new tables, net.ReceiversConfigTime (for more information, see net.Receive) and net.ReceiversProtectionSpam, and we're going to take a look at the net.ReceiversProtectionSpam table. In this table we'll have this structure: 
```
[“76561198389123776”]:
                [“testNet”] = 1538.0303955078 (CurTime() + Float Value)
```           

Example (Print) : 
```
Player Vitroze Gaming (STEAM_0:0:214429024) tried to spam the net message testNet too much.
```

We're going to emit a (simple) timer that deletes the table value if the cooldown is exceeded. I'm aware that if the player disconnects, his table will still be there, but **_I don't know if we're allowed to create hooks (PlayerDisconnected) in this file, so I'd rather not do it and let others have their say._**

### net.Receive
In the net.Receive modification I've just added an argument (iTime: which can be a float/int) that just changes the cooldown of the specific net.

The net.ReceiversConfigTime table will be used to modify this value.

# ConVar
`sv_net_time` (Float ; Default : 0.5) : The time in seconds between each net message a player can send.
`sv_net_protect` (Int --> Boolean ; Default : 1 (true)) : Whether or not to protect the net messages from spam.

# Documentation (Wiki)

## net.Receive 
```html 
<arg name="TimeCooldown" type="number">Modify net cooldown. Cooldown uses CurTime()</arg>
```
Preview : 
<arg name="TimeCooldown" type="number">Modify net cooldown. Cooldown uses CurTime()</arg>