### PR TITLE
Add table.RemoveIf

### DIFF
--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -778,6 +778,25 @@ function table.Flip( tab )
 
 end
 
+function table.RemoveIf( t, funcname )
+
+	local j, n = 1, #t;
+
+	for i = 1, n do
+		if funcname( i, t[ i ] ) then
+			t[ i ] = nil
+		else
+			if ( i != j ) then
+				t[ j ] = t[ i ];
+				t[ i ] = nil;
+			end
+
+			j = j + 1;
+		end
+	end
+
+end
+
 -- Polyfill for table.move on 32-bit
 -- Don't forget to remove this when it's no longer necessary
 if ( !table.move ) then


### PR DESCRIPTION
Inspired by the C++ standard library function "remove_if." An altered version of the function provided here: https://stackoverflow.com/a/53038524

The only area that could possibly raise concern is 
`if funcname( i, t[ i ] ) then`

By indexing, we are decreasing performance. However, to perform a removal on the basis of a key in a sequential table is highly **irregular**. In most circumstances the user will perform a operation based on the value.