### PR TITLE
Player Auth - Hook PlayerUserGroupChanged

### DIFF
--- a/garrysmod/lua/includes/extensions/player_auth.lua
+++ b/garrysmod/lua/includes/extensions/player_auth.lua
@@ -60,8 +60,11 @@ if ( not SERVER ) then return end
 -----------------------------------------------------------]]
 function meta:SetUserGroup( name )
 
+	local sOldUserGroup = self:GetUserGroup()
+
 	self:SetNWString( "UserGroup", name )
 
+	hook.Run( "PlayerUserGroupChanged", self, sOldUserGroup, name )
 end
 
 


### PR DESCRIPTION
**_Hello,_**
I noticed in the GMod wiki that there is no native hook to detect whether a player has changed rank or not. This is annoying, as most administration systems or gamemodes use their own hooks. I therefore propose the addition of a native hook common to all, to simplify compatibility between different systems.

# Hook added
### PlayerUserGroupChanged
Description : Executed when a player changes rank.
Args : pPlayer (PLAYER) ; sOldUserGroup (String) ; sNewUserGroup (String)

Example : 
```lua
hook.Add("PlayerUserGroupChanged", "PlayerUserGroupChanged", function(pPlayer, sOldUser, sNewUser)
    print(pPlayer, "has changed from", sOldUser, "to", sNewUser)
end)
```

Preview : 
![image](https://github.com/user-attachments/assets/8605e39c-dd80-4710-88c1-e4ab795e9a30)
