### PR TITLE
Update base lights.rad

### DIFF
--- a/garrysmod/lights.rad
+++ b/garrysmod/lights.rad
@@ -1,57 +1,182 @@
-lights/fluorescentcool001a	189 231 232 350
-lights/fluorescentcool001b	236 255 182 350
-lights/fluorescentcool002a	189 231 232 400
-lights/fluorescentcool002b	236 255 182 400
-lights/fluorescentcool003a	189 231 232 300
-lights/fluorescentwarm001a	239 216 193 350
-lights/fluorescentwarm002a	239 216 193 400
-lights/fluorescentwhite001a	245 245 245 350
-lights/fluorescentwhite002a	245 245 245 400
+ldr: lights/fluorescentcool001a	189 231 232 350
+hdr: lights/fluorescentcool001a	189 231 232 175
 
+ldr: lights/fluorescentcool001b	236 255 182 350
+hdr: lights/fluorescentcool001b	236 255 182 175
 
-lights/hazzardred001a		228 37 0 300
-lights/hazzardyellow001a	250 215 74 300
+ldr: lights/fluorescentcool002a	189 231 232 400
+hdr: lights/fluorescentcool002a	189 231 232 200
 
-lights/HIDcool001a		145 222 172 650
-lights/HIDcool001b		205 232 255 650
-lights/HIDwarm001a		255 201 116 650
+ldr: lights/fluorescentcool002b	236 255 182 400
+hdr: lights/fluorescentcool002b	236 255 182 200
 
-lights/white001			250 250 250 70
-lights/white002			189 233 247 425
-lights/white003			232 246 190 350
-lights/white004			170 228 247 425
-lights/white005			234 235 220 375
-lights/white006			234 235 220 100
+ldr: lights/fluorescentcool003a	189 231 232 300
+hdr: lights/fluorescentcool003a	189 231 232 150
 
-lights/white001_nochop	250 240 205 100
-lights/white002_nochop	189 233 247 425
-lights/white003_nochop	232 246 190 350
-lights/white004_nochop	170 228 247 425
-lights/white005_nochop	234 235 220 375
-lights/white006_nochop	234 235 220 100
+ldr: lights/fluorescentwarm001a	239 216 193 350
+hdr: lights/fluorescentwarm001a	239 216 193 175
 
-lights/incandescentcool001a	235 235 235 300
-lights/incandescentwarm001a	250 226 129 300
+ldr: lights/fluorescentwarm002a	239 216 193 400
+hdr: lights/fluorescentwarm002a	239 216 193 200
 
+ldr: lights/fluorescentwhite001a 245 245 245 350
+hdr: lights/fluorescentwhite001a 245 245 245 175
 
-glass/glassscreen001a		172 192 161 225
-glass/glasspipe001f		214 72 44 200
-glass/glassscreen001c		172 192 161 225
-glass/glassscreen001d		211 187 134 225
-glass/glassblock001a		70 194 209 200 
-composite/citadelfloor001a	103 143 203 200
-props/tvscreen006a		196 0 0 200
-shadertest/gooinglass		149 49 15 50
+ldr: lights/fluorescentwhite002a 245 245 245 400
+hdr: lights/fluorescentwhite002a 245 245 245 200
 
-glass/glasswindow002e		189 233 247 425
-glass/glasswindow035a		145 222 172 100
+ldr: lights/hazzardred001a 228 37 0 300
+hdr: lights/hazzardred001a 228 37 0 150
 
-dev/DEV_INTERIORLIGHT02B	151 176 204 225
+ldr: lights/hazzardyellow001a 250 215 74 300
+hdr: lights/hazzardyellow001a 250 215 74 150
 
-plaster/plasterwall029h		189 223 227 125
-building_template/Building_Trainstation_Template001d	230 230 200 65
-building_template/Building_Trainstation_Template001e	230 230 200 150
-building_template/Building_Trainstation_window002d	230 230 200 300
-building_template/Building_Trainstation_window002e	230 230 200 300
+ldr: lights/HIDcool001a 145 222 172 650
+hdr: lights/HIDcool001a 145 222 172 325
 
