### PR TITLE
Update dmenubar.lua

### DIFF
--- a/garrysmod/lua/vgui/dmenubar.lua
+++ b/garrysmod/lua/vgui/dmenubar.lua
@@ -29,8 +29,8 @@ end
 function PANEL:AddOrGetMenu( label )
 
 	if ( self.Menus[ label ] ) then return self.Menus[ label ] end
-	return self:AddMenu( label )
-
+	local menu, btn = self:AddMenu( label )
+	return menu, btn
 end
 
 function PANEL:AddMenu( label )
@@ -67,7 +67,7 @@ function PANEL:AddMenu( label )
 		b:DoClick()
 	end
 
-	return m
+	return m, b
 
 end
 


### PR DESCRIPTION
allows the :AddMenu() and :AddOrGetMenu() functions to also return the DButton they create on the menubar as well as the actual DMenu like normal. 

Shouldn't break anything since the menu is still returned first and old code just wont utilize the additional button return.