### PR TITLE
[TTT] fix players sometimes being revealed as dead when they chat/voicechat right as they die (again)

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_voice.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_voice.lua
@@ -51,7 +51,7 @@ net.Receive("TTT_RoleChat", RoleChatRecv)
 
 function GM:GetTeamColor(ent)
    -- don't reveal that a player has died when they happen to chat or voicechat at the moment of death
-   if not LocalPlayer():IsSpec() and ent:IsPlayer() and ent:IsSpec() and ScoreGroup(ent) == GROUP_NOTFOUND then
+   if LocalPlayer():IsTerror() and ent:IsPlayer() then
       return hook.Run("GetTeamNumColor", TEAM_TERROR)
    end
 


### PR DESCRIPTION
the last pr #2229 seems to make the issue less likely to happen but doesn't fix it entirely for some reason

