### PR TITLE
Return from keypad.OnUp() and keypad.OnDown() if key is none

### DIFF
--- a/garrysmod/lua/includes/modules/numpad.lua
+++ b/garrysmod/lua/includes/modules/numpad.lua
@@ -18,6 +18,7 @@ local math			= math
 local IsValid		= IsValid
 local type			= type
 local ErrorNoHaltWithStack = ErrorNoHaltWithStack
+local KEY_NONE		= KEY_NONE
 
 module( "numpad" )
 
@@ -174,7 +175,6 @@ end
 function OnDown( ply, key, name, ... )
 
 	if ( !key || key ~= key ) then ErrorNoHaltWithStack( "bad argument #2 to 'numpad.OnDown' (number expected, got ", type( key ), ")" ) return end
-
 	if ( key == KEY_NONE ) then return end
 
 	keys_in[ key ] = keys_in[ key ] or {}
@@ -195,9 +195,8 @@ end
 function OnUp( ply, key, name, ... )
 
 	if ( !key || key ~= key ) then ErrorNoHaltWithStack( "bad argument #2 to 'numpad.OnUp' (number expected, got ", type( key ), ")" ) return end
-
 	if ( key == KEY_NONE ) then return end
-	
+
 	keys_out[ key ] = keys_out[ key ] or {}
 
 	local impulse = {}


### PR DESCRIPTION
This commit makes it so if `numpad.OnUp/Down()` gets called with `KEY_NONE` (i.e. the kind is unbound) it doesn't do anything.

This fixes the issue with `gmod_button` and such without binds activating every entity without binds. This can become a problem with stuff like keypads: if it's 'Access Denied' key is not bound (because it's not needed) and there's for example a fading door with its 'Fade' key not bound (because it's controlled by wire or something), it can cause it to unexpectedly open.

I believe this is unintended behavior. It doesn't make sense for something to wait for `NONE` key to pressed. If something is not bounded to any key, a player expects it to never trigger. Similarly, if a button is not set to simulate any key, a played expects it to never trigger anything.

This commit shouldn't break anything because
a) These functions can already return 'nil' if key is not a number
b) The returned number is only used in `numpad.Remove()`, which can handle 'nil' just fine