-lights/physgunlight	189 231 232 20
+ldr: lights/HIDcool001b 205 232 255 650
+hdr: lights/HIDcool001b 205 232 255 325
+
+ldr: lights/HIDwarm001a 255 201 116 650
+hdr: lights/HIDwarm001a 255 201 116 325
+
+ldr: lights/white001 250 240 205 100
+hdr: lights/white001 250 240 205 50
+
+ldr: lights/white002 189 233 247 425
+hdr: lights/white002 189 233 247 212
+
+ldr: lights/white003 232 246 190 350
+hdr: lights/white003 232 246 190 175
+
+ldr: lights/white004 170 228 247 425
+hdr: lights/white004 170 228 247 100
+
+ldr: lights/white005 234 235 220 375
+hdr: lights/white005 234 235 220 187
+
+ldr: lights/white006 234 235 220 100
+hdr: lights/white006 234 235 220 50
+
+ldr: lights/white001_nochop 250 240 205 100
+hdr: lights/white001_nochop 250 240 205 50
+
+ldr: lights/white002_nochop 189 233 247 425
+hdr: lights/white002_nochop 189 233 247 212
+
+ldr: lights/white003_nochop 232 246 190 350
+hdr: lights/white003_nochop 232 246 190 175
+
+ldr: lights/white004_nochop 170 228 247 425
+hdr: lights/white004_nochop 170 228 247 100
+
+ldr: lights/white005_nochop 234 235 220 375
+hdr: lights/white005_nochop 234 235 220 187
+
+ldr: lights/white006_nochop 234 235 220 100
+hdr: lights/white006_nochop 234 235 220 50
+
+ldr: lights/incandescentcool001a 235 235 235 300
+hdr: lights/incandescentcool001a 235 235 235 150
+
+ldr: lights/incandescentwarm001a 250 226 129 300
+hdr: lights/incandescentwarm001a 250 226 129 150
+
+ldr: glass/glassscreen001a 172 192 161 225
+hdr: glass/glassscreen001a 172 192 161 112
+
+ldr: glass/glasspipe001f 214 72 44 200
+hdr: glass/glasspipe001f 214 72 44 100
+
+ldr: glass/glassscreen001c 172 192 161 225
+hdr: glass/glassscreen001c 172 192 161 112
+
+ldr: glass/glassscreen001d 211 187 134 225
+hdr: glass/glassscreen001d 211 187 134 112
+
+ldr: glass/glassblock001a 70 194 209 200 
+hdr: glass/glassblock001a 70 194 209 100 
+
+ldr: composite/citadelfloor001a 103 143 203 200
+hdr: composite/citadelfloor001a 103 143 203 100
+
+ldr: props/tvscreen006a 196 0 0 200
+hdr: props/tvscreen006a 196 0 0 100
+
+ldr: shadertest/gooinglass 149 49 15 50
+hdr: shadertest/gooinglass 149 49 15 25
+
+ldr: glass/glasswindow002e 189 233 247 425
+hdr: glass/glasswindow002e 189 233 247 212
+
+ldr: glass/glasswindow035a 145 222 172 100
+hdr: glass/glasswindow035a 145 222 172 50
+
+ldr: dev/DEV_INTERIORLIGHT02B 151 176 204 225
+hdr: dev/DEV_INTERIORLIGHT02B 151 176 204 112
+
+ldr: plaster/plasterwall029h 189 223 227 125
+hdr: plaster/plasterwall029h 189 223 227 62
+
+ldr: building_template/Building_Trainstation_Template001d 230 230 200 65
+hdr: building_template/Building_Trainstation_Template001d 230 230 200 32
+
+ldr: building_template/Building_Trainstation_Template001e 230 230 200 150
+hdr: building_template/Building_Trainstation_Template001e 230 230 200 75
+
+ldr: building_template/Building_Trainstation_window002d	230 230 200 300
+hdr: building_template/Building_Trainstation_window002d	230 230 200 150
+
+ldr: building_template/Building_Trainstation_window002e	230 230 200 300
+hdr: building_template/Building_Trainstation_window002e	230 230 200 150
+
+ldr: lights/physgunlight 189 231 232 20
+hdr: lights/physgunlight 189 231 232 10
+
+noshadow tree_deciduous_01a_branches.vmt
+noshadow tree_deciduous_01a_leaves.vmt
+noshadow tree_deciduous_01a_lod.vmt
+noshadow tree_deciduous_01a_lod-leaves.vmt
+
+forcetextureshadow props_wasteland/exterior_fence_notbarbed002a.mdl
+forcetextureshadow props_wasteland/exterior_fence_notbarbed002b.mdl
+forcetextureshadow props_wasteland/exterior_fence_notbarbed002c.mdl
+forcetextureshadow props_wasteland/exterior_fence_notbarbed002d.mdl
+forcetextureshadow props_wasteland/exterior_fence_notbarbed002e.mdl
+forcetextureshadow props_wasteland/exterior_fence_notbarbed002f.mdl
+forcetextureshadow props_wasteland/exterior_fence001a.mdl
+forcetextureshadow props_wasteland/exterior_fence001b.mdl
+forcetextureshadow props_wasteland/exterior_fence002a.mdl
+forcetextureshadow props_wasteland/exterior_fence002b.mdl
+forcetextureshadow props_wasteland/exterior_fence002c.mdl
+forcetextureshadow props_wasteland/exterior_fence002d.mdl
+forcetextureshadow props_wasteland/exterior_fence002e.mdl
+forcetextureshadow props_wasteland/exterior_fence003a.mdl
+forcetextureshadow props_wasteland/exterior_fence003b.mdl
+forcetextureshadow props_foliage/tree_cliff_01a.mdl
+forcetextureshadow props_foliage/tree_cliff_02a.mdl
+forcetextureshadow props_foliage/tree_deciduous_01a-lod.mdl
+forcetextureshadow props_foliage/tree_deciduous_01a.mdl
+forcetextureshadow props_foliage/tree_deciduous_02a.mdl
+forcetextureshadow props_foliage/tree_deciduous_03a.mdl
+forcetextureshadow props_foliage/tree_deciduous_03b.mdl
+forcetextureshadow props_foliage/tree_poplar_01.mdl
+forcetextureshadow props_wasteland/interior_fence001a.mdl
+forcetextureshadow props_wasteland/interior_fence001b.mdl
+forcetextureshadow props_wasteland/interior_fence001c.mdl
+forcetextureshadow props_wasteland/interior_fence001d.mdl
+forcetextureshadow props_wasteland/interior_fence001e.mdl
+forcetextureshadow props_wasteland/interior_fence001g.mdl
+forcetextureshadow props_wasteland/interior_fence002a.mdl
+forcetextureshadow props_wasteland/interior_fence002b.mdl
+forcetextureshadow props_wasteland/interior_fence002c.mdl
+forcetextureshadow props_wasteland/interior_fence002d.mdl
+forcetextureshadow props_wasteland/interior_fence002e.mdl
+forcetextureshadow props_wasteland/interior_fence002f.mdl
+forcetextureshadow props_wasteland/interior_fence003a.mdl
+forcetextureshadow props_wasteland/interior_fence003b.mdl
+forcetextureshadow props_wasteland/interior_fence003d.mdl
+forcetextureshadow props_wasteland/interior_fence003e.mdl
+forcetextureshadow props_wasteland/interior_fence003f.mdl
+forcetextureshadow props_wasteland/interior_fence004a.mdl
+forcetextureshadow props_wasteland/interior_fence004b.mdl


### PR DESCRIPTION
Updates the lights.rad file to the one from pre-Anniversary base HL2/Half-Life-2 replacing the ancient one that's currently present. This should act as a nice base for future PRs related to adding lights or texture shadows (I plan to submit at least one other PR if this one gets accepted). The only light added in the Anniversary update for HL2 is "white002_soft" however GMod does not currently have this file/light and I felt like keeping this PR pretty bare bones hence why I have not included it here in this exact PR.

Additionally 3 of the defined lights (defined in both the new and old lights.rad) are missing and have seemingly never existed with those being:
- `white005_nochop`
- `white006`
- `white006_nochop`

attached below are materials for the missing lights setup exactly how they would be if they actually existed:
[missing base white lights.zip](https://github.com/user-attachments/files/20734527/missing.base.white.lights.zip)
