### PR TITLE
Add mainmenu_reload_html for development

### DIFF
--- a/garrysmod/lua/menu/mainmenu.lua
+++ b/garrysmod/lua/menu/mainmenu.lua
@@ -656,7 +656,7 @@ end )
 --
 
 local function reloadMenu()
-	if IsValid(pnlMainMenu) then
+	if IsValid( pnlMainMenu ) then
 		pnlMainMenu:Remove()
 	end
 
@@ -677,4 +677,4 @@ local function reloadMenu()
 	end )
 end
 timer.Simple( 0, reloadMenu )
-concommand.Add("mainmenu_reload_html", reloadMenu)
+concommand.Add( "mainmenu_reload_html", reloadMenu )


### PR DESCRIPTION
Adds ``mainmenu_reload_html`` for menu development. This PR pretty much wraps what Garry's Mod already does for loading the menu into a concommand.

Would resolve https://github.com/Facepunch/garrysmod-requests/issues/2765