### PR TITLE
TTT: Added ability to use parameters when defining radio sound names

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_radio.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_radio.lua
@@ -1,6 +1,7 @@
 --- Traitor radio controls
 
 local GetTranslation = LANG.GetTranslation
+local GetPTranslation = LANG.GetParamTranslation
 local TryTranslation = LANG.TryTranslation
 
 TRADIO.SoundOrder = {
@@ -44,7 +45,15 @@ local function CreateSoundBoard(parent)
    for ri, snd in ipairs(sorder) do
       local but = grid:Add("DButton")
       but:SetSize(bw, bh)
-      but:SetText(TryTranslation(TRADIO.Sounds[snd].name))
+
+      local name = TRADIO.Sounds[snd].name
+      local name_params = TRADIO.Sounds[snd].name_params
+      local translated = TryTranslation(name)
+      if name_params and name != translated then
+         translated = GetPTranslation(name, name_params)
+      end
+      but:SetText(translated)
+
       but.snd = snd
       but.DoClick = ButtonClickPlay
    end
@@ -78,4 +87,5 @@ function TRADIO.CreateMenu(parent)
 
    return wrap
 end
+
 

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_radio.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_radio.lua
@@ -87,5 +87,3 @@ function TRADIO.CreateMenu(parent)
 
    return wrap
 end
-
-

--- a/garrysmod/gamemodes/terrortown/gamemode/radio_shd.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/radio_shd.lua
@@ -8,6 +8,7 @@ TRADIO = {}
 -- or how the sound is played on the server:
 --
 -- name: The name of the sound shown in the T menu. Can be localized.
+-- name_params: The parameters to use when localizing the name, if any.
 -- sound: The sound to be played, or a table of sounds to pick from randomly.
 -- serial: If true, play through the sound table in sequential order instead of randomly.
 -- times: The number of times to repeat the sound. If set to a table, randomizes the number of times within the range {min, max}.


### PR DESCRIPTION
Reviewed with @figardo prior to submitting

The updated translation logic preserves the fallback to the untranslated name when the translation string does not exist