### PR TITLE
Menu: Make it easier to click form inputs

### DIFF
--- a/garrysmod/html/css/menu/Servers.css
+++ b/garrysmod/html/css/menu/Servers.css
@@ -625,8 +625,13 @@ DIV.page DIV.options UL LI.sb_filters
 DIV.page DIV.options UL LI.sb_filter_sep
 {
 	border-top: 1px solid white;
+	box-shadow: 1px 1px 1px black;
 	margin-right: 42px;
 	margin-bottom: 24px;
+}
+DIV.page DIV.options UL LI.sb_filters .passworded
+{
+	vertical-align: text-top;
 }
 .gmfilter_rev
 {

--- a/garrysmod/html/template/addon_list.html
+++ b/garrysmod/html/template/addon_list.html
@@ -112,15 +112,15 @@
 		<div ng-show="Category == 'subscribed'" class="ugc_settings {{IfElse(UGCSettingsOpen, 'active', 'hidden')}}">
 			<div class="ugc_settings_cat">
 				<span ng-Tranny="'addons.filter_by'"></span>
-				<input type="checkbox" ng-model="FilterEnabledOnly" ng-change="HandleFilterChange( 1 )"/><label ng-Tranny="'addons.enabled_only'"></label><br>
-				<input type="checkbox" ng-model="FilterDisabledOnly" ng-change="HandleFilterChange( 0 )"/><label ng-Tranny="'addons.disabled_only'"></label>
+				<input type="checkbox" ng-model="FilterEnabledOnly" ng-change="HandleFilterChange( 1 )" id="FilterEnabledOnly"/><label for="FilterEnabledOnly" ng-Tranny="'addons.enabled_only'"></label><br>
+				<input type="checkbox" ng-model="FilterDisabledOnly" ng-change="HandleFilterChange( 0 )" id="FilterDisabledOnly"/><label for="FilterDisabledOnly" ng-Tranny="'addons.disabled_only'"></label>
 			</div>
 			<div class="ugc_settings_cat">
 				<span ng-Tranny="'addons.sort_by'"></span>
-				<input type="radio" name="sort" value="title" ng-model="UGCSortMethod" ng-change="HandleSortChange()"/><label ng-Tranny="'addons.name'"></label><br>
-				<input type="radio" name="sort" value="size" ng-model="UGCSortMethod" ng-change="HandleSortChange()"/><label ng-Tranny="'addons.size'"></label><br>
-				<input type="radio" name="sort" value="updated" ng-model="UGCSortMethod" ng-change="HandleSortChange()"/><label ng-Tranny="'addons.update_date'"></label><br>
-				<input type="radio" name="sort" value="subscribed" ng-model="UGCSortMethod" ng-change="HandleSortChange()"/><label ng-Tranny="'addons.sub_date'"></label>
+				<input type="radio" name="sort" value="title" ng-model="UGCSortMethod" ng-change="HandleSortChange()" id="UGCSortMethod_title"/><label for="UGCSortMethod_title" ng-Tranny="'addons.name'"></label><br>
+				<input type="radio" name="sort" value="size" ng-model="UGCSortMethod" ng-change="HandleSortChange()" id="UGCSortMethod_size"/><label for="UGCSortMethod_size" ng-Tranny="'addons.size'"></label><br>
+				<input type="radio" name="sort" value="updated" ng-model="UGCSortMethod" ng-change="HandleSortChange()" id="UGCSortMethod_updated"/><label for="UGCSortMethod_updated" ng-Tranny="'addons.update_date'"></label><br>
+				<input type="radio" name="sort" value="subscribed" ng-model="UGCSortMethod" ng-change="HandleSortChange()" id="UGCSortMethod_subscribed"/><label for="UGCSortMethod_subscribed" ng-Tranny="'addons.sub_date'"></label>
 			</div>
 			<div class="ugc_settings_cat"><!--<span>Selection:</span>-->
 				<div ng-show="!IsAnySelected()">
@@ -159,14 +159,14 @@
 			<input type="text" class="preset_name" ng-tranny="'addons.preset_name_placeholder'" ng-model="CreatePresetName"/><br/>
 			<br/>
 
-			<input type="checkbox" ng-model="CreatePresetSaveEnabled"/><label ng-tranny="'addons.preset_save_enabled'"></label><br/>
-			<input type="checkbox" ng-model="CreatePresetSaveDisabled"/><label ng-tranny="'addons.preset_save_disabled'"></label><br/>
+			<input type="checkbox" ng-model="CreatePresetSaveEnabled" id="CreatePresetSaveEnabled"/><label for="CreatePresetSaveEnabled" ng-tranny="'addons.preset_save_enabled'"></label><br/>
+			<input type="checkbox" ng-model="CreatePresetSaveDisabled" id="CreatePresetSaveDisabled"/><label for="CreatePresetSaveDisabled" ng-tranny="'addons.preset_save_disabled'"></label><br/>
 			<br/>
 
 			<b ng-Tranny="'addons.preset_new_action'"></b><br/>
-			<input type="radio" name="createpreset_newitems" value="" ng-model="CreatePresetNewAct"/><label ng-tranny="'addons.action_nothing'"></label><br/>
-			<input type="radio" name="createpreset_newitems" value="disable" ng-model="CreatePresetNewAct"/><label ng-tranny="'addons.action_disable'"></label><br/>
-			<input type="radio" name="createpreset_newitems" value="enable" ng-model="CreatePresetNewAct"/><label ng-tranny="'addons.action_enable'"></label><br/>
+			<input type="radio" name="createpreset_newitems" value="" ng-model="CreatePresetNewAct" id="CreatePresetNewAct_nothing"/><label for="CreatePresetNewAct_nothing" ng-tranny="'addons.action_nothing'"></label><br/>
+			<input type="radio" name="createpreset_newitems" value="disable" ng-model="CreatePresetNewAct" id="CreatePresetNewAct_disable"/><label for="CreatePresetNewAct_disable" ng-tranny="'addons.action_disable'"></label><br/>
+			<input type="radio" name="createpreset_newitems" value="enable" ng-model="CreatePresetNewAct" id="CreatePresetNewAct_enable"/><label for="CreatePresetNewAct_enable" ng-tranny="'addons.action_enable'"></label><br/>
 			<br/>
 
 			<a ng-click="CreateNewPreset()" ng-tranny="'addons.create_preset'" class="create big {{IfElse( CreatePresetName == '', 'disabled', '' )}}"></a>
@@ -188,9 +188,9 @@
 			<br/>
 
 			<b ng-Tranny="'addons.preset_new_action'"></b><br/>
-			<input type="radio" name="importpreset_newitems" value="" ng-model="CreatePresetNewAct"/><label ng-tranny="'addons.action_nothing'"></label><br/>
-			<input type="radio" name="importpreset_newitems" value="disable" ng-model="CreatePresetNewAct"/><label ng-tranny="'addons.action_disable'"></label><br/>
-			<input type="radio" name="importpreset_newitems" value="enable" ng-model="CreatePresetNewAct"/><label ng-tranny="'addons.action_enable'"></label><br/>
+			<input type="radio" name="importpreset_newitems" value="" ng-model="CreatePresetNewAct" id="CreatePresetNewAct_nothing"/><label for="CreatePresetNewAct_nothing" ng-tranny="'addons.action_nothing'"></label><br/>
+			<input type="radio" name="importpreset_newitems" value="disable" ng-model="CreatePresetNewAct" id="CreatePresetNewAct_disable"/><label for="CreatePresetNewAct_disable" ng-tranny="'addons.action_disable'"></label><br/>
+			<input type="radio" name="importpreset_newitems" value="enable" ng-model="CreatePresetNewAct" id="CreatePresetNewAct_enable"/><label for="CreatePresetNewAct_enable" ng-tranny="'addons.action_enable'"></label><br/>
 			<br/>
 
 			<a ng-click="ImportPreset()" ng-tranny="'addons.import_preset'" class="create {{IfElse( ImportPresetSource == '' || CreatePresetName == '', 'disabled', '' )}}"></a>
@@ -218,12 +218,12 @@
 					<b ng-Tranny="'addons.preset_name'"></b> {{PresetList[ SelectedPreset ].name}}<br>
 					<b ng-Tranny="'addons.preset_enabled'"></b> {{PresetList[ SelectedPreset ].enabled.length}}<br>
 					<b ng-Tranny="'addons.preset_disabled'"></b> {{PresetList[ SelectedPreset ].disabled.length}}<br>
-					<input type="checkbox" ng-model="LoadPresetResub"/><label ng-tranny="'addons.preset_resub_missing'"></label><br/>
+					<input type="checkbox" ng-model="LoadPresetResub" id="LoadPresetResub"/><label for="LoadPresetResub" ng-tranny="'addons.preset_resub_missing'"></label><br/>
 
 					<br><b ng-Tranny="'addons.preset_new_action'"></b><br>
-					<input type="radio" name="loadpreset_newitems" value="" ng-model="CreatePresetNewAct"/><label ng-tranny="'addons.action_nothing'"></label><br/>
-					<input type="radio" name="loadpreset_newitems" value="disable" ng-model="CreatePresetNewAct"/><label ng-tranny="'addons.action_disable'"></label><br/>
-					<input type="radio" name="loadpreset_newitems" value="enable" ng-model="CreatePresetNewAct"/><label ng-tranny="'addons.action_enable'"></label><br/>
+					<input type="radio" name="loadpreset_newitems" value="" ng-model="CreatePresetNewAct" id="CreatePresetNewAct_nothing"/><label for="CreatePresetNewAct_nothing" ng-tranny="'addons.action_nothing'"></label><br/>
+					<input type="radio" name="loadpreset_newitems" value="disable" ng-model="CreatePresetNewAct" id="CreatePresetNewAct_disable"/><label for="CreatePresetNewAct_disable" ng-tranny="'addons.action_disable'"></label><br/>
+					<input type="radio" name="loadpreset_newitems" value="enable" ng-model="CreatePresetNewAct" id="CreatePresetNewAct_enable"/><label for="CreatePresetNewAct_enable" ng-tranny="'addons.action_enable'"></label><br/>
 
 					<br>
 					<a ng-click="LoadSelectedPreset()" ng-tranny="'addons.load_preset'" class="create"></a>

--- a/garrysmod/html/template/newgame.html
+++ b/garrysmod/html/template/newgame.html
@@ -51,38 +51,38 @@
 				<div class="scrollable" style="margin: 10px; bottom: 80px; top: 32px">
 
 					<div class='control' ng-show="MaxPlayers > 1">
-						<label ng-Tranny="'server_name'"></label>
-						<input type="text" ng-model="ServerSettings.hostname" />
+						<label for="ServerSettings_hostname" ng-Tranny="'server_name'"></label>
+						<input id="ServerSettings_hostname" type="text" ng-model="ServerSettings.hostname" />
 					</div>
 
 					<div class='control' ng-show="MaxPlayers > 1">
-						<input type="checkbox" ng-model="ServerSettings.sv_lan" ng-bind="CheckboxCheck()" />
-						<label ng-Tranny="'lan_server'"></label>
+						<input id="ServerSettings_sv_lan" type="checkbox" ng-model="ServerSettings.sv_lan" ng-bind="CheckboxCheck()" />
+						<label for="ServerSettings_sv_lan" ng-Tranny="'lan_server'"></label>
 					</div>
 
 					<div class='control' ng-show="MaxPlayers > 1">
-						<input type="checkbox" ng-model="ServerSettings.p2p_enabled" ng-bind="CheckboxCheck()" />
-						<label ng-Tranny="'p2p_server'"></label>
+						<input id="ServerSettings_p2p_enabled" type="checkbox" ng-model="ServerSettings.p2p_enabled" ng-bind="CheckboxCheck()" />
+						<label for="ServerSettings_p2p_enabled" ng-Tranny="'p2p_server'"></label>
 					</div>
 
 					<div class='control' ng-show="MaxPlayers > 1">
-						<input type="checkbox" ng-model="ServerSettings.p2p_friendsonly" id="p2p_friendsonly" />
-						<label ng-Tranny="'p2p_server_friendsonly'"></label>
+						<input id="p2p_friendsonly" type="checkbox" ng-model="ServerSettings.p2p_friendsonly"/>
+						<label for="p2p_friendsonly" ng-Tranny="'p2p_server_friendsonly'"></label>
 					</div>
 
 					<div class='control control-text' ng-repeat="s in ServerSettings.Text" ng-show="MaxPlayers > 1 || s.Singleplayer">
-						<label ng-Tranny="s.text"></label>
-						<input type="text" ng-model="s.Value"/>
+						<label for="ServerSettings_text_{{s.name}}" ng-Tranny="s.text"></label>
+						<input id="ServerSettings_text_{{s.name}}" type="text" ng-model="s.Value"/>
 					</div>
 
 					<div class='control control-numeric' ng-repeat="s in ServerSettings.Numeric" ng-show="MaxPlayers > 1 || s.Singleplayer">
-						<label ng-Tranny="s.text"></label>
-						<input type="text" ng-model="s.Value"/>
+						<label for="ServerSettings_num_{{s.name}}" ng-Tranny="s.text"></label>
+						<input id="ServerSettings_num_{{s.name}}" type="text" ng-model="s.Value"/>
 					</div>
 
 					<div class='control' ng-repeat="s in ServerSettings.CheckBox" ng-show="MaxPlayers > 1 || s.Singleplayer">
-						<input type="checkbox" ng-model="s.Value" />
-						<label ng-Tranny="s.text"></label>
+						<input id="ServerSettings_check_{{s.name}}" type="checkbox" ng-model="s.Value" />
+						<label for="ServerSettings_check_{{s.name}}" ng-Tranny="s.text"></label>
 					</div>
 
 				</div>

--- a/garrysmod/html/template/servers.html
+++ b/garrysmod/html/template/servers.html
@@ -33,15 +33,15 @@
 					<input type="text" ng-model="GMSearch" class="gm_search" ng-tranny="'gmsearch_placeholder'" /><br/>
 				</li>
 				<li class="sb_filters" ng-show="CurrentGamemode != null">
-					<label ng-tranny="'svfltr_ply_limit'"></label><br/>
-					<input ng-model="SVFilterPlyMin" type="number" class="smalltextbox" placeholder="0`"/>
+					<label for="SVFilterPlyMin" ng-tranny="'svfltr_ply_limit'"></label><br/>
+					<input id="SVFilterPlyMin" ng-model="SVFilterPlyMin" type="number" class="smalltextbox" placeholder="0" min="0" max="128" step="8"/>
 					&nbsp;-&nbsp;
-					<input ng-model="SVFilterPlyMax" type="number" class="smalltextbox" placeholder="128"/><br/>
-					<label ng-tranny="'svfltr_ping_limit'"></label><br/>
-					<input ng-model="SVFilterMaxPing" type="number" class="smalltextbox" placeholder="2000"/><br/>
+					<input ng-model="SVFilterPlyMax" type="number" class="smalltextbox" placeholder="128" min="0" max="128" step="8"/><br/>
+					<label for="SVFilterMaxPing" ng-tranny="'svfltr_ping_limit'"></label><br/>
+					<input id="SVFilterMaxPing" ng-model="SVFilterMaxPing" type="number" class="smalltextbox" placeholder="2000" min="0" max="2500" step="20"/><br/>
 					<input type="checkbox" id="sv_notfull" ng-model="SVFilterNotFull"/><label for="sv_notfull" ng-tranny="'svfltr_not_full'"></label><br>
 					<input type="checkbox" id="sv_notempty" ng-model="SVFilterHasPly"/><label for="sv_notempty" ng-tranny="'svfltr_has_players'"></label><br>
-					<input type="checkbox" id="sv_nopass" ng-model="SVFilterHidePass"/><label for="sv_nopass" ng-tranny="'svfltr_no_password'"></label> <img class="passworded" src='img/server-passworded.png'/><br>
+					<input type="checkbox" id="sv_nopass" ng-model="SVFilterHidePass"/><label for="sv_nopass"><span ng-tranny="'svfltr_no_password'"></span> <img class="passworded" src='img/server-passworded.png'/></label><br>
 					<input type="checkbox" id="sv_outdated" ng-model="SVFilterHideOutdated"/><label for="sv_outdated" ng-tranny="'svfltr_outdated'"></label>
 
 					<div class="flags_filter" ng-show="CurrentGamemode.hasflags">


### PR DESCRIPTION
I've made it easier to click form inputs in the main menu by associating their labels with the corresponding input elements. 

Currently if you click things like the "enabled only" filter in the addon list, it does nothing, you need to click the actual input element. This fixes it so the text itself is assigned to the input and is clickable. This has been done to various inputs across the Addons page, New Game page, and Server List.

Full list of fixes:
- Made filter/sort labels clickable on Addons: Enabled only, disabled only, title sort, size sort, updated sort, subscribed sort.
- Made presets labels clickable on Addons: this includes all the "include disabled" "include enabled" "do nothing" etc checkboxes.
- Made server settings labels clickable on New Game: server name, lan toggle, p2p toggle, friendsonly toggle, and custom gamemode option labels
- Made filter labels clickable on Server List: Minimum Players, Ping Limit (note: from 'minimum players' you can easily to get 'maximum players' via the tab key on keyboard, or by directly clicking it as normal)
- On server list, min/max players filters will accept arrow key up/down and change the value in increments of 8, max ping filter in increments of 20.  Direct input is still available for exact values.
- On server list, fixed "Hide 🔒" filter option label. Previously only "hide" was clickable while clicking "🔒" did nothing. Now the whole "Hide 🔒" is clickable.
- On server list, made the left-column separator have the same drop shadow that the text in that column has. Improves visibility on light backgrounds.