### PR TITLE
Improve __index performance

### DIFF
--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -25,6 +25,18 @@ function meta:SetShouldPlayPickupSound( bPlaySound )
 end
 
 --
+-- Cache entity.GetTable for even faster access
+--
+local EntityTable = setmetatable( {}, {
+	__index = function( tab, ent )
+		local var = meta.GetTable( ent )
+		tab[ ent ] = var
+		return var
+	end,
+	__mode = "k"
+} )
+
+--
 -- Entity index accessor. This used to be done in engine, but it's done in Lua now because it's faster
 --
 function meta:__index( key )
@@ -32,16 +44,15 @@ function meta:__index( key )
 	--
 	-- Search the metatable. We can do this without dipping into C, so we do it first.
 	--
-	local val = meta[ key ]
-	if ( val != nil ) then return val end
+	if ( meta[ key ] ~= nil ) then
+		return meta[ key ]
+	end
 
 	--
 	-- Search the entity table
 	--
-	local tab = meta.GetTable( self )
-	if ( tab ) then
-		local tabval = tab[ key ]
-		if ( tabval != nil ) then return tabval end
+	if ( EntityTable[ self ][ key ] ~= nil ) then
+		return EntityTable[ self ][ key ]
 	end
 
 	--

--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -6,6 +6,18 @@ local entity = FindMetaTable( "Entity" )
 if ( !meta ) then return end
 
 --
+-- Cache entity.GetTable for even faster access
+--
+local PlayerTable = setmetatable( {}, {
+	__index = function( tab, ply )
+		local var = entity.GetTable( ply )
+		tab[ ply ] = var
+		return var
+	end,
+	__mode = "k"
+} )
+
+--
 -- Entity index accessor. This used to be done in engine, but it's done in Lua now because it's faster
 --
 function meta:__index( key )
@@ -13,24 +25,21 @@ function meta:__index( key )
 	--
 	-- Search the metatable. We can do this without dipping into C, so we do it first.
 	--
-	local val = meta[key]
-	if ( val ~= nil ) then return val end
+	if ( meta[ key ] ~= nil ) then
+		return meta[ key ]
+	end
 
 	--
 	-- Search the entity metatable
 	--
-	local entval = entity[key]
-	if ( entval ~= nil ) then return entval end
+	if ( entity[ key ] ~= nil ) then
+		return entity[ key ]
+	end
 
 	--
 	-- Search the entity table
 	--
-	local tab = entity.GetTable( self )
-	if ( tab ) then
-		return tab[ key ]
-	end
-
-	return nil
+	return PlayerTable[ self ][ key ]
 
 end
 

--- a/garrysmod/lua/includes/extensions/weapon.lua
+++ b/garrysmod/lua/includes/extensions/weapon.lua
@@ -8,6 +8,18 @@ local entity	= FindMetaTable( "Entity" )
 if ( !meta ) then return end
 
 --
+-- Cache entity.GetTable for even faster access
+--
+local WeaponTable = setmetatable( {}, {
+	__index = function( tab, wep )
+		local var = entity.GetTable( wep )
+		tab[ wep ] = var
+		return var
+	end,
+	__mode = "k"
+} )
+
+--
 -- Entity index accessor. This used to be done in engine, but it's done in Lua now because it's faster
 --
 function meta:__index( key )
@@ -15,22 +27,22 @@ function meta:__index( key )
 	--
 	-- Search the metatable. We can do this without dipping into C, so we do it first.
 	--
-	local val = meta[key]
-	if ( val != nil ) then return val end
+	if ( meta[ key ] ~= nil ) then
+		return meta[ key ]
+	end
 
 	--
 	-- Search the entity metatable
 	--
-	local val = entity[key]
-	if ( val != nil ) then return val end
+	if ( entity[ key ] ~= nil ) then
+		return entity[ key ]
+	end
 
 	--
 	-- Search the entity table
 	--
-	local tab = entity.GetTable( self )
-	if ( tab != nil ) then
-		local val = tab[ key ]
-		if ( val != nil ) then return val end
+	if ( WeaponTable[ self ][ key ] ~= nil ) then
+		return WeaponTable[ self ][ key ]
 	end
 
 	--


### PR DESCRIPTION
Due to me not being a legendary Git user I accidentally closed the old pull request. https://github.com/Facepunch/garrysmod/pull/2272

Entity.__index
Player.__index
Weapon.__index

Cached the entity.GetTable result to make it about 50% quicker.
Now keeping the if statements, there does not seem to be a performance penalty for it.
I don't think there will be any issues with this change now.