### PR TITLE
motor bug fix

### DIFF
--- a/garrysmod/lua/includes/modules/constraint.lua
+++ b/garrysmod/lua/includes/modules/constraint.lua
@@ -1083,6 +1083,8 @@ function Motor( Ent1, Ent2, Bone1, Bone2, LPos1, LPos2, friction, torque, forcet
 		Constraint:SetPhysConstraintObjects( Phys1, Phys1 )
 		Constraint:Spawn()
 		Constraint:Activate()
+		Constraint:Fire( "Scale", 0 )
+        Constraint:Fire( "Activate" )
 
 	onFinishConstraint()
 


### PR DESCRIPTION
Fixes very annoying bug where rotating a motor constraint before having activated it at least once causes the torque to be applied on a wrong axis.