### PR TITLE
Move player.GetAll to lua

### DIFF
--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -307,12 +307,13 @@ function player.GetBySteamID64( ID )
 	return false
 end
 
+local player_GetAll = player.GetAll
 local inext = ipairs( {} )
 local PlayerCache = nil
 
 function player.Iterator()
 
-	if ( PlayerCache == nil ) then PlayerCache = player.GetAll() end
+	if ( PlayerCache == nil ) then PlayerCache = player_GetAll() end
 
 	return inext, PlayerCache, 0
 
@@ -326,3 +327,13 @@ end
 
 hook.Add( "OnEntityCreated", "player.Iterator", InvalidatePlayerCache )
 hook.Add( "EntityRemoved", "player.Iterator", InvalidatePlayerCache )
+
+function player.GetAll()
+	local players = {}
+
+	for _, pl in player.Iterator() do
+		table.insert( players, pl )
+	end
+
+	return players
+end

--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -331,8 +331,8 @@ hook.Add( "EntityRemoved", "player.Iterator", InvalidatePlayerCache )
 function player.GetAll()
 	local players = {}
 
-	for _, pl in player.Iterator() do
-		table.insert( players, pl )
+	for i, pl in player.Iterator() do
+		players[i] = pl
 	end
 
 	return players


### PR DESCRIPTION
It's significantly faster to create the table in lua than it is to push it from C.

### Benhmarks:

With 1 player:
```
old
0.13022569999885
new
0.0056074999993143
```
With 128 players:
```
old
1.1069849000014
new
0.29961660000117
```

``` lua
function player.GetAll2()
	local players = {}

	for _, pl in player.Iterator() do
		table.insert(players, pl)
	end

	return players
end

print 'old'
local s = SysTime()

for i = 1, 100000 do
	player.GetAll()
end

print(SysTime() - s)

print 'new'
s = SysTime()
for i = 1, 100000 do
	player.GetAll2()
end

print(SysTime() - s)
```