### PR TITLE
Add `PreRegisterPANEL` hook

### DIFF
--- a/garrysmod/lua/includes/extensions/client/panel/scriptedpanels.lua
+++ b/garrysmod/lua/includes/extensions/client/panel/scriptedpanels.lua
@@ -76,6 +76,11 @@ function vgui.Register( classname, mtable, base )
 	-- Remove the global
 	PANEL = nil
 
+	-- Check if something wants to modify or prevent it
+	if ( hook.Run( "PreRegisterPANEL", classname, mtable, base ) == false ) then
+		return
+	end
+
 	-- Default base is Panel
 	mtable.Base = base or "Panel"
 	mtable.Init = mtable.Init or function() end


### PR DESCRIPTION
Does the same thing as all other `PreRegister*` hooks, allowing addons to override panel functions without replacing the entire file/putting it into less-than-suitable hooks.