### PR TITLE
DProperty_Float SetMin/SetMax passthrough

### DIFF
--- a/garrysmod/lua/vgui/prop_float.lua
+++ b/garrysmod/lua/vgui/prop_float.lua
@@ -58,6 +58,16 @@ function PANEL:Setup( vars )
 		ctrl:SetValue( val )
 	end
 
+	-- Set the min
+	self.SetMin = function( slf, val )
+		ctrl:SetMin( val )
+	end
+
+	-- Set the max
+	self.SetMax = function( slf, val )
+		ctrl:SetMax( val )
+	end
+	
 	-- Alert row that value changed
 	ctrl.OnValueChanged = function( slf, newval )
 


### PR DESCRIPTION
I can't think of a good reason why these weren't added, you've got to do some panel child-hunting to locate it otherwise, thx