### PR TITLE
Add hook PlayerFullyConnected

### DIFF
--- a/garrysmod/lua/includes/extensions/player_auth.lua
+++ b/garrysmod/lua/includes/extensions/player_auth.lua
@@ -47,12 +47,27 @@ function meta:GetUserGroup()
 
 end
 
+if CLIENT then
+	hook.Add( "InitPostEntity", "PlayerAuthInitPostEntity", function()
+		net.Start( "GMODPlayerFullyConnected" )
+		net.SendToServer()
+	end )
+end
 
 --[[---------------------------------------------------------
 	This is the meat and spunk of the player auth system
 -----------------------------------------------------------]]
 
 if ( not SERVER ) then return end
+
+util.AddNetworkString( "GMODPlayerFullyConnected" )
+net.Receive( "GMODPlayerFullyConnected", function( len, ply )
+	if not IsValid( ply ) then return end
+	if ply.bIsFullyConnected then return end
+
+	ply.bIsFullyConnected = true
+	hook.Run( "PlayerFullyConnected", ply )
+end ) 
 
 --[[---------------------------------------------------------
 	Name: SetUserGroup


### PR DESCRIPTION
The PlayerFullyConnected hook has been added to enable developers to ensure that the client receives the net. It will run only when the client is loaded. 

Admittedly, on the wiki, there are solutions already proposed for PlayerInitialSpawn, but the addition of this hook will make it possible to use a single hook instead of each developer creating his own hook or function. 