### PR TITLE
Implement `panel index accessor` in Lua

### DIFF
--- a/garrysmod/lua/includes/extensions/client/panel.lua
+++ b/garrysmod/lua/includes/extensions/client/panel.lua
@@ -6,6 +6,64 @@ include ( "panel/scriptedpanels.lua" )
 
 local meta = FindMetaTable( "Panel" )
 
+--
+-- Panel index accessor
+--
+local g_PanelsTables = {}
+
+function meta:__index( key )
+
+	--
+	-- Panel-specialized values
+	--
+	if ( key == "Hovered" ) then
+		return meta.GetTable( self ).Hovered
+	elseif ( key == "x" or key == "X" ) then
+
+		local x = meta.GetPos( self )
+		return x
+
+	elseif ( key == "y" or key == "Y" ) then
+
+		local _, y = meta.GetPos( self )
+		return y
+
+	end
+
+	--
+	-- Search the panel table
+	--
+	local pnlTable = g_PanelsTables[self]
+
+	if ( !pnlTable ) then
+
+		pnlTable = meta.GetTable( self )
+
+		if ( !pnlTable ) then
+
+			-- If table isn't yet installed, look in the metatable
+			return meta[key]
+
+		end
+
+		g_PanelsTables[self] = pnlTable
+
+	end
+
+	local value = pnlTable[key]
+
+	-- Look in the table
+	if ( value != nil ) then
+		return value
+	end
+
+	-- Look in the metatable
+	value = meta[key]
+
+	return value
+
+end
+
 AccessorFunc( meta, "m_strCookieName", "CookieName" )
 
 meta.SetFGColorEx = meta.SetFGColor

--- a/garrysmod/lua/includes/extensions/client/panel.lua
+++ b/garrysmod/lua/includes/extensions/client/panel.lua
@@ -16,9 +16,7 @@ function meta:__index( key )
 	--
 	-- Panel-specialized values
 	--
-	if ( key == "Hovered" ) then
-		return meta.GetTable( self ).Hovered
-	elseif ( key == "x" or key == "X" ) then
+	if ( key == "x" or key == "X" ) then
 
 		local x = meta.GetPos( self )
 		return x

--- a/garrysmod/lua/includes/extensions/client/panel.lua
+++ b/garrysmod/lua/includes/extensions/client/panel.lua
@@ -9,40 +9,54 @@ local meta = FindMetaTable( "Panel" )
 --
 -- Panel index accessor
 --
-local __index_internal = meta.__index
+local VGUIGetHoveredPanel = vgui.GetHoveredPanel
+local GetPanelTable = meta.GetTable
+local GetPos = meta.GetPos
 
 local g_PanelsTables = {}
 
 function meta:__index( key )
 
 	--
-	-- Panel-specialized values; fall back on the original index accessor
+	-- Panel-specialized values
 	--
-	if ( key == "Hovered" or key == "x" or key == "y" or key == "X" or key == "Y" ) then
-		return __index_internal( self, key )
+	if ( key == "Hovered" ) then
+		return VGUIGetHoveredPanel() == self or GetPanelTable( self ).Hovered
+	end
+
+	if ( key == "x" or key == "X" ) then
+
+		local x = GetPos( self )
+		return x
+
+	end
+
+	if ( key == "y" or key == "Y" ) then
+
+		local _, y = GetPos( self )
+		return y
+
 	end
 
 	--
 	-- Search the panel table
 	--
-	local pnlTable = g_PanelsTables[self]
+	local pnl_tbl = g_PanelsTables[self]
 
-	if ( !pnlTable ) then
+	if ( !pnl_tbl ) then
 
-		pnlTable = meta.GetTable( self )
+		pnl_tbl = GetPanelTable( self )
 
-		if ( !pnlTable ) then
-
-			-- If table isn't yet installed, look in the metatable
+		-- If table isn't yet installed, looking in the metatable
+		if ( !pnl_tbl ) then
 			return meta[key]
-
 		end
 
-		g_PanelsTables[self] = pnlTable
+		g_PanelsTables[self] = pnl_tbl
 
 	end
 
-	local value = pnlTable[key]
+	local value = pnl_tbl[key]
 
 	-- Look in the table
 	if ( value != nil ) then
@@ -55,6 +69,26 @@ function meta:__index( key )
 	return value
 
 end
+
+--
+-- GC
+--
+local IsPanelValid = meta.IsValid
+
+local function Timer_PanelsTablesGC()
+
+	for pnl in pairs( g_PanelsTables ) do
+
+		if ( !IsPanelValid( pnl ) ) then
+			g_PanelsTables[pnl] = nil
+		end
+
+	end
+
+end
+
+timer.Create( "PanelsTables_GC", 30, 0, Timer_PanelsTablesGC )
+
 
 AccessorFunc( meta, "m_strCookieName", "CookieName" )
 

