### PR TITLE
Add string.Capitalize function

### DIFF
--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -449,3 +449,14 @@ function string.NiceName( name )
 	return ret
 
 end
+
+
+function string.Capitalize(str, allWords)
+
+	if allWords then
+		return string.gsub(str, "(%S+)", string.Capitalize)
+	else
+		return string.upper(string.sub(str, 1, 1)) .. string.sub(str, 2)
+	end
+
+end


### PR DESCRIPTION
Adds `string.Capitalize` function that capitalizes the first letter of a word and also the first letter of all words within a sentence if the second argument is declared.

![image](https://github.com/user-attachments/assets/146e72f2-87e4-4984-b3d7-e561b85619ad)


Credits to @Zaurzo who [help me with this function](https://discord.com/channels/565105920414318602/567617926991970306/1375161134180728932)