### PR TITLE
Add ents.FindInCube utility function

### DIFF
--- a/garrysmod/lua/includes/extensions/ents.lua
+++ b/garrysmod/lua/includes/extensions/ents.lua
@@ -18,3 +18,11 @@ function ents.FindByClassAndParent( classname, entity )
 	return out
 
 end
+
+function ents.FindInCube( center, radius )
+
+	local rvec = Vector( radius, radius, radius )
+
+	return ents.FindInBox( center - rvec, center + rvec )
+
+end

--- a/garrysmod/lua/includes/extensions/ents.lua
+++ b/garrysmod/lua/includes/extensions/ents.lua
@@ -21,6 +21,14 @@ end
 
 function ents.FindInCube( center, radius )
 
+	if ( !isvector( center ) ) then
+		return error( "Invalid argument: 'center' must be a Vector" )
+	end
+
+	if ( !isnumber( radius ) or radius <= 0 ) then
+		return error( "Invalid argument: 'radius' must be a positive number" )
+	end
+
 	local rvec = Vector( radius, radius, radius )
 
 	return ents.FindInBox( center - rvec, center + rvec )


### PR DESCRIPTION
This pull request introduces a new utility function to the `ents` library in `garrysmod/lua/includes/extensions/ents.lua`. The new function simplifies finding entities within a cube-shaped area.

### Additions to the `ents` library:

* `ents.FindInCube(center, radius)`: Added a new function that calculates a cube based on a center point and radius, and uses `ents.FindInBox` to return entities within that cube. This provides a more intuitive way to search for entities in a cubic area.