### PR TITLE
Clean-up doubleclicking in menu

### DIFF
--- a/garrysmod/html/js/menu/control.NewGame.js
+++ b/garrysmod/html/js/menu/control.NewGame.js
@@ -97,26 +97,12 @@ function ControllerNewGame( $scope, $element, $rootScope, $location, $filter )
 		$rootScope.LastCategory = $scope.CurrentCategory;
 	}
 
-	$scope.DoubleClick = ""
-	$scope.ClickMap = function( m )
+	$scope.DblClickMap = function( m )
 	{
 		$scope.SelectMap( m );
 
-		if ( $scope.DoubleClick == m )
-		{
-			$scope.StartGame();
-			return;
-		}
+		$scope.StartGame();
 
-		//
-		// ng-dblclick doesn't work properly in engine, so we fake it!
-		//
-		$scope.DoubleClick = m;
-
-		setTimeout( function()
-		{
-			$scope.DoubleClick = "";
-		}, 500 )
 	}
 
 	$scope.FavMap = function( m )

--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -111,21 +111,6 @@ function ControllerServers( $scope, $element, $rootScope, $location )
 			lua.Run( "PingServer( %s )", server.address );
 		}, 10000 );
 
-		//
-		// ng-dblclick doesn't work properly in engine, so we fake it!
-		//
-		if ( server.DoubleClick )
-		{
-			$scope.JoinServer( server );
-			return;
-		}
-
-		server.DoubleClick = true;
-
-		setTimeout( function()
-		{
-			server.DoubleClick = false;
-		}, 500 );
 	}
 
 	$scope.SelectGamemode = function( gm )

--- a/garrysmod/html/template/newgame.html
+++ b/garrysmod/html/template/newgame.html
@@ -24,7 +24,7 @@
 
 					<li class="icon mapicon {{MapClass( map )}}" ng-repeat="map in category.maps | orderBy:'toString()' | mapFilter:SearchText" >
 						<img ng-click="FavMap( map )" class="{{FavMapClass( map )}} {{FavMapHover( map )}}" src="img/empty.png" loading="lazy"/>
-						<img ng-click="ClickMap( map )" ng-src="{{MapIcon( map, category.category )}}" class="thumbnail" loading="lazy"/><br />
+						<img ng-click="SelectMap( map )" ng-dblclick="DblClickMap( map )" ng-src="{{MapIcon( map, category.category )}}" class="thumbnail" loading="lazy"/><br />
 						<span>{{map}}</span>
 					</li>
 

--- a/garrysmod/html/template/servers.html
+++ b/garrysmod/html/template/servers.html
@@ -130,7 +130,7 @@
 						<div id="placeholder_pre" style="height: {{CurrentGamemode.server_offset * 22}}px"></div>
 
 						<div ng-repeat="server in CurrentGamemode.servers | orderBy: CurrentGamemode.OrderBy : CurrentGamemode.OrderReverse | filter: serverFilter | startFrom : CurrentGamemode.server_offset | limitTo : ServersPerPage"
-							class="server {{ ServerClass( server ) }} {{IfElse( CurrentGamemode.Selected == server, 'activeserver', '' )}}" ng-mouseup="SelectServer( server, $event )" >
+							class="server {{ ServerClass( server ) }} {{IfElse( CurrentGamemode.Selected == server, 'activeserver', '' )}}" ng-mouseup="SelectServer( server, $event )" ng-dblclick="JoinServer( server )">
 
 							<name>
 								<a class='favbutton {{IfElse( server.favorite, "favorited", "" )}}' ng-click="ToggleFavorite( server );$event.stopPropagation();"></a>


### PR DESCRIPTION
Garry used a timer-based detection for double click because "ng-dblclick doesn't work properly in engine, so we fake it!"
That appears to be due to an angularjs bug which has since been fixed from updating.

I've updated the main menu to use ng-dblclick as it works now. Tested in both Awesomium and CEF.