### PR TITLE
Run Javascript functions on HTML, safely - html:RunFunction(string jsfuncname, varargs)

### DIFF
--- a/garrysmod/lua/vgui/dhtml.lua
+++ b/garrysmod/lua/vgui/dhtml.lua
@@ -63,6 +63,82 @@ function PANEL:Call( js )
 	self:QueueJavascript( js )
 end
 
+local function BuildFunction( func, ... )
+
+	--
+	-- Build a Javascript-safe JS function call.
+	-- To be run by either panel:RunFunction or panel:QueueFunction
+	--
+	-- First parameter is the JS function name,
+	-- additional parameters are the values to provide to the function call.
+	-- The values provided to the function call are treated as strings except where noted below.
+	--
+	
+	local formatArgs = {}
+	local safeArgs = {}
+	
+	for k, v in ipairs( { ... } ) do
+	
+		if isbool( v ) then -- Boolean
+		
+			formatArgs[ k ] = '%s'
+			safeArgs[ k ] = v and true or false
+			
+		elseif isnumber( v ) then -- Numbers
+		
+			formatArgs[ k ] = '%s'
+			safeArgs[ k ] = v
+			
+		elseif IsColor( v ) then -- Colors, convert to CSS format
+		
+			formatArgs[ k ] = '"%s"'
+			safeArgs[ k ] = v:ToHex() -- returns "#rrggbb" or "#rrggbbaa" depending on alpha
+			
+			-- Awesomium does NOT support "#rrggbbaa", so for now we're overriding any alpha ones with "rgba()". Once Awesomium has been fully replaced by CEF, remove this override.
+			if v.a != 255 then
+				-- alpha has 3dp precision, as that's enough to accurately convert back to 0-255 or 00-FF.
+				safeArgs[ k ] = string.format( "rgba(%d,%d,%d,%.3f)", v.r, v.g, v.b, ( v.a / 255 ) )
+			end
+			
+		elseif istable( v ) then -- Tables, convert to json object
+		
+			formatArgs[ k ] = 'JSON.parse("%s")'
+			safeArgs[ k ] = string.JavascriptSafe( util.TableToJSON( v ) )
+			
+		else -- Strings, and all else treated as strings
+		
+			formatArgs[ k ] = '"%s"'
+			safeArgs[ k ] = string.JavascriptSafe( tostring( v ) )
+			
+		end
+		
+	end
+	
+	
+	func = string.gsub( func, "[^%w%._]", "" ) -- Function name strips any characters that aren't underscore "_", dot ".", or alphanumeric.
+
+	return string.format( [[ %s( ]] .. table.concat( formatArgs, ", " ) .. [[ ); ]], func, unpack( safeArgs ) )
+	
+end
+
+function PANEL:RunFunction( func, ... )
+
+	--
+	-- Build and Run a Javascript function immediately.
+	--
+	self:RunJavascript( BuildFunction( func, ... ) )
+	
+end
+
+function PANEL:QueueFunction( func, ... )
+
+	--
+	-- Build and Queue a Javascript function.
+	--
+	self:QueueJavascript( BuildFunction( func, ... ) )
+	
+end
+
 function PANEL:ConsoleMessage( msg, file, line, severity )
 
 	if ( !isstring( msg ) ) then msg = "*js variable*" end

--- a/garrysmod/lua/vgui/dhtml.lua
+++ b/garrysmod/lua/vgui/dhtml.lua
@@ -73,52 +73,44 @@ local function BuildFunction( func, ... )
 	-- additional parameters are the values to provide to the function call.
 	-- The values provided to the function call are treated as strings except where noted below.
 	--
-	
+
 	local formatArgs = {}
 	local safeArgs = {}
-	
+
 	for k, v in ipairs( { ... } ) do
-	
-		if isbool( v ) then -- Boolean
-		
+
+		if isbool( v ) then -- Booleans
+
 			formatArgs[ k ] = '%s'
 			safeArgs[ k ] = v and true or false
