### PR TITLE
Server rank calculation tweaks

### DIFF
--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -399,7 +399,7 @@ function CalculateRank( server )
 	// Penalise Ranking
 	if ( server.players == 0 ) recommended += 75; // Server is empty
 	if ( server.flag == "" || server.flag == "unknown" ) recommended += 150; // No location
-	if ( server.pass || server.version_c != 0 ) recommended += 300; // Password protected or outdated, can't join it
+	if ( server.pass || server.version_c < 0 ) recommended += 300; // Password protected or outdated, can't join it
 	if ( server.isAnon ) recommended += 1000; // Anonymous server
 	
 	// Promote Ranking


### PR DESCRIPTION
Updated the server rank calculation with the following changes. Note that a lower 'score' places the server higher on the list as the list is sorted ascending.

- Ping is now grouped by ranges of 20 for calculating ping impact on 'score'. ie pings 0-19 are treated as 0, pings 20-39 are treated as 20, pings 40-59 are treated as 40, etc. This means servers within those groups have no ping advantage from others within the same group. 
- Servers without a flag are given a higher score. This is to encourage servers to set their sv_location or put it in the server name for automated extraction (eg "[US]"). Either method results in a flag and is therefore not given a higher score.
- Outdated servers are given a higher score. This is based on their networking version, so it only impacts servers that your game can't join. It doesn't impact servers that haven't applied an optional update and it doesn't impact the regular dev/x86-64 updates.
- Favourite servers are given a lower score.


Note: as per Facepunch statement of "_I don't think server owners should be making decisions on the server listings. Their opinions are not unbiased_" - I am confirming that I do not own or run any servers and have not done for many years, and I am not connected to any server providers. Any opinions expressed on server listings are as a player, where players want to see servers that are most likely to provide a good experience, not servers that have gamed the system.