### PR TITLE
Fix lua error

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/creator.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/creator.lua
@@ -29,7 +29,7 @@ function TOOL:LeftClick( trace, attach )
 			weapon = gmod_npcweapon
 		else
 			local NPCinfo = list.Get( "NPC" )[ name ]
-			weapon = table.Random( NPCinfo.Weapons or {} ) or ""
+			weapon = table.Random( NPCinfo and NPCinfo.Weapons or {} ) or ""
 		end
 
 		Spawn_NPC( self:GetOwner(), name, weapon, trace )


### PR DESCRIPTION
Fixes:
```
- attempt to index local 'NPCinfo' (a nil value)
1. LeftClick - gamemodes/sandbox/entities/weapons/gmod_tool/stools/creator.lua:32
 2. <unknown> - gamemodes/sandbox/entities/weapons/gmod_tool/shared.lua:235
```