### PR TITLE
Improved player search system

### DIFF
--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -261,15 +261,33 @@ function meta:HasGodMode()
 
 end
 
+local tPlayersSteamID64 = {}
+local tPlayersSteamID32 = {}
+local tPlayersAccountID = {}
+
+local function insertPlayer( eEnt ) 
+    if not eEnt:IsPlayer() then return end
+
+    tPlayersSteamID64[eEnt:SteamID64()] = eEnt
+    tPlayersSteamID32[eEnt:SteamID()] = eEnt
+    tPlayersAccountID[eEnt:AccountID()] = eEnt
+    
+end
+
+local function removePlayer( eEnt )
+    if not eEnt:IsPlayer() then return end
+
+    tPlayersSteamID64[eEnt:SteamID64()] = nil
+    tPlayersSteamID32[eEnt:SteamID()] = nil
+    tPlayersAccountID[eEnt:AccountID()] = nil
+end
+
+hook.Add("OnEntityCreated", "player.Search", insertPlayer)
+hook.Add("EntityRemoved", "player.Search", removePlayer)
+
 -- These are totally in the wrong place.
 function player.GetByAccountID( ID )
-	for _, pl in player.Iterator() do
-		if ( pl:AccountID() == ID ) then
-			return pl
-		end
-	end
-
-	return false
+	return tPlayersAccountID[ID] or false
 end
 
 function player.GetByUniqueID( ID )
@@ -283,23 +301,9 @@ function player.GetByUniqueID( ID )
 end
 
 function player.GetBySteamID( ID )
-	ID = string.upper( ID )
-
-	for _, pl in player.Iterator() do
-		if ( pl:SteamID() == ID ) then
-			return pl
-		end
-	end
-
-	return false
+	return tPlayersSteamID32[ID] or false
 end
 
 function player.GetBySteamID64( ID )
-	for _, pl in player.Iterator() do
-		if ( pl:SteamID64() == ID ) then
-			return pl
-		end
-	end
-
-	return false
+	return tPlayersSteamID64[ID] or false
 end

--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -264,22 +264,25 @@ end
 local tPlayersSteamID64 = {}
 local tPlayersSteamID32 = {}
 local tPlayersAccountID = {}
+local tPlayersUserID = {}
 
-local function insertPlayer( eEnt ) 
-    if not eEnt:IsPlayer() then return end
+local function insertPlayer( ent )
+    if not ent:IsPlayer() then return end
 
-    tPlayersSteamID64[eEnt:SteamID64()] = eEnt
-    tPlayersSteamID32[eEnt:SteamID()] = eEnt
-    tPlayersAccountID[eEnt:AccountID()] = eEnt
-    
+    tPlayersSteamID64[ent:SteamID64()] = ent
+    tPlayersSteamID32[ent:SteamID()] = ent
+    tPlayersAccountID[ent:AccountID()] = ent
+	tPlayersUserID[ent:UserID()] = ent
+
 end
 
-local function removePlayer( eEnt )
-    if not eEnt:IsPlayer() then return end
+local function removePlayer( ent )
+    if not ent:IsPlayer() then return end
 
-    tPlayersSteamID64[eEnt:SteamID64()] = nil
-    tPlayersSteamID32[eEnt:SteamID()] = nil
-    tPlayersAccountID[eEnt:AccountID()] = nil
+    tPlayersSteamID64[ent:SteamID64()] = nil
+    tPlayersSteamID32[ent:SteamID()] = nil
+    tPlayersAccountID[ent:AccountID()] = nil
+	tPlayersUserID[ent:UserID()] = nil
 end
 
 hook.Add("OnEntityCreated", "player.Search", insertPlayer)
@@ -291,13 +294,7 @@ function player.GetByAccountID( ID )
 end
 
 function player.GetByUniqueID( ID )
-	for _, pl in player.Iterator() do
-		if ( pl:UniqueID() == ID ) then
-			return pl
-		end
-	end
-
-	return false
+	return tPlayersUserID[ID] or false
 end
 
 function player.GetBySteamID( ID )


### PR DESCRIPTION
Modification of search functions (GetByAccountID, GetBySteamID, GetBySteamID64) for better optimization. I didn't do it for GetByUniqueID because in the wiki it's indicated that this function should be removed. 

# Benchmark

Below you can see different benchmarks for different numbers of players. 

**_In the benchmark, all functions ending in 2 are the modified versions proposed in the pull request._**

## For 1 player : 
```
player.GetBySteamID64() (Function Base) took 0.25048040000001 seconds. Total players: 1
player.GetBySteamID642() took 0.00026289999999562 seconds. Total players: 1
player.GetBySteamID() (Function Base) took 0.28991280000002 seconds. Total players: 1
player.GetBySteamID2() took 0.00012540000000172 seconds. Total players: 1
player.GetByAccountID() (Function Base) took 0.16199240000003 seconds. Total players: 1
player.GetByAccountID2() took 9.4599999954426e-05 seconds. Total players: 1
```

On average we have : 

- **99.895041687894%** performance gain for the GetBySteamID642 function
- **99.956745614543%** performance gain for the GetBySteamID2 function
- **99.94160219865%** performance gain for the GetByAccountID2 function

## For 32 players : 

```
player.GetBySteamID64() (Function Base) took 0.62707689999996 seconds. Total players: 32
player.GetBySteamID642() took 8.3399999994072e-05 seconds. Total players: 32
player.GetBySteamID() (Function Base) took 0.46229270000003 seconds. Total players: 32
player.GetBySteamID2() took 8.4700000002158e-05 seconds. Total players: 32
player.GetByAccountID() (Function Base) took 0.34629919999998 seconds. Total players: 32
player.GetByAccountID2() took 0.0036090000000399 seconds. Total players: 32
```

On average we have : 

- **99.986700195782%** performance gain for the GetBySteamID642 function
- **99.981678274391%** performance gain for the GetBySteamID2 function
- **98.957837615553%** performance gain for the GetByAccountID2 function

## For 128 players : 

```
player.GetBySteamID64() (Function Base) took 1.3004917 seconds. Total players: 128
player.GetBySteamID642() took 0.00014929999997548 seconds. Total players: 128
player.GetBySteamID() (Function Base) took 1.1024031 seconds. Total players: 128
player.GetBySteamID2() took 8.8199999993321e-05 seconds. Total players: 128
player.GetByAccountID() (Function Base) took 0.99094490000004 seconds. Total players: 128
player.GetByAccountID2() took 0.0039582999999652 seconds. Total players: 128
```

On average we have : 

- **99.98851972681%** performance gain for the GetBySteamID642 function
- **99.99199929681%** performance gain for the GetBySteamID2 function
- **99.600552967177%** performance gain for the GetByAccountID2 function