### PR TITLE
TTT: Raise passive equipment item limit from 16 to 32

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -456,7 +456,7 @@ local function ReceiveEquipment()
    local ply = LocalPlayer()
    if not IsValid(ply) then return end
 
-   ply.equipment_items = net.ReadUInt(16)
+   ply.equipment_items = net.ReadInt(util.BitsRequired(EQUIP_MAX, true))
 end
 net.Receive("TTT_Equipment", ReceiveEquipment)
 
@@ -494,10 +494,19 @@ local function ReceiveBought()
 end
 net.Receive("TTT_Bought", ReceiveBought)
 
+local bitsRequired = util.BitsRequired
+
 -- Player received the item he has just bought, so run clientside init
 local function ReceiveBoughtItem()
-   local is_item = net.ReadBit() == 1
-   local id = is_item and net.ReadUInt(16) or net.ReadString()
+   local is_item = net.ReadBool()
+
+   local id
+   if is_item then
+      local exponent = net.ReadUInt(bitsRequired(bitsRequired(EQUIP_MAX)))
+      id = 2 ^ exponent
+   else
+      id = net.ReadString()
+   end
 
    -- I can imagine custom equipment wanting this, so making a hook
    hook.Run("TTTBoughtItem", is_item, id)

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -502,7 +502,7 @@ local function ReceiveBoughtItem()
 
    local id
    if is_item then
-      local exponent = net.ReadUInt(bitsRequired(bitsRequired(EQUIP_MAX)))
+      local exponent = net.ReadUInt(bitsRequired(math.log(EQUIP_MAX) / math.log(2)))
       id = 2 ^ exponent
    else
       id = net.ReadString()

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_search.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_search.lua
@@ -5,8 +5,8 @@ local PT = LANG.GetParamTranslation
 
 local is_dmg = util.BitSet
 
