### PR TITLE
Server list: Added option to "hide outdated servers"

### DIFF
--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -18,6 +18,7 @@ function ControllerServers( $scope, $element, $rootScope, $location )
 	$scope.SVFilterHasPly = false;
 	$scope.SVFilterNotFull = false;
 	$scope.SVFilterHidePass = false;
+	$scope.SVFilterHideOutdated = false;
 	$scope.SVFilterMaxPing = 2000;
 	$scope.SVFilterPlyMin = 0;
 	$scope.SVFilterPlyMax = 128;
@@ -311,6 +312,7 @@ function ControllerServers( $scope, $element, $rootScope, $location )
 		if ( server.ping > $scope.SVFilterMaxPing ) return false;
 		if ( server.players < $scope.SVFilterPlyMin ) return false;
 		if ( server.players > $scope.SVFilterPlyMax ) return false;
+		if ( server.version_c < 0 && $scope.SVFilterHideOutdated ) return false;
 		if ( server.flag && $scope.CurrentGamemode.FilterFlags[ server.flag ] == false ) return false;
 		if ( $scope.CurrentGamemode.HasPreferFlags && $scope.CurrentGamemode.FilterFlags[ server.flag ] != true ) return false;
 

--- a/garrysmod/html/template/servers.html
+++ b/garrysmod/html/template/servers.html
@@ -41,7 +41,8 @@
 					<input ng-model="SVFilterMaxPing" type="number" class="smalltextbox" placeholder="2000"/><br/>
 					<input type="checkbox" id="sv_notfull" ng-model="SVFilterNotFull"/><label for="sv_notfull" ng-tranny="'svfltr_not_full'"></label><br>
 					<input type="checkbox" id="sv_notempty" ng-model="SVFilterHasPly"/><label for="sv_notempty" ng-tranny="'svfltr_has_players'"></label><br>
-					<input type="checkbox" id="sv_nopass" ng-model="SVFilterHidePass"/><label for="sv_nopass" ng-tranny="'svfltr_no_password'"></label> <img class="passworded" src='img/server-passworded.png'/>
+					<input type="checkbox" id="sv_nopass" ng-model="SVFilterHidePass"/><label for="sv_nopass" ng-tranny="'svfltr_no_password'"></label> <img class="passworded" src='img/server-passworded.png'/><br>
+					<input type="checkbox" id="sv_outdated" ng-model="SVFilterHideOutdated"/><label for="sv_outdated" ng-tranny="'svfltr_outdated'"></label>
 
 					<div class="flags_filter" ng-show="CurrentGamemode.hasflags">
 						<img ng-repeat="(flag, whatever) in CurrentGamemode.flags" class="flag {{FilterFlagClass( flag )}}" ng-src='asset://garrysmod/materials/flags16/{{flag}}.png' ng-click="FilterFlag( flag, this );" onerror="MissingFlag( this )" loading="lazy"/>

--- a/garrysmod/resource/localization/en/main_menu.properties
+++ b/garrysmod/resource/localization/en/main_menu.properties
@@ -180,6 +180,7 @@ svsearch_placeholder=Search maps or servers
 svfltr_not_full=Hide full servers
 svfltr_has_players=Hide empty servers
 svfltr_no_password=Hide
+svfltr_outdated=Hide outdated servers
 svfltr_ply_limit=Player limit\:
 svfltr_ping_limit=Ping limit\:
 sv_join_if_not_full=Join when not full


### PR DESCRIPTION
<img width="231" height="98" alt="image" src="https://github.com/user-attachments/assets/dc93f424-822c-4091-85a3-431e5516ab80" />


This option, when ticked, filters out any servers that are outdated and are therefore not able to be connected to. 

This is done by hiding any servers that are using a network version older than your client. Technically a more accurate label would be "hide servers using an older networking version than my game client" but I think that's a bit much.
This does mean if your game itself is outdated, you will still see servers that are technically outdated but compatible with your game, as your game doesn't consider them outdated. And you'll see servers marked "future" that have updated.
