### PR TITLE
Fix GetCountUpdate Lua error

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/player_extension.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/player_extension.lua
@@ -90,7 +90,7 @@ function meta:AddCount( str, ent )
 		-- Update count on deletion
 		ent:CallOnRemove( "GetCountUpdate", function( ent, ply, countType, uid )
 			if ( !IsValid( ply ) ) then ply = player.GetByUniqueID( uid ) end
-			if ( !ply ) then return end
+			if ( !IsValid( ply ) ) then return end
 
 			ply:GetCount( countType )
 		end, self, str, key )


### PR DESCRIPTION
Can happen when a player's entity is removed after they've disconnected.

gamemodes/sandbox/gamemode/player_extension.lua:93: attempt to index local 'ply' (a boolean value)