### PR TITLE
Remove useless tostring convertation in `player.GetBySteamID64`

### DIFF
--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -297,7 +297,6 @@ function player.GetBySteamID( ID )
 end
 
 function player.GetBySteamID64( ID )
-	ID = tostring( ID )
 	local players = player.GetAll()
 	for i = 1, #players do
 		if ( players[i]:SteamID64() == ID ) then


### PR DESCRIPTION
Due to the loss of precision, we anyway won't be able to convert a number to a string
```lua
> print(tostring(90071996842377216) == "90071996842377216")...
false
```