### PR TITLE
Localizationfix

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/entities.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/entities.lua
@@ -10,9 +10,15 @@ hook.Add( "PopulateEntities", "AddEntityContent", function( pnlContent, tree, br
 	-- Add this list into the tormoil
 	local SpawnableEntities = list.Get( "SpawnableEntities" )
 	if ( SpawnableEntities ) then
+		local TranslateNames = {
+			["Editors"] = "#spawnmenu.category.editors",
+			["Fun + Games"] = "#spawnmenu.category.fun_games",
+			["Other"] = "#spawnmenu.category.other"
+		}
+
 		for k, v in pairs( SpawnableEntities ) do
 
-			local Category = language.GetPhrase( v.Category or "#spawnmenu.category.other" )
+			local Category = language.GetPhrase( TranslateNames[v.Category] or v.Category or "#spawnmenu.category.other" )
 			if ( !isstring( Category ) ) then Category = tostring( Category ) end
 			Categorised[ Category ] = Categorised[ Category ] or {}
 

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/npcs.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/npcs.lua
@@ -6,6 +6,15 @@ hook.Add( "PopulateNPCs", "AddNPCContent", function( pnlContent, tree, browseNod
 
 	-- Categorize them
 	local Categories = {}
+
+	local TranslateNames = {
+		["Animals"] = "#spawnmenu.category.animals",
+		["Combine"] = "#spawnmenu.category.combine",
+		["Humans + Resistance"] = "#spawnmenu.category.humans_resistance",
+		["Zombies + Enemy Aliens"] = "#spawnmenu.category.zombies_aliens",
+		["Other"] = "#spawnmenu.category.other"
+	}
+
 	for k, v in pairs( NPCList ) do
 
 		local Category = language.GetPhrase( v.Category or "#spawnmenu.category.other" )

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/npcs.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/npcs.lua
@@ -17,7 +17,7 @@ hook.Add( "PopulateNPCs", "AddNPCContent", function( pnlContent, tree, browseNod
 
 	for k, v in pairs( NPCList ) do
 
-		local Category = language.GetPhrase( v.Category or "#spawnmenu.category.other" )
+		local Category = language.GetPhrase( TranslateNames[v.Category] or v.Category or "#spawnmenu.category.other" )
 		if ( !isstring( Category ) ) then Category = tostring( Category ) end
 
 		local Tab = Categories[ Category ] or {}

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/postprocess.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/postprocess.lua
@@ -7,10 +7,16 @@ hook.Add( "PopulatePostProcess", "AddPostProcess", function( pnlContent, tree, n
 	local PostProcess = list.Get( "PostProcess" )
 
 	if ( PostProcess ) then
+		local TranslateNames = {
+			["Effects"] = "#effects_pp",
+			["Overlay"] = "#overlay_pp",
+			["Shaders"] = "#shaders_pp",
+			["Texturize"] = "#texturize_pp"
+		}
 
 		for k, v in pairs( PostProcess ) do
 
-			local Category = language.GetPhrase( v.category or "#spawnmenu.category.other" )
+			local Category = language.GetPhrase( TranslateNames[v.category] or v.category or "#spawnmenu.category.other" )
 			if ( !isstring( Category ) ) then Category = tostring( Category ) end
 			Categorised[ Category ] = Categorised[ Category ] or {}
 

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/vehicles.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/vehicles.lua
@@ -8,7 +8,7 @@ hook.Add( "PopulateVehicles", "AddEntityContent", function( pnlContent, tree, br
 	if ( Vehicles ) then
 		for k, v in pairs( Vehicles ) do
 
-			local Category = language.GetPhrase( v.Category or "#spawnmenu.category.other" )
+			local Category = language.GetPhrase( v.Category != "Other" and v.Category or "#spawnmenu.category.other" )
 			if ( !isstring( Category ) ) then Category = tostring( Category ) end
 			Categorised[ Category ] = Categorised[ Category ] or {}
 

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/vehicles.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/vehicles.lua
@@ -6,9 +6,14 @@ hook.Add( "PopulateVehicles", "AddEntityContent", function( pnlContent, tree, br
 	-- Add this list into the tormoil
 	local Vehicles = list.Get( "Vehicles" )
 	if ( Vehicles ) then
+		local TranslateNames = {
+			["Chairs"] = "#spawnmenu.category.chairs",
+			["Other"] = "#spawnmenu.category.other"
+		}
+
 		for k, v in pairs( Vehicles ) do
 
-			local Category = language.GetPhrase( v.Category != "Other" and v.Category or "#spawnmenu.category.other" )
+			local Category = language.GetPhrase( TranslateNames[v.Category] or v.Category or "#spawnmenu.category.other" )
 			if ( !isstring( Category ) ) then Category = tostring( Category ) end
 			Categorised[ Category ] = Categorised[ Category ] or {}
 

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/weapons.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/weapons.lua
@@ -8,7 +8,7 @@ local function BuildWeaponCategories()
 
 		if ( !weapon.Spawnable ) then continue end
 
-		local Category = language.GetPhrase( weapon.Category or "#spawnmenu.category.other" )
+		local Category = language.GetPhrase( weapon.Category != "Other" and weapon.Category or "#spawnmenu.category.other" )
 		if ( !isstring( Category ) ) then Category = tostring( Category ) end
 
 		Categorised[ Category ] = Categorised[ Category ] or {}


### PR DESCRIPTION
After #2153 there are still many addons that, for example, set their entity category to `Fun + Games` instead of `#spawnmenu.category.fun_games`, causing a split of categories if the game language is not english

This PR solves it