### PR TITLE
Mipmaps for png icons in spawnmenu

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenticon.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenticon.lua
@@ -69,7 +69,7 @@ function PANEL:SetMaterial( name )
 
 	self.m_MaterialName = name
 
-	local mat = Material( name )
+	local mat = Material( name, "mips" )
 
 	-- Look for the old style material
 	if ( !mat || mat:IsError() ) then
@@ -129,13 +129,13 @@ function PANEL:Paint( w, h )
 		end
 	end
 
-	render.PushFilterMag( TEXFILTER.ANISOTROPIC )
-	render.PushFilterMin( TEXFILTER.ANISOTROPIC )
+	-- render.PushFilterMag( TEXFILTER.ANISOTROPIC )
+	-- render.PushFilterMin( TEXFILTER.ANISOTROPIC )
 
 	self.Image:PaintAt( 3 + self.Border, 3 + self.Border, 128 - 8 - self.Border * 2, 128 - 8 - self.Border * 2 )
 
-	render.PopFilterMin()
-	render.PopFilterMag()
+	-- render.PopFilterMin()
+	-- render.PopFilterMag()
 
 	surface.SetDrawColor( 255, 255, 255, 255 )
 


### PR DESCRIPTION
Lots of custom weapons on workshop are using 256-512px icons for spawnmenu, but it creates materials for them without using any png parameters, which makes them very aliased.

I've compared all possible combinations of params and filtering options and found out "mips" without extra filtering produces best result. 
"mips smooth" makes icons very blurry, "smooth" keeps aliasing and filtering blurs out icons even more.

![ezgif com-animated-gif-maker](https://github.com/user-attachments/assets/74c7b307-51f2-49e2-ac6e-0f6336a53c91)

Here's link to comparison between all combinations, taken on 1920x1080 screen - https://imgsli.com/MzY5MzE1/1/3

There's no visible changes to regular 128px icons like ones that included in the game.
