### PR TITLE
Show ENT.PrintName in property editor panel title

### DIFF
--- a/garrysmod/lua/autorun/properties/editentity.lua
+++ b/garrysmod/lua/autorun/properties/editentity.lua
@@ -19,9 +19,18 @@ properties.Add( "editentity", {
 
 	Action = function( self, ent )
 
+		local printName = ent.PrintName
+
+		if printName then
+			printName = language.GetPhrase( printName )
+			printName = string.format( "%s [%d]", printName, ent:EntIndex() )
+		else
+			printName = tostring( ent )
+		end
+
 		local window = g_ContextMenu:Add( "DFrame" )
 		window:SetSize( 320, 400 )
-		window:SetTitle( tostring( ent ) )
+		window:SetTitle( printName )
 		window:Center()
 		window:SetSizable( true )
 


### PR DESCRIPTION
Make the entity property editor show `ENT.PrintName` in the title.

Before the change:
![old property panel](https://github.com/user-attachments/assets/13de2e8a-3c10-4a3e-b641-cb1a117c2405)

After the change:
![new property panel](https://github.com/user-attachments/assets/410b767e-6dcd-49d7-ba9b-77ed382e0e0c)

Changes:
- Output translated ENT.PrintName
- Still output entity index, so windows can be distinguished.
- Falls back to old output (`tostring()`)