### PR TITLE
Add a "strict" duplicator mode

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/commands.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/commands.lua
@@ -619,6 +619,8 @@ function Spawn_NPC( ply, NPCClassName, WeaponName, tr )
 end
 concommand.Add( "gmod_spawnnpc", function( ply, cmd, args ) Spawn_NPC( ply, args[ 1 ], args[ 2 ] ) end )
 
+local strictDuplicator = GetConVar( "duplicator_strict" )
+
 -- This should be in base_npcs.lua really
 local function GenericNPCDuplicator( ply, mdl, class, equipment, spawnflags, data )
 
@@ -656,7 +658,9 @@ local function GenericNPCDuplicator( ply, mdl, class, equipment, spawnflags, dat
 		if ( data.CurHealth ) then ent:SetHealth( data.CurHealth ) end
 		if ( data.MaxHealth ) then ent:SetMaxHealth( data.MaxHealth ) end
 
-		table.Merge( ent:GetTable(), data )
+		if ( not strictDuplicator:GetBool() ) then
+			table.Merge( ent:GetTable(), data )
+		end
 
 	end
 

--- a/garrysmod/lua/includes/modules/duplicator.lua
+++ b/garrysmod/lua/includes/modules/duplicator.lua
@@ -470,6 +470,12 @@ function DoBoneManipulator( ent, Bones )
 
 end
 
+local strictDuplicator = CreateConVar(
+	"duplicator_strict",
+	"0", { FCVAR_ARCHIVE },
+	"Prevents entities from being duped with unauthorized data. Can fix certain exploits at the cost of some entities potentially duping incorrectly"
+)
+
 --[[---------------------------------------------------------
    Generic function for duplicating stuff
 -----------------------------------------------------------]]
@@ -502,7 +508,9 @@ function GenericDuplicatorFunction( Player, data )
 
 	EntityPhysics.Load( data.PhysicsObjects, Entity )
 
-	table.Merge( Entity:GetTable(), data )
+	if ( !strictDuplicator:GetBool() ) then
+		table.Merge( Entity:GetTable(), data )
+	end
 
 	return Entity
 


### PR DESCRIPTION
This pull request adds a `duplicator_strict` (0 by default) convar that makes it so the generic duplicator function doesn't merge the entity table

Merging the entire entity table allows clients to add any arbitrary key/value pairs to any entity that doesn't have a proper factory function. This can lead to a variety of exploits, such as:
* Spawning weapons with edited stats
* Breaking limit management mods (for example WUMA)
* Breaking any other addon that stores things in entity tables

Things that break with "strict" mode enabled in my testing:
* *None?* It ran 100% bug free on my server with wiremod, starfall, glide, etc for 2 weeks. I guess it *can* break some old addons that rely on this behavior, but those can be fixed by defining a proper factory function for them. And again, it's an opt-in feature

Further improvements:
* Better name/description for the convar
* It still copies the entire entity table when copying an entity, so clients can still see everything that was defined on the server-side when copying the entity, which might be exploitable