### PR TITLE
Add new table extensions

### DIFF
--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -778,6 +778,27 @@ function table.Flip( tab )
 
 end
 
+function table.SwapRemove( tab, index )
+
+	local res = tab[ index ]
+	local len = #tab
+
+	tab[ index ] = tab[ len ]
+	tab[ len ] = nil
+
+	return res
+
+end
+
+function table.Swap( tab, key1, key2 )
+
+	local tmp = tab[ key1 ]
+
+	tab[ key1 ] = tab[ key2 ]
+	tab[ key2 ] = tmp
+
+end
+
 -- Polyfill for table.move on 32-bit
 -- Don't forget to remove this when it's no longer necessary
 if ( !table.move ) then

--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -792,10 +792,7 @@ end
 
 function table.Swap( tab, key1, key2 )
 
-	local tmp = tab[ key1 ]
-
-	tab[ key1 ] = tab[ key2 ]
-	tab[ key2 ] = tmp
+	tab[ key1 ], tab[ key2 ] = tab[ key2 ], tab[ key1 ]
 
 end
 


### PR DESCRIPTION
I've made 2 simple table lib extensions.

`table.Swap` simply swaps 2 key-value pairs.

`table.SwapRemove` behaves like `table.remove` except when removing a value it puts the last value of the table where the removed value used to be. The last value is replaced with `nil`. In tables where you do not care about the order of elements after removal, this should be useful and even preferred.