### PR TITLE
Add spawnmenu icon to npc_tf2_ghost

### DIFF
--- a/garrysmod/gamemodes/base/entities/entities/npc_tf2_ghost.lua
+++ b/garrysmod/gamemodes/base/entities/entities/npc_tf2_ghost.lua
@@ -67,5 +67,6 @@ end
 --
 list.Set( "NPC", "npc_tf2_ghost", {
 	Name = "Example NPC",
-	Class = "npc_tf2_ghost"
+	Class = "npc_tf2_ghost",
+	IconOverride = "entities/npc_mossman.png"
 } )


### PR DESCRIPTION
This just adds a spawnmenu icon to the example NPC so that it isn't totally blank.

<img width="127" height="127" alt="image" src="https://github.com/user-attachments/assets/5a1ff45f-51a1-4bbb-9f58-aa4c4cc2d187" />