### PR TITLE
Add vector/angle 'reset' key to DAdjustableModelPanel

### DIFF
--- a/garrysmod/lua/vgui/dadjustablemodelpanel.lua
+++ b/garrysmod/lua/vgui/dadjustablemodelpanel.lua
@@ -99,6 +99,20 @@ function PANEL:FirstPersonControls()
 
 	local x, y = self:CaptureMouse()
 
+	if ( IsKeyBindDown( "+reload" ) or input.IsKeyDown( KEY_R ) ) then
+		self.vCamPos = Vector( 50, 50, 50 )
+		self.vLookatPos = Vector( 0, 0, 40 )
+
+		self.aLookAngle = ( self.vLookatPos - self.vCamPos ):Angle()
+
+		self.fFOV = 70
+
+		self.OrbitPoint = self.vLookatPos
+		self.OrbitDistance = ( self.OrbitPoint - self.vCamPos ):Length()
+
+		return
+	end
+
 	local scale = self:GetFOV() / 180
 	x = x * -0.5 * scale
 	y = y * 0.5 * scale


### PR DESCRIPTION
Pretty self explanatory. I kept moving around too quickly and losing where my models where, so this adds ability to use +reload / KEY_R to reset the panel to its base values

default values from DModelPanel init: https://github.com/Facepunch/garrysmod/blob/master/garrysmod/lua/vgui/dmodelpanel.lua#L21

if anyone wants to chip in this could probably do with a way to set 'default' vector/angles and it use those instead, but wasnt sure of the best way to go about it tbh.