### PR TITLE
Fix of several lua errors - KillIcon

### DIFF
--- a/garrysmod/lua/includes/modules/killicon.lua
+++ b/garrysmod/lua/includes/modules/killicon.lua
@@ -68,8 +68,10 @@ end
 
 function GetSize( name, dontEqualizeHeight )
 
+	name = name or "default"
+
 	if ( !Icons[name] ) then
-		Msg( "Warning: killicon not found '" .. name .. "'\n" )
+		Msg( "Warning: killicon not found '", name, "'\n" )
 		Icons[name] = Icons["default"]
 	end
 
@@ -132,9 +134,10 @@ end
 local function DrawInternal( x, y, name, alpha, noCorrections, dontEqualizeHeight )
 
 	alpha = alpha or 255
+	name = name or "default"
 
 	if ( !Icons[name] ) then
-		Msg( "Warning: killicon not found '" .. name .. "'\n" )
+		Msg( "Warning: killicon not found '", name, "'\n" )
 		Icons[name] = Icons["default"]
 	end
 


### PR DESCRIPTION
Fixed several lua errors if the third argument was set to “nil” in the [GM:AddDeathNotice](https://wiki.facepunch.com/gmod/GM:AddDeathNotice). To get these errors, I just followed the wiki example, while waiting for it to be corrected I modified the wiki page. 

Function to reproduce lua error : 
```lua
lua_run_cl GAMEMODE:AddDeathNotice( LocalPlayer():GetName(), LocalPlayer():Team(), nil, LocalPlayer():GetName(), LocalPlayer():Team() )
```

Here are the lua errors corrected: 
```
lua/includes/modules/killicon.lua:72: attempt to concatenate local 'name' (a nil value)
    1. GetSize - lua/includes/modules/killicon.lua:72
        2. DrawDeath - gamemodes/base/gamemode/cl_deathnotice.lua:227
            3. Run - gamemodes/base/gamemode/cl_deathnotice.lua:278
                4. HUDPaint - gamemodes/base/gamemode/cl_init.lua:84
                    5. unknown - gamemodes/sandbox/gamemode/cl_init.lua:106

[ERROR] lua/includes/modules/killicon.lua:73: table index is nil
  1. GetSize - lua/includes/modules/killicon.lua:73
   2. DrawDeath - gamemodes/base/gamemode/cl_deathnotice.lua:227
    3. Run - gamemodes/base/gamemode/cl_deathnotice.lua:278
     4. HUDPaint - gamemodes/base/gamemode/cl_init.lua:84
      5. unknown - gamemodes/sandbox/gamemode/cl_init.lua:106

[ERROR] lua/includes/modules/killicon.lua:139: attempt to concatenate local 'name' (a nil value)
  1. DrawInternal - lua/includes/modules/killicon.lua:139
   2. Render - lua/includes/modules/killicon.lua:200
    3. DrawDeath - gamemodes/base/gamemode/cl_deathnotice.lua:237
     4. Run - gamemodes/base/gamemode/cl_deathnotice.lua:278
      5. HUDPaint - gamemodes/base/gamemode/cl_init.lua:84
       6. unknown - gamemodes/sandbox/gamemode/cl_init.lua:106 (x431)

```