### PR TITLE
Make team.NumPlayers mildly less slow

### DIFF
--- a/garrysmod/lua/includes/modules/team.lua
+++ b/garrysmod/lua/includes/modules/team.lua
@@ -132,7 +132,15 @@ end
 
 function NumPlayers( index )
 
-	return #GetPlayers( index )
+	local players = 0
+
+	for _, ply in player.Iterator() do
+		if ( ply:Team() == index ) then
+			players = players + 1
+		end
+	end
+
+	return players
 
 end
 


### PR DESCRIPTION
There's no need to create a new table to get a teams player count, so instead do it as `team.TotalDeaths` and `team.TotalFrags` do with a loop.