### PR TITLE
Util - SteamID Valid

### DIFF
--- a/garrysmod/lua/includes/extensions/util.lua
+++ b/garrysmod/lua/includes/extensions/util.lua
@@ -416,3 +416,59 @@ function util.IsBinaryModuleInstalled( name )
 
 	return false
 end
+
+--[[---------------------------------------------------------
+	Name: IsSteamID( sSteamID )
+	Desc: Returns true if the argument is a valid SteamID
+-----------------------------------------------------------]]
+
+function util.IsSteamID( sSteamID )
+
+	if not isstring( sSteamID ) or sSteamID == "" then return false end
+
+	if sSteamID:len() ~= 19 and sSteamID != "BOT" then return false end 
+
+	return sSteamID:match( "STEAM_%d:%d:%d+" ) ~= nil or sSteamID == "BOT"
+end
+
+--[[---------------------------------------------------------
+	Name: IsSteamID64( sSteamID64 )
+	Desc: Returns true if the argument is a valid SteamID64
+-----------------------------------------------------------]]
+
+function util.IsSteamID64( sSteamID64 )
+
+	if not isstring( sSteamID64 ) or sSteamID64 == "" then return false end
+
+	if sSteamID64:len() ~= 17 then return false end
+
+	return sSteamID64:match( "7656119%d+" ) ~= nil or sSteamID64:match( "9007199%d+" ) ~= nil
+end
+
+--[[---------------------------------------------------------
+	Name: SteamIDToAccountID( sSteamID )
+	Desc: Converts a SteamID to an AccountID
+-----------------------------------------------------------]]
+
+function util.SteamIDToAccountID( sSteamID )
+
+	if not util.IsSteamID( sSteamID ) then return 0 end
+	if sSteamID == "BOT" then return 0 end
+
+	local iSteamID = tonumber( sSteamID:sub( 11 ) )
+
+	return iSteamID * 2 + tonumber( sSteamID:sub( 9, 9 ) )
+end
+
+--[[---------------------------------------------------------
+	Name: SteamID64ToAccountID( sSteamID64 )
+	Desc: Converts a SteamID64 to an AccountID
+-----------------------------------------------------------]]
+
+function util.SteamID64ToAccountID( sSteamID64 )
+
+	if not util.IsSteamID64( sSteamID64 ) then return 0 end
+	if sSteamID64:find("9007199") != nil then return 0 end
+
+	return util.SteamIDToAccountID( util.SteamIDFrom64( sSteamID64 ) )
+end


### PR DESCRIPTION
**_Hello,_**
I've seen that these functions don't exist on gmod and this could be useful in certain cases, like converting SteamID64 if you have a steamid32, or directly retrieving account ID without having to have the player connected.

**I decided to recreate the pull request in order to clean up the useless commits that had previously been deleted. Old Pull Request : https://github.com/Facepunch/garrysmod/pull/2246** 

# Function added
### util.IsSteamID
Description : Checks whether the steamid entered is in the correct format. It sets **true for bot**
Args : sSteamID (String) 
Return : boolean

Info : Concerning this function, I have a doubt about the number of characters that the SteamID32 can contain (19 Char), if someone can correct me I'm a taker ;) 

### util.IsSteamID64
Description : Checks whether the steamid64 entered is in the correct format. It sets **true for bot**
Args : sSteamID64 (String) 
Return : boolean

### util.SteamIDToAccountID
Description : Converts SteamID32 to AccountID. **Returns 0 if it's a bot**
Args : sSteamID (String) 
Return : Int 

### util.SteamID64ToAccountID
Description : Converts SteamID64 to AccountID. **Returns 0 if it's a bot**
Args : sSteamID64 (String) 
Return : Int 

**All these functions are on the Shared side (i.e. Client and Server).**
Thanks to those who take the time to read and to those who improve the code.

You can see commits on the net.lua file this is an error I changed branch with a modified net.lua file, normally everything is back to normal 