### PR TITLE
Add `player.GetByNick`

### DIFF
--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -262,6 +262,17 @@ function meta:HasGodMode()
 end
 
 -- These are totally in the wrong place.
+function player.GetByNick( ID )
+	local players = player.GetAll()
+	for i = 1, #players do
+		if ( players[i]:Nick() == ID ) then
+			return players[i]
+		end
+	end
+
+	return false
+end
+
 function player.GetByAccountID( ID )
 	local players = player.GetAll()
 	for i = 1, #players do


### PR DESCRIPTION
It will be a convenient addition for different admin mods so that, for example, when entering commands, you don’t have to write your own detection logic by nick