### PR TITLE
Add COLOR:Copy() method

### DIFF
--- a/garrysmod/lua/includes/util/color.lua
+++ b/garrysmod/lua/includes/util/color.lua
@@ -182,7 +182,12 @@ end
 
 function COLOR:Copy()
 
-	return Color(self:Unpack())
+    return setmetatable({
+        r = self.r,
+        g = self.g,
+        b = self.b,
+        a = self.a
+    }, COLOR)
 
 end
 

--- a/garrysmod/lua/includes/util/color.lua
+++ b/garrysmod/lua/includes/util/color.lua
@@ -180,6 +180,12 @@ function COLOR:Unpack()
 
 end
 
+function COLOR:Copy()
+
+	return Color(self:Unpack())
+
+end
+
 function COLOR:Lerp( target_clr, frac )
 
 	return Color(


### PR DESCRIPTION
Adds a way to copy a color object over to a new object, useful when you want to keep the original color and you're working with functions that change the original like for example `color:AddHue()`

Thanks to https://github.com/TankNut for suggesting directly setting the metatable instead of using self:Unpack.