### PR TITLE
Fix an error with taking ammo from NPCs

### DIFF
--- a/garrysmod/gamemodes/base/entities/weapons/weapon_base/shared.lua
+++ b/garrysmod/gamemodes/base/entities/weapons/weapon_base/shared.lua
@@ -162,6 +162,8 @@ function SWEP:TakePrimaryAmmo( num )
 	-- Doesn't use clips
 	if ( self:Clip1() <= 0 ) then
 
+		if ( self:GetOwner():IsNPC() ) then return end
+
 		if ( self:Ammo1() <= 0 ) then return end
 
 		self:GetOwner():RemoveAmmo( num, self:GetPrimaryAmmoType() )
@@ -180,6 +182,8 @@ function SWEP:TakeSecondaryAmmo( num )
 
 	-- Doesn't use clips
 	if ( self:Clip2() <= 0 ) then
+
+		if ( self:GetOwner():IsNPC() ) then return end
 
 		if ( self:Ammo2() <= 0 ) then return end
 


### PR DESCRIPTION
If an NPC is holding a weapon where Clip1 (or 2) <= 0 then TakePrimaryAmmo (or TakeSecondaryAmmo) will cause an error because the Ammo1 and Ammo2 functions call GetAmmoCount which doesn't exist for NPCs.

If GetAmmoCount was added for NPCs it would still error because of the RemoveAmmo call, since that also does not exist for NPCs.

Reproduce:
```lua
local Guy = ents.Create("npc_combine_s")
Guy:Spawn()
Guy:Give("weapon_base")

timer.Simple(1, function()
    Guy:GetActiveWeapon():SetClip1(0)
    Guy:GetActiveWeapon():TakePrimaryAmmo(1) -- Should error here
end)
```

EDIT: Minor spelling mistake