### PR TITLE
Allow players spawn duped weapons in multiplayer

### DIFF
--- a/garrysmod/lua/includes/modules/duplicator.lua
+++ b/garrysmod/lua/includes/modules/duplicator.lua
@@ -485,7 +485,7 @@ function GenericDuplicatorFunction( Player, data )
 	--
 	if ( IsValid( Player ) and !Player:IsAdmin() ) then
 
-		local weapon = list.GetForEdit("Weapon")
+		local weapon = list.GetForEdit( "Weapon" )
 
 		if ( weapon[ data.Class ] ) then
 			if ( !weapon.Spawnable ) then return end

--- a/garrysmod/lua/includes/modules/duplicator.lua
+++ b/garrysmod/lua/includes/modules/duplicator.lua
@@ -485,8 +485,15 @@ function GenericDuplicatorFunction( Player, data )
 	--
 	if ( IsValid( Player ) and !Player:IsAdmin() ) then
 
-		if ( !scripted_ents.GetMember( data.Class, "Spawnable" ) ) then return end
-		if ( scripted_ents.GetMember( data.Class, "AdminOnly" ) ) then return end
+		local weapon = list.GetForEdit("Weapon")
+
+		if ( weapon[ data.Class ] ) then
+			if ( !weapon.Spawnable ) then return end
+			if ( weapon.AdminOnly ) then return end
+		else
+			if ( !scripted_ents.GetMember( data.Class, "Spawnable" ) ) then return end
+			if ( scripted_ents.GetMember( data.Class, "AdminOnly" ) ) then return end
+		end
 
 	end
 


### PR DESCRIPTION
Weapons are not in the list of script entities, so they require separate logic. This PR will allow players in multiplayer to easily spawn weapon dupes