### PR TITLE
[TTT] Fix incosistency for default values

### DIFF
--- a/garrysmod/gamemodes/terrortown/terrortown.txt
+++ b/garrysmod/gamemodes/terrortown/terrortown.txt
@@ -15,7 +15,7 @@
 			"type"		"CheckBox"
 			"default"	"0"
 		}
-		
+
 		2
 		{
 			"name"		"ttt_haste"
@@ -23,7 +23,7 @@
 			"type"		"CheckBox"
 			"default"	"1"
 		}
-		
+
 		5
 		{
 			"name"		"ttt_time_limit_minutes"
@@ -31,7 +31,7 @@
 			"type"		"Numeric"
 			"default"	"75"
 		}
-		
+
 		6
 		{
 			"name"		"ttt_firstpreptime"
@@ -39,7 +39,7 @@
 			"type"		"Numeric"
 			"default"	"60"
 		}
-		
+
 		7
 		{
 			"name"		"ttt_preptime_seconds"
@@ -47,7 +47,7 @@
 			"type"		"Numeric"
 			"default"	"30"
 		}
-		
+
 		8
 		{
 			"name"		"ttt_posttime_seconds"
@@ -55,7 +55,7 @@
 			"type"		"Numeric"
 			"default"	"30"
 		}
-		
+
 		9
 		{
 			"name"		"ttt_round_limit"
@@ -63,7 +63,7 @@
 			"type"		"Numeric"
 			"default"	"6"
 		}
-		
+
 		10
 		{
 			"name"		"ttt_roundtime_minutes"
@@ -71,7 +71,7 @@
 			"type"		"Numeric"
 			"default"	"10"
 		}
-		
+
 		11
 		{
 			"name"		"ttt_haste_starting_minutes"
@@ -79,15 +79,15 @@
 			"type"		"Numeric"
 			"default"	"5"
 		}
-		
+
 		12
 		{
 			"name"		"ttt_haste_minutes_per_death"
 			"text"		"haste_kill_time_bonus"
 			"type"		"Numeric"
-			"default"	".5"
+			"default"	"0.5"
 		}
-		
+
 		13
 		{
 			"name"		"ttt_postround_dm"
@@ -95,7 +95,7 @@
 			"type"		"CheckBox"
 			"default"	"0"
 		}
-		
+
 		14
 		{
 			"name"		"ttt_traitor_max"
@@ -103,7 +103,7 @@
 			"type"		"Numeric"
 			"default"	"32"
 		}
-		
+
 		15
 		{
 			"name"		"ttt_traitor_pct"
@@ -111,7 +111,7 @@
 			"type"		"Numeric"
 			"default"	"0.25"
 		}
-		
+
 		16
 		{
 			"name"		"ttt_credits_starting"
@@ -119,7 +119,7 @@
 			"type"		"Numeric"
 			"default"	"2"
 		}
-		
+
 		17
 		{
 			"name"		"ttt_detective_max"
@@ -127,15 +127,15 @@
 			"type"		"Numeric"
 			"default"	"32"
 		}
-		
+
 		18
 		{
 			"name"		"ttt_detective_pct"
 			"text"		"detective_ratio"
 			"type"		"Numeric"
-			"default"	"0.125"
+			"default"	"0.13"
 		}
-		
+
 		19
 		{
 			"name"		"ttt_det_credits_starting"
@@ -143,7 +143,7 @@
 			"type"		"Numeric"
 			"default"	"1"
 		}
-		
+
 		20
 		{
 			"name"		"ttt_detective_min_players"
@@ -151,7 +151,7 @@
 			"type"		"Numeric"
 			"default"	"8"
 		}
-		
+
 		21
 		{
 			"name"		"ttt_detective_karma_min"
@@ -159,7 +159,7 @@
 			"type"		"Numeric"
 			"default"	"600"
 		}
-		
+
 		22
 		{
 			"name"		"ttt_detective_hats"
@@ -167,7 +167,7 @@
 			"type"		"CheckBox"
 			"default"	"1"
 		}
-		
+
 		23
 		{
 			"name"		"ttt_allow_discomb_jump"
@@ -175,7 +175,7 @@
 			"type"		"CheckBox"
 			"default"	"0"
 		}
-		
+
 		24
 		{
 			"name"		"ttt_no_nade_throw_during_prep"
@@ -183,7 +183,7 @@
 			"type"		"CheckBox"
 			"default"	"1"
 		}
-		
+
 		25
 		{
 			"name"		"ttt_teleport_telefrags"
@@ -191,7 +191,7 @@
 			"type"		"CheckBox"
 			"default"	"1"
 		}
-		
+
 		26
 		{
 			"name"		"ttt_ragdoll_pinning"
@@ -199,7 +199,7 @@
 			"type"		"CheckBox"
 			"default"	"1"
 		}
-		
+
 		27
 		{
 			"name"		"ttt_ragdoll_pinning_innocents"
@@ -207,7 +207,7 @@
 			"type"		"CheckBox"
 			"default"	"0"
 		}
-		
+
 		30
 		{
 			"name"		"ttt_namechange_kick"
@@ -215,7 +215,7 @@
 			"type"		"CheckBox"
 			"default"	"1"
 		}
-		
+
 		31
 		{
 			"name"		"ttt_namechange_bantime"
@@ -223,6 +223,6 @@
 			"type"		"Numeric"
 			"default"	"10"
 		}
-		
+
 	}
 }


### PR DESCRIPTION
Fixes ConVars `ttt_haste_minutes_per_death` and `ttt_detective_pct` in `terrortown.txt` (main menu settings) not following the same values as the GM's Lua files.