### PR TITLE
Prevent DAdjustableModelPanel from handling MMB presses

### DIFF
--- a/garrysmod/lua/vgui/dadjustablemodelpanel.lua
+++ b/garrysmod/lua/vgui/dadjustablemodelpanel.lua
@@ -17,8 +17,8 @@ function PANEL:OnMousePressed( mousecode )
 
 	-- input.SetCursorPos does not work while main menu is open
 	if ( !MENU_DLL and gui.IsGameUIVisible() ) then return end
-	-- Prevent the FOV to reset
-	if ( mousecode == MOUSE_MIDDLE ) then return end
+
+	if ( mousecode != MOUSE_LEFT and mousecode != MOUSE_RIGHT ) then return end
 
 	self:SetCursor( "none" )
 	self:MouseCapture( true )

--- a/garrysmod/lua/vgui/dadjustablemodelpanel.lua
+++ b/garrysmod/lua/vgui/dadjustablemodelpanel.lua
@@ -17,6 +17,8 @@ function PANEL:OnMousePressed( mousecode )
 
 	-- input.SetCursorPos does not work while main menu is open
 	if ( !MENU_DLL and gui.IsGameUIVisible() ) then return end
+	-- Prevent the FOV to reset
+	if ( mousecode == MOUSE_MIDDLE ) then return end
 
 	self:SetCursor( "none" )
 	self:MouseCapture( true )


### PR DESCRIPTION
This PR adds a guard clause to 'DAdjustableModelPanel:OnMousePressed' to return early if the pressed button is 'MOUSE_MIDDLE'.

- By default, the parent DoMiddleClick function is empty, so middle mouse input should have no effect.
- Curiously, pressing the middle mouse button on a DAdjustableModelPanel would still trigger camera logic capture in DAdjustableModelPanel, which lead to unintended behavior (FOV reseting).
- This fix aligns the panel's behavior with expectations and prevents accidental camera or FOV changes due to middle mouse clicks.

Middle mouse button now does nothing in DAdjustableModelPanel, as expected.