### PR TITLE
Added a variable that allows hiding help for specific tools

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/cl_init.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/cl_init.lua
@@ -58,6 +58,7 @@ function SWEP:DrawHUD()
 	toolObject:DrawHUD()
 
 	if ( !gmod_drawhelp:GetBool() ) then return end
+	if ( toolObject.HideHelp ) then return end
 
 	-- This could probably all suck less than it already does
 


### PR DESCRIPTION
I noticed that in GMod, it is not possible to hide the help for certain specific tools natively.

I decided to add a HideHelp variable to the tool that allows you to hide (if it is true) the HUD.

```lua
TOOL.HideHelp = true
```