-			
+
 		elseif isnumber( v ) then -- Numbers
-		
+
 			formatArgs[ k ] = '%s'
 			safeArgs[ k ] = v
-			
-		elseif IsColor( v ) then -- Colors, convert to CSS format
-		
+
+		elseif IsColor( v ) then -- Colors, convert to CSS hex color string
+
 			formatArgs[ k ] = '"%s"'
-			safeArgs[ k ] = v:ToHex() -- returns "#rrggbb" or "#rrggbbaa" depending on alpha
-			
-			-- Awesomium does NOT support "#rrggbbaa", so for now we're overriding any alpha ones with "rgba()". Once Awesomium has been fully replaced by CEF, remove this override.
-			if v.a != 255 then
-				-- alpha has 3dp precision, as that's enough to accurately convert back to 0-255 or 00-FF.
-				safeArgs[ k ] = string.format( "rgba(%d,%d,%d,%.3f)", v.r, v.g, v.b, ( v.a / 255 ) )
-			end
-			
+			safeArgs[ k ] = v:ToHex() -- "#rrggbb"/"#rrggbbaa"
+
 		elseif istable( v ) then -- Tables, convert to json object
-		
+
 			formatArgs[ k ] = 'JSON.parse("%s")'
 			safeArgs[ k ] = string.JavascriptSafe( util.TableToJSON( v ) )
-			
+
 		else -- Strings, and all else treated as strings
-		
+
 			formatArgs[ k ] = '"%s"'
 			safeArgs[ k ] = string.JavascriptSafe( tostring( v ) )
-			
-		end
-		
-	end
-	
-	
-	func = string.gsub( func, "[^%w%._]", "" ) -- Function name strips any characters that aren't underscore "_", dot ".", or alphanumeric.
 
+		end
+
+	end
+
+	func = string.gsub( func, "[^%w%._]", "" ) -- Function name is limited to alphanumeric, underscore "_", dot "."
 	return string.format( [[ %s( ]] .. table.concat( formatArgs, ", " ) .. [[ ); ]], func, unpack( safeArgs ) )
-	
+
 end
 
 function PANEL:RunFunction( func, ... )


### PR DESCRIPTION
### Summary
Function to let you run a Javascript function on an HTML panel from Lua without having to deal with complex messy injection issues. _See #2328 for previous development progress._

### Example
As an example, the loading screen panel currently uses this:
```lua
pnlLoading.JavascriptRun = string.format( [[if ( window.GameDetails ) GameDetails( "%s", "%s", "%s", %i, "%s", "%s", %.2f, "%s", "%s" );]],
	servername:JavascriptSafe(), serverurl:JavascriptSafe(), mapname:JavascriptSafe(), maxplayers_visible, steamid:JavascriptSafe(), gamemode:JavascriptSafe(),
	GetConVarNumber( "snd_musicvolume" ), GetConVarString( "gmod_language" ):JavascriptSafe(), niceGamemode:JavascriptSafe() )

self.HTML:RunJavascript( str )
```

Using the new function from this PR, you could instead do this:
```lua
self.HTML:RunFunction( "GameDetails", 
	servername, serverurl, mapname, maxplayers_visible, steamid, gamemode, 
	GetConVarNumber( "snd_musicvolume" ), GetConVarString( "gmod_language" ), niceGamemode  )
``` 
_This is not a suggestion to update the loading screen with this, it's just an example of how it's easier for developers._


