### PR TITLE
Re-add Episode 2 soundscapes to gm_construct

### DIFF
--- a/garrysmod/scripts/soundscapes/soundscapes_garrysmod.txt
+++ b/garrysmod/scripts/soundscapes/soundscapes_garrysmod.txt
@@ -2,17 +2,17 @@
 {
 	"dsp"	"1"
 
-	//"playsoundscape"
-	//{
-	//	"name"		"ep2_forest.util_birds"
-	//	"volume"	"0.3"
-	//}
+	"playsoundscape"
+	{
+		"name"		"ep2_forest.util_birds"
+		"volume"	"0.3"
+	}
 
-	//"playsoundscape"
-	//{
-	//	"name"		"ep2_forest.util_windgusts"
-	//	"volume"	"0.4"
-	//}
+	"playsoundscape"
+	{
+		"name"		"ep2_forest.util_windgusts"
+		"volume"	"0.4"
+	}
 
 	"playlooping"
 	{


### PR DESCRIPTION
Brings back the EP2 soundscapes that used to be present in gm_construct since the sounds for them should always be present now (as of the coming update).