### PR TITLE
Make Spawn_ functions return the spawned entity

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/commands.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/commands.lua
@@ -614,6 +614,7 @@ function Spawn_NPC( ply, NPCClassName, WeaponName, tr )
 
 	ply:SendLua( "achievements.SpawnedNPC()" )
 
+	return SpawnedNPC
 end
 concommand.Add( "gmod_spawnnpc", function( ply, cmd, args ) Spawn_NPC( ply, args[ 1 ], args[ 2 ] ) end )
 
@@ -897,6 +898,7 @@ function Spawn_SENT( ply, EntityName, tr )
 	ply:AddCleanup( "sents", entity )
 	entity:SetVar( "Player", ply )
 
+	return entity
 end
 concommand.Add( "gm_spawnsent", function( ply, cmd, args ) Spawn_SENT( ply, args[ 1 ] ) end )
 
@@ -999,6 +1001,7 @@ function Spawn_Weapon( ply, wepname, tr )
 
 	gamemode.Call( "PlayerSpawnedSWEP", ply, entity )
 
+	return entity
 end
 concommand.Add( "gm_spawnswep", function( ply, cmd, args ) Spawn_Weapon( ply, args[1] ) end )
 
@@ -1125,6 +1128,7 @@ function Spawn_Vehicle( ply, vname, tr )
 
 	ply:AddCleanup( "vehicles", Ent )
 
+	return Ent
 end
 concommand.Add( "gm_spawnvehicle", function( ply, cmd, args ) Spawn_Vehicle( ply, args[1] ) end )
 


### PR DESCRIPTION
Functions such as `Spawn_NPC` will now return the entity it spawned. This was originally for the NPC function, but I went ahead and applied it to all of them in case anyone has a use for those. In general, this will allow for better customization when creating a command similar to `gmod_spawnnpc`