--- a/garrysmod/lua/includes/extensions/client/panel.lua
+++ b/garrysmod/lua/includes/extensions/client/panel.lua
@@ -9,23 +9,17 @@ local meta = FindMetaTable( "Panel" )
 --
 -- Panel index accessor
 --
+local __index_internal = meta.__index
+
 local g_PanelsTables = {}
 
 function meta:__index( key )
 
 	--
-	-- Panel-specialized values
+	-- Panel-specialized values; fall back on the original index accessor
 	--
-	if ( key == "x" or key == "X" ) then
-
-		local x = meta.GetPos( self )
-		return x
-
-	elseif ( key == "y" or key == "Y" ) then
-
-		local _, y = meta.GetPos( self )
-		return y
-
+	if ( key == "Hovered" or key == "x" or key == "y" or key == "X" or key == "Y" ) then
+		return __index_internal( self, key )
 	end
 
 	--


### PR DESCRIPTION
Analogous to the entity index accessor, this approach will be faster. In the game, panel functions are called and panel values are accessed really frequently and numerously.

# Benchmark
Using [gluafuncbudget](https://gist.github.com/noaccessl/2336bb390aca15bc7ba50d2c9d966daa#file-gluafuncbudget-lua)
CPU: Intel i7-3770
OS: Windows 10
<details> <summary>Code</summary>

```lua
local meta = FindMetaTable( "Panel" )

local PanelIndexAccessor_C = meta.__index

local g_PanelsTables = {}

local function PanelIndexAccessor_Lua( self, key )

	--
	-- Panel-specialized values
	--
	if ( key == "Hovered" ) then
		return meta.GetTable( self ).Hovered
	elseif ( key == "x" or key == "X" ) then

		local x = meta.GetPos( self )
		return x

	elseif ( key == "y" or key == "Y" ) then

		local _, y = meta.GetPos( self )
		return y

	end

	--
	-- Search the panel table
	--
	local pnlTable = g_PanelsTables[self]

	if ( !pnlTable ) then

		pnlTable = meta.GetTable( self )

		if ( !pnlTable ) then

			-- If table isn't yet installed, look in the metatable
			return meta[key]

		end

		g_PanelsTables[self] = pnlTable

	end

	local value = pnlTable[key]

	-- Look in the table
	if ( value != nil ) then
		return value
	end

	-- Look in the metatable
	value = meta[key]

	return value

end


local TestPanel = vgui.Create( "EditablePanel" )
TestPanel.var = "Hello World!"

local JIT_OFF = false

local Tests = {

	{ name = "C; access x, y", func = function()

		PanelIndexAccessor_C( TestPanel, "x" )
		PanelIndexAccessor_C( TestPanel, "y" )

	end; standard = true; jit_off = JIT_OFF };

	{ name = "Lua; access x, y", func = function()

		PanelIndexAccessor_Lua( TestPanel, "x" )
		PanelIndexAccessor_Lua( TestPanel, "y" )

	end; jit_off = JIT_OFF };

	{ name = "C; access metamethod", func = function()

		PanelIndexAccessor_C( TestPanel, "SetSize" )

	end; standard = true; jit_off = JIT_OFF };

	{ name = "Lua; access metamethod", func = function()

		PanelIndexAccessor_Lua( TestPanel, "SetSize" )

	end; jit_off = JIT_OFF };

	{ name = "C; access table value", func = function()

		PanelIndexAccessor_C( TestPanel, "var" )

	end; standard = true; jit_off = JIT_OFF };

	{ name = "Lua; access table value", func = function()

		PanelIndexAccessor_Lua( TestPanel, "var" )

	end; jit_off = JIT_OFF };

}


gluafuncbudget.Configure( {

	frames = 500;
	iterations_per_frame = 5000;

	digit = 4;

	measure_unit = "ms";
	comparison_basis = "average"

} )

for k, v in ipairs( Tests ) do
	gluafuncbudget.Queue( v )
end
```
</details>
<details open> <summary>Results</summary>

### LuaJIT 2.1.0-beta3 (x86-64 Branch)
![image](https://github.com/user-attachments/assets/e8b7da2e-8168-4c88-938b-83fe3569587d)
### LuaJIT 2.0.4
![image](https://github.com/user-attachments/assets/27c4cc5b-119a-4474-aa6c-bf856a7b2048)

</details>