-local dtt = { search_dmg_crush = DMG_CRUSH, search_dmg_bullet = DMG_BULLET, search_dmg_fall = DMG_FALL, 
-search_dmg_boom = DMG_BLAST, search_dmg_club = DMG_CLUB, search_dmg_drown = DMG_DROWN, search_dmg_stab = DMG_SLASH, 
+local dtt = { search_dmg_crush = DMG_CRUSH, search_dmg_bullet = DMG_BULLET, search_dmg_fall = DMG_FALL,
+search_dmg_boom = DMG_BLAST, search_dmg_club = DMG_CLUB, search_dmg_drown = DMG_DROWN, search_dmg_stab = DMG_SLASH,
 search_dmg_burn = DMG_BURN, search_dmg_tele = DMG_SONIC, search_dmg_car = DMG_VEHICLE }
 
 -- "From his body you can tell XXX"
@@ -422,14 +422,7 @@ local function StoreSearchResult(search)
    end
 end
 
-local function bitsRequired(num)
-   local bits, max = 0, 1
-   while max <= num do
-      bits = bits + 1
-      max = max + max
-   end
-   return bits
-end
+local bitsRequired = util.BitsRequired
 
 local plyBits = bitsRequired(game.MaxPlayers())
 
@@ -448,7 +441,7 @@ local function ReceiveRagdollSearch()
    search.nick = net.ReadString()
 
    -- Equipment
-   local eq = net.ReadUInt(bitsRequired(EQUIP_MAX))
+   local eq = net.ReadInt(bitsRequired(EQUIP_MAX, true))
 
    -- All equipment pieces get their own icon
    search.eq_armor = util.BitSet(eq, EQUIP_ARMOR)
@@ -489,7 +482,7 @@ local function ReceiveRagdollSearch()
    --
    local words = net.ReadString()
    search.words = (words ~= "") and words or nil
-   
+
    hook.Call("TTTBodySearchEquipment", nil, search, eq)
 
    if search.show and hook.Run("TTTShowSearchScreen", search) ~= false then

--- a/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
@@ -164,14 +164,7 @@ local function CallDetective(ply, cmd, args)
 end
 concommand.Add("ttt_call_detective", CallDetective)
 
-local function bitsRequired(num)
-   local bits, max = 0, 1
-   while max <= num do
-      bits = bits + 1
-      max = max + max
-   end
-   return bits
-end
+local bitsRequired = util.BitsRequired
 
 local plyBits = bitsRequired(game.MaxPlayers()) -- first game.MaxPlayers() of entities are for players.
 
@@ -260,7 +253,7 @@ function CORPSE.ShowSearch(ply, rag, covert, long_range)
       net.WriteUInt(rag:EntIndex(), 16) -- 16 bits
       net.WriteUInt(owner, plyBits) -- 128 max players. ( 8 bits )
       net.WriteString(nick)
-      net.WriteUInt(eq, bitsRequired(EQUIP_MAX)) -- Equipment ( default: 3 bits )
+      net.WriteInt(eq, bitsRequired(EQUIP_MAX, true)) -- Equipment ( default: 4 bits )
       net.WriteUInt(role, 2) -- ( 2 bits )
       net.WriteUInt(c4, bitsRequired(C4_WIRE_COUNT)) -- 0 -> 2^bits ( default c4: 3 bits )
       net.WriteUInt(dmg, 30) -- DMG_BUCKSHOT is the highest. ( 30 bits )
@@ -282,7 +275,7 @@ function CORPSE.ShowSearch(ply, rag, covert, long_range)
 
       net.WriteString(words)
 
-      -- 93 + string data + plyBits * (3 + #kill_entids)
+      -- 94 + string data + plyBits * (3 + #kill_entids)
 
    -- If found by detective, send to all, else just the finder
    if ply:IsActiveDetective() then

--- a/garrysmod/gamemodes/terrortown/gamemode/equip_items_shd.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/equip_items_shd.lua
@@ -116,8 +116,17 @@ function GetEquipmentItem(role, id)
    end
 end
 
- -- Utility function to register a new Equipment ID
+-- GMod's bitwise library is limited to a 32-bit signed int
+local EQUIP_LIMIT = 2 ^ 31
+
+-- Utility function to register a new Equipment ID
 function GenerateNewEquipmentID()
-   EQUIP_MAX = EQUIP_MAX * 2
+   local new_max = EQUIP_MAX * 2
+
+   if new_max > EQUIP_LIMIT then
+      error("Passive equipment item limit reached. Things may break in strange ways!")
+   end
+
+   EQUIP_MAX = new_max
    return EQUIP_MAX
 end

--- a/garrysmod/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player_ext.lua
@@ -82,7 +82,7 @@ end
 -- We do this instead of an NW var in order to limit the info to just this ply
 function plymeta:SendEquipment()
    net.Start("TTT_Equipment")
-      net.WriteUInt(self.equipment_items, 16)
+      net.WriteInt(self.equipment_items, util.BitsRequired(EQUIP_MAX, true))
    net.Send(self)
 end
 

--- a/garrysmod/gamemodes/terrortown/gamemode/util.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/util.lua
@@ -292,8 +292,9 @@ function IsRagdoll(ent)
 end
 
 local band = bit.band
+local tobit = bit.tobit
 function util.BitSet(val, bit)
-   return band(val, bit) == bit
+   return band(val, bit) == tobit(bit)
 end
 
 if CLIENT then
@@ -357,13 +358,28 @@ end
 -- Like string.FormatTime but simpler (and working), always a string, no hour
 -- support
 function util.SimpleTime(seconds, fmt)
-	if not seconds then seconds = 0 end
+   if not seconds then seconds = 0 end
 
-    local ms = (seconds - math.floor(seconds)) * 100
-    seconds = math.floor(seconds)
-    local s = seconds % 60
-    seconds = (seconds - s) / 60
-    local m = seconds % 60
+   local ms = (seconds - math.floor(seconds)) * 100
+   seconds = math.floor(seconds)
+   local s = seconds % 60
+   seconds = (seconds - s) / 60
+   local m = seconds % 60
 
-    return string.format(fmt, m, s, ms)
+   return string.format(fmt, m, s, ms)
+end
+
+-- Returns the number of bits required to network an integer
+function util.BitsRequired(num, signed)
+   local bits, max = 0, 1
+   while max <= num do
+      bits = bits + 1
+      max = max + max
+   end
+
+   if signed then
+      bits = math.min(bits + 1, 32)
+   end
+
+   return bits
 end

--- a/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
@@ -337,6 +337,8 @@ function GM:TTTCanOrderEquipment(ply, id, is_item)
    return true
 end
 
+local bitsRequired = util.BitsRequired
+
 -- Equipment buying
 local function OrderEquipment(ply, cmd, args)
    if not IsValid(ply) or #args != 1 then return end
@@ -349,7 +351,7 @@ local function OrderEquipment(ply, cmd, args)
    -- it's an item if the arg is an id instead of an ent name
    local id = args[1]
    local is_item = tonumber(id)
-   
+
    if not hook.Run("TTTCanOrderEquipment", ply, id, is_item) then return end
 
    -- we use weapons.GetStored to save time on an unnecessary copy, we will not
@@ -416,9 +418,13 @@ local function OrderEquipment(ply, cmd, args)
                    function()
                       if not IsValid(ply) then return end
                       net.Start("TTT_BoughtItem")
-                      net.WriteBit(is_item)
+                      net.WriteBool(is_item)
                       if is_item then
-                         net.WriteUInt(id, 16)
+                         -- since we only network one item here, convert the bitflag equipment id
+                         -- into a power of two exponent before networking it
+
+                         local exponent = math.log(math.abs(id)) / math.log(2)
+                         net.WriteUInt(exponent, bitsRequired(bitsRequired(EQUIP_MAX)))
                       else
                          net.WriteString(id)
                       end

--- a/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
@@ -423,8 +423,8 @@ local function OrderEquipment(ply, cmd, args)
                          -- since we only network one item here, convert the bitflag equipment id
                          -- into a power of two exponent before networking it
 
-                         local exponent = math.log(math.abs(id)) / math.log(2)
-                         net.WriteUInt(exponent, bitsRequired(bitsRequired(EQUIP_MAX)))
+                         local exponent = math.log(id) / math.log(2)
+                         net.WriteUInt(exponent, bitsRequired(math.log(EQUIP_MAX) / math.log(2)))
                       else
                          net.WriteString(id)
                       end


### PR DESCRIPTION
Also includes net message optimizations to save 12 bits on TTT_Equipment and 14 bits on TTT_BoughtItem by default.

If the bitwise library is ever updated to support numbers greater than a 32-bit signed int in the future, the limit could in theory be raised to 53. However, 32 items is already way more than plenty.