### PR TITLE
feat(devtools): add find_globals console command to search global table

### DIFF
--- a/garrysmod/lua/autorun/developer_functions.lua
+++ b/garrysmod/lua/autorun/developer_functions.lua
@@ -146,3 +146,21 @@ concommand.Add( "trace", function( ply )
 end )
 
 end
+
+--[[---------------------------------------------------------
+	Command: find_globals
+	Searches _G for global variables containing the given string.
+-----------------------------------------------------------]]
+concommand.Add("find_globals", function(ply, cmd, args)
+	if not args[1] then
+		MsgN("Usage: find_globals <search_term>")
+		return
+	end
+
+	local term = args[1]:lower()
+	for k, v in pairs(_G) do
+		if isstring(k) and k:lower():find(term, 1, true) then
+			MsgN("Global: ", k, " = ", tostring(v), " (", type(v), ")")
+		end
+	end
+end)

--- a/garrysmod/lua/autorun/developer_functions.lua
+++ b/garrysmod/lua/autorun/developer_functions.lua
@@ -1,4 +1,5 @@
 
+-- Recursively searches through a Lua table and logs keys that match a search term.
 local function FindInTable( tab, find, parents, depth )
 
 	depth = depth or 0


### PR DESCRIPTION
This pull request adds a new developer-facing console command: `find_globals`.

### New Command
```
find_globals <search_term>
```

This command searches through the global `_G` table and prints out any variables or functions whose key contains the specified term. It is useful for:

- Quickly inspecting runtime globals
- Debugging unexpected behavior
- Exploring available variables in complex environments

### Example Usage
```
find_globals hook
```
Might return:
```
Global: hook = table: 0x00abc123 (table)
Global: hooksecurefunc = function: 0x001def45 (function)
```

### Additional Changes
- Added a documentation comment above `FindInTable` to improve code clarity.

This is a non-breaking, developer-focused change aimed at improving usability and debugging tools.