### PR TITLE
Add `player_manager.GetStoredPlayerClass`

### DIFF
--- a/garrysmod/lua/includes/modules/player_manager.lua
+++ b/garrysmod/lua/includes/modules/player_manager.lua
@@ -303,6 +303,12 @@ function GetPlayerClasses()
 
 end
 
+function GetStoredPlayerClass( name )
+
+	return Type[name]
+
+end
+
 local function LookupPlayerClass( ply )
 
 	local id = ply:GetClassID()


### PR DESCRIPTION
Currently the only way to directly get a player class is doing something hacky like
```lua
    local _, tbl = debug.getupvalue( player_manager.GetPlayerClasses, 2 )
    local defTbl = tbl.player_sandbox
```
It'd be great if there was a base game function to just get the direct table