### PR TITLE
Add CapabilitiesHas method to NPC metatable

### DIFF
--- a/garrysmod/lua/includes/extensions/npc.lua
+++ b/garrysmod/lua/includes/extensions/npc.lua
@@ -1,0 +1,6 @@
+local meta = FindMetaTable("NPC")
+if ( !meta ) then return end
+
+function meta:HasCapability( cap )
+    return bit.band( self:CapabilitiesGet(), cap ) == cap
+end

--- a/garrysmod/lua/includes/extensions/npc.lua
+++ b/garrysmod/lua/includes/extensions/npc.lua
@@ -1,6 +1,8 @@
 local meta = FindMetaTable( "NPC" )
 if ( !meta ) then return end
 
-function meta:HasCapability( cap )
-    return bit.band( self:CapabilitiesGet(), cap ) == cap
+if ( SERVER ) then
+    function meta:HasCapability( cap )
+        return bit.band( self:CapabilitiesGet(), cap ) == cap
+    end
 end

--- a/garrysmod/lua/includes/extensions/npc.lua
+++ b/garrysmod/lua/includes/extensions/npc.lua
@@ -1,4 +1,4 @@
-local meta = FindMetaTable("NPC")
+local meta = FindMetaTable( "NPC" )
 if ( !meta ) then return end
 
 function meta:HasCapability( cap )

--- a/garrysmod/lua/includes/extensions/npc.lua
+++ b/garrysmod/lua/includes/extensions/npc.lua
@@ -2,7 +2,7 @@ local meta = FindMetaTable( "NPC" )
 if ( !meta ) then return end
 
 if ( SERVER ) then
-    function meta:HasCapability( cap )
+    function meta:CapabilitiesHas( cap )
         return bit.band( self:CapabilitiesGet(), cap ) == cap
     end
 end

--- a/garrysmod/lua/includes/init.lua
+++ b/garrysmod/lua/includes/init.lua
@@ -110,6 +110,7 @@ include( "extensions/game.lua" )
 include( "extensions/motionsensor.lua" )
 include( "extensions/weapon.lua" )
 include( "extensions/coroutine.lua" )
+include( "extensions/npc.lua")
 
 if ( CLIENT ) then
 


### PR DESCRIPTION
Introduces a CapabilitiesHas function for NPCs, allowing capability checks using bitwise operations. This extends the NPC metatable for easier capability management.