### About
The function is available as both `RunFunction()` and `QueueFunction()`, the only difference is internally it calls either [RunJavascript()](https://wiki.facepunch.com/gmod/Panel:RunJavascript) or [QueueJavascript()](https://wiki.facepunch.com/gmod/DHTML:QueueJavascript) respectively with the prepared javascript.

Syntax is `html:QueueFunction( javascript function name to call, varargs to pass to it )` 
eg running `html:QueueFunction( "myfunc", "hello world", true, 10/2, game.GetMap() )` will execute `myfunc( "hello world", true, 5, "gm_flatgrass" );` in the javascript.

Arguments support the following data types: Booleans, Numbers, Colours, Tables, and Strings. 
Some additional notes on data type handling:
- Colours are converted by `:ToHex()` to strings. eg if you provide `Color(255,0,255,255)` the JS function will receive string `"#ff00ff"`, or if you provide `Color(255,0,255,153)` the JS function will receive string `"#ff00ff99"`
- Tables (and table-like) are converted to json objects with `util.TableToJSON`. They can be read in JS eg `ply["rank"]`, `ghosts[0]["time"]`, `pos["x"]`, etc
- Any other types are converted to string and protected by [JavascriptSafe](https://wiki.facepunch.com/gmod/string.JavascriptSafe)

## Demo
<details><summary><mark>[Click to view demo, including sample code and output]</mark></summary>


Here is a test panel to demonstrate functionality - [htmltest.lua](https://github.com/user-attachments/files/29847195/htmltest.lua.txt) 
Please try running it along with this PR to see functionality. concommand `htmltest` will open the panel. if you edit the code with autorefresh, run `htmltest` again and it'll regenerate the panel.

Here are some examples from the test code:

### Works for native JS functions
```lua
html:QueueFunction( "console.log", "'hello world!' is a mandatory reference to make in any demo." )
```
> <img width="431" height="12" alt="image" src="https://github.com/user-attachments/assets/be8ce1f7-10e8-4c94-af5e-47d6117394bf" />

### Works for custom JS functions, and multiple parameters
lua: 
```lua
html:QueueFunction( "GameInfo", LocalPlayer():Name(), game.GetMap(), engine.ActiveGamemode() )
```
Javascript: 
```js
function GameInfo(player, map, gamemode) {
	var div = document.createElement("div");
	div.innerHTML = "Player <span class='ply info'></span> is on map <span class='map info'></span> in gamemode <span class='gm info'></span>";
						
	div.querySelector(".ply").innerText = player;
	div.querySelector(".map").innerText = map;
	div.querySelector(".gm").innerText = gamemode;
					
	document.body.appendChild(div);
}
```
Output:
> <img width="411" height="32" alt="image" src="https://github.com/user-attachments/assets/cfdb8b58-fcda-4fb2-b069-5e9d0e77ad8a" />

 
### Tables /  Json
```lua
html:QueueFunction( "ExplainJson", { [ "hero" ] = "freeman", [ "villain" ] = "combine", [ "episode" ] = 3 } )
```
> <img width="294" height="261" alt="image" src="https://github.com/user-attachments/assets/a4c024a4-53f2-492e-832e-787333ccd2ae" />


### Demo of various types
```lua
html:QueueFunction( "ExplainType", "this is a string" )
html:QueueFunction( "ExplainType", true )
html:QueueFunction( "ExplainType", false )
html:QueueFunction( "ExplainType", 1234 )
html:QueueFunction( "ExplainType", -2/3 )
html:QueueFunction( "ExplainType", Color( 255, 0, 255, 255 ) )
html:QueueFunction( "ExplainType", Color( 255, 0, 255, 153 ) )
```
> <img width="571" height="202" alt="image" src="https://github.com/user-attachments/assets/24ac595c-daf7-47d0-9ac9-8964a14e56f7" />


### Demo of choosing to send a table depending on use
```lua
html:QueueFunction( "ExplainType", Color( 255, 0, 255, 153 ) ) -- gets sent as a CSS hex string "#ff00ff99"
html:QueueFunction( "ExplainType", Color( 255, 0, 255, 153 ):ToTable() ) -- gets sent as json object [255, 0, 255, 153], so you can access individual values
```
> <img width="475" height="218" alt="image" src="https://github.com/user-attachments/assets/9be2ff6d-48c2-4b93-9d3c-9d919cb01613" />
</details>

<hr>

Suggestions and improvements are welcome. Thanks to @Grocel, @bloodycop6385, and @WinterPhoenix for feedback and reviews in #2328