### PR TITLE
Remove default return in WorldPickerMouseDisable

### DIFF
--- a/garrysmod/lua/includes/extensions/util/worldpicker.lua
+++ b/garrysmod/lua/includes/extensions/util/worldpicker.lua
@@ -39,7 +39,7 @@ util.worldpicker = {
 
 hook.Add( "VGUIMousePressAllowed", "WorldPickerMouseDisable", function( code )
 
-	if ( !bDoing ) then return false end
+	if ( !bDoing ) then return end
 
 	local dir = gui.ScreenToVector( input.GetCursorPos() )
 	local tr = util.TraceLine( {


### PR DESCRIPTION
This hook always returning something can prevent other VGUIMousePressAllowed hooks from running, such as a base GAMEMODE hook