### PR TITLE
Replace `hook.Call(name, GAMEMODE, ...)` with `hook.Run(name, ...)` everywhere

### DIFF
--- a/garrysmod/gamemodes/base/entities/entities/gmod_hands.lua
+++ b/garrysmod/gamemodes/base/entities/entities/gmod_hands.lua
@@ -21,7 +21,7 @@ function ENT:DoSetup( ply, spec )
 	self:SetOwner( ply )
 
 	-- Which hands should we use? Let the gamemode decide
-	hook.Call( "PlayerSetHandsModel", GAMEMODE, spec or ply, self )
+	hook.Run( "PlayerSetHandsModel", spec or ply, self )
 
 	-- Attach them to the viewmodel
 	local vm = ( spec or ply ):GetViewModel( 0 )

--- a/garrysmod/gamemodes/base/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/base/gamemode/cl_init.lua
@@ -606,7 +606,7 @@ function GM:PostDrawViewModel( ViewModel, Player, Weapon )
 		local hands = Player:GetHands()
 		if ( IsValid( hands ) && IsValid( hands:GetParent() ) ) then
 
-			if ( not hook.Call( "PreDrawPlayerHands", self, hands, ViewModel, Player, Weapon ) ) then
+			if ( not hook.Run( "PreDrawPlayerHands", hands, ViewModel, Player, Weapon ) ) then
 
 				if ( Weapon.ViewModelFlip ) then render.CullMode( MATERIAL_CULLMODE_CW ) end
 				hands:DrawModel()
@@ -614,7 +614,7 @@ function GM:PostDrawViewModel( ViewModel, Player, Weapon )
 
 			end
 
-			hook.Call( "PostDrawPlayerHands", self, hands, ViewModel, Player, Weapon )
+			hook.Run( "PostDrawPlayerHands", hands, ViewModel, Player, Weapon )
 
 		end
 

--- a/garrysmod/gamemodes/base/gamemode/player.lua
+++ b/garrysmod/gamemodes/base/gamemode/player.lua
@@ -248,11 +248,11 @@ function GM:PlayerSpawn( pl, transiton )
 	-- If we are in transition, do not touch player's weapons
 	if ( !transiton ) then
 		-- Call item loadout function
-		hook.Call( "PlayerLoadout", GAMEMODE, pl )
+		hook.Run( "PlayerLoadout", pl )
 	end
 
 	-- Set player model
-	hook.Call( "PlayerSetModel", GAMEMODE, pl )
+	hook.Run( "PlayerSetModel", pl )
 
 	pl:SetupHands()
 
@@ -312,7 +312,7 @@ function GM:PlayerSelectTeamSpawn( TeamID, pl )
 	for i = 0, 6 do
 
 		ChosenSpawnPoint = table.Random( SpawnPoints )
-		if ( hook.Call( "IsSpawnpointSuitable", GAMEMODE, pl, ChosenSpawnPoint, i == 6 ) ) then
+		if ( hook.Run( "IsSpawnpointSuitable", pl, ChosenSpawnPoint, i == 6 ) ) then
 			return ChosenSpawnPoint
 		end
 
@@ -462,7 +462,7 @@ function GM:PlayerSelectSpawn( pl, transiton )
 	-- This is needed for single player maps.
 	for k, v in pairs( self.SpawnPoints ) do
 
-		if ( v:HasSpawnFlags( 1 ) && hook.Call( "IsSpawnpointSuitable", GAMEMODE, pl, v, true ) ) then
+		if ( v:HasSpawnFlags( 1 ) && hook.Run( "IsSpawnpointSuitable", pl, v, true ) ) then
 			return v
 		end
 
@@ -478,7 +478,7 @@ function GM:PlayerSelectSpawn( pl, transiton )
 		if ( IsValid( ChosenSpawnPoint ) && ChosenSpawnPoint:IsInWorld() ) then
 			if ( ( ChosenSpawnPoint == pl:GetVar( "LastSpawnpoint" ) || ChosenSpawnPoint == self.LastSpawnPoint ) && Count > 1 ) then continue end
 
-			if ( hook.Call( "IsSpawnpointSuitable", GAMEMODE, pl, ChosenSpawnPoint, i == Count ) ) then
+			if ( hook.Run( "IsSpawnpointSuitable", pl, ChosenSpawnPoint, i == Count ) ) then
 
 				self.LastSpawnPoint = ChosenSpawnPoint
 				pl:SetVar( "LastSpawnpoint", ChosenSpawnPoint )
@@ -846,7 +846,7 @@ end
 function GM:PlayerButtonDown( ply, btn ) end
 function GM:PlayerButtonUp( ply, btn ) end
 
-concommand.Add( "changeteam", function( pl, cmd, args ) hook.Call( "PlayerRequestTeam", GAMEMODE, pl, tonumber( args[ 1 ] ) ) end )
+concommand.Add( "changeteam", function( pl, cmd, args ) hook.Run( "PlayerRequestTeam", pl, tonumber( args[ 1 ] ) ) end )
 
 --[[---------------------------------------------------------
 	Name: gamemode:HandlePlayerArmorReduction()

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/contextmenu.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/contextmenu.lua
@@ -238,14 +238,14 @@ function GM:OnContextMenuOpen()
 	contextMenuLastOpen = SysTime()
 
 	-- Let the gamemode decide whether we should open or not..
-	if ( !hook.Call( "ContextMenuOpen", self ) ) then return end
+	if ( !hook.Run( "ContextMenuOpen" ) ) then return end
 
 	if ( IsValid( g_ContextMenu ) && !g_ContextMenu:IsVisible() ) then
 		g_ContextMenu:Open()
 		menubar.ParentTo( g_ContextMenu )
 	end
 
-	hook.Call( "ContextMenuOpened", self )
+	hook.Run( "ContextMenuOpened" )
 
 end
 
@@ -254,6 +254,6 @@ function GM:OnContextMenuClose()
 	if ( SysTime() - contextMenuLastOpen < 0.200 ) then return end
 
 	if ( IsValid( g_ContextMenu ) ) then g_ContextMenu:Close() end
-	hook.Call( "ContextMenuClosed", self )
+	hook.Run( "ContextMenuClosed" )
 
 end

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/content.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/content.lua
@@ -55,7 +55,7 @@ end
 
 function PANEL:CallPopulateHook( HookName )
 
-	hook.Call( HookName, GAMEMODE, self, self.ContentNavBar.Tree, self.OldSpawnlists )
+	hook.Run( HookName, self, self.ContentNavBar.Tree, self.OldSpawnlists )
 
 end
 
@@ -91,7 +91,7 @@ local function CreateContentPanel()
 	ctrl.OldSpawnlists = ctrl.ContentNavBar.Tree:AddNode( "#spawnmenu.category.browse", "icon16/cog.png" )
 
 	ctrl:EnableModify()
-	hook.Call( "PopulatePropMenu", GAMEMODE )
+	hook.Run( "PopulatePropMenu" )
 	ctrl:CallPopulateHook( "PopulateContent" )
 
 	ctrl.OldSpawnlists:MoveToFront()

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contentsidebar.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contentsidebar.lua
@@ -9,7 +9,7 @@ function PANEL:Init()
 
 	self.Tree = vgui.Create( "DTree", self )
 	self.Tree:SetClickOnDragHover( true )
-	self.Tree.OnNodeSelected = function( Tree, Node ) hook.Call( "ContentSidebarSelection", GAMEMODE, self:GetParent(), Node ) end
+	self.Tree.OnNodeSelected = function( Tree, Node ) hook.Run( "ContentSidebarSelection", self:GetParent(), Node ) end
 	self.Tree:Dock( FILL )
 	self.Tree:SetBackgroundColor( Color( 240, 240, 240, 255 ) )
 

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/spawnmenu.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/spawnmenu.lua
@@ -265,14 +265,14 @@ function GM:OnSpawnMenuOpen()
 	spawnMenuLastOpen = SysTime()
 
 	-- Let the gamemode decide whether we should open or not..
-	if ( !hook.Call( "SpawnMenuOpen", self ) ) then return end
+	if ( !hook.Run( "SpawnMenuOpen" ) ) then return end
 
 	if ( IsValid( g_SpawnMenu ) ) then
 		g_SpawnMenu:Open()
 		menubar.ParentTo( g_SpawnMenu )
 	end
 
-	hook.Call( "SpawnMenuOpened", self )
+	hook.Run( "SpawnMenuOpened" )
 
 end
 
@@ -281,7 +281,7 @@ function GM:OnSpawnMenuClose()
 	if ( SysTime() - spawnMenuLastOpen < 0.200 ) then return end
 
 	if ( IsValid( g_SpawnMenu ) ) then g_SpawnMenu:Close() end
-	hook.Call( "SpawnMenuClosed", self )
+	hook.Run( "SpawnMenuClosed" )
 
 end
 

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_wtester.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_wtester.lua
@@ -190,7 +190,7 @@ function SWEP:AddPlayerSample(corpse, killer)
 
          DamageLog("SAMPLE:\t " .. self:GetOwner():Nick() .. " retrieved DNA of " .. (IsValid(killer) and killer:Nick() or "<disconnected>") .. " from corpse of " .. (IsValid(corpse) and CORPSE.GetPlayerNick(corpse) or "<invalid>"))
 
-         hook.Call("TTTFoundDNA", GAMEMODE, self:GetOwner(), killer, corpse)
+         hook.Run("TTTFoundDNA", self:GetOwner(), killer, corpse)
       end
       return true
    end
@@ -217,7 +217,7 @@ function SWEP:AddItemSample(ent)
             DamageLog("SAMPLE:\t " .. self:GetOwner():Nick() .. " retrieved DNA of " .. (IsValid(p) and p:Nick() or "<disconnected>") .. " from " .. ent:GetClass())
 
             new = new + 1
-            hook.Call("TTTFoundDNA", GAMEMODE, self:GetOwner(), p, ent)
+            hook.Run("TTTFoundDNA", self:GetOwner(), p, ent)
          end
       end
       return new, old, own
@@ -232,9 +232,9 @@ function SWEP:RemoveItemSample(idx)
       end
 
       table.remove(self.ItemSamples, idx)
-      
+
       self:SendPrints(false)
-   end   
+   end
 end
 
 function SWEP:SecondaryAttack()
@@ -316,7 +316,7 @@ if SERVER then
       local pos = target:LocalToWorld(target:OBBCenter())
 
       self:SendScan(pos)
-      
+
       self:SetLastScanned(idx)
       self.NowRepeating = self:GetRepeating()
 
@@ -334,7 +334,7 @@ if SERVER then
          end
       elseif self.NowRepeating and IsValid(self:GetOwner()) then
          -- owner changed his mind since running last scan?
-         if self:GetRepeating() then 
+         if self:GetRepeating() then
             self:PerformScan(self:GetLastScanned(), true)
          else
             self.NowRepeating = self:GetRepeating()
@@ -362,7 +362,7 @@ if CLIENT then
    local T = LANG.GetTranslation
    local PT = LANG.GetParamTranslation
    local TT = LANG.TryTranslation
-   
+
    function SWEP:DrawHUD()
       self:DrawHelp()
 
@@ -474,7 +474,7 @@ if CLIENT then
                         scanned_pnl:SetIconColor(COLOR_WHITE)
                      end
 
-      if ilist.VBar then 
+      if ilist.VBar then
          ilist.VBar:Remove()
          ilist.VBar = nil
       end
@@ -576,7 +576,7 @@ if CLIENT then
       mwrap:SetPos(m,100)
       mwrap:SetSize(370, 90)
 
-      
+
       local bar = vgui.Create("TTTProgressBar", mwrap)
       bar:SetSize(370, 35)
       bar:SetPos(0, 0)

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_help.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_help.lua
@@ -185,7 +185,7 @@ function HELPSCRN:Show()
 
    dtabs:AddSheet(GetTranslation("help_settings"), dsettings, "icon16/wrench.png", false, false, GetTranslation("help_settings_tip"))
 
-   hook.Call("TTTSettingsTabs", GAMEMODE, dtabs)
+   hook.Run("TTTSettingsTabs", dtabs)
 
    dframe:MakePopup()
 end

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_hud.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_hud.lua
@@ -318,48 +318,48 @@ end
 function GM:HUDPaint()
    local client = LocalPlayer()
 
-   if hook.Call( "HUDShouldDraw", GAMEMODE, "TTTTargetID" ) then
-       hook.Call( "HUDDrawTargetID", GAMEMODE )
+   if hook.Run( "HUDShouldDraw", "TTTTargetID" ) then
+       hook.Run( "HUDDrawTargetID" )
    end
-   
-   if hook.Call( "HUDShouldDraw", GAMEMODE, "TTTMStack" ) then
+
+   if hook.Run( "HUDShouldDraw", "TTTMStack" ) then
        MSTACK:Draw(client)
    end
 
    if (not client:Alive()) or client:Team() == TEAM_SPEC then
-      if hook.Call( "HUDShouldDraw", GAMEMODE, "TTTSpecHUD" ) then
+      if hook.Run( "HUDShouldDraw", "TTTSpecHUD" ) then
           SpecHUDPaint(client)
       end
 
       return
    end
 
-   if hook.Call( "HUDShouldDraw", GAMEMODE, "TTTRadar" ) then
+   if hook.Run( "HUDShouldDraw", "TTTRadar" ) then
        RADAR:Draw(client)
    end
-   
-   if hook.Call( "HUDShouldDraw", GAMEMODE, "TTTTButton" ) then
+
+   if hook.Run( "HUDShouldDraw", "TTTTButton" ) then
        TBHUD:Draw(client)
    end
-   
-   if hook.Call( "HUDShouldDraw", GAMEMODE, "TTTWSwitch" ) then
+
+   if hook.Run( "HUDShouldDraw", "TTTWSwitch" ) then
        WSWITCH:Draw(client)
    end
 
-   if hook.Call( "HUDShouldDraw", GAMEMODE, "TTTVoice" ) then
+   if hook.Run( "HUDShouldDraw", "TTTVoice" ) then
        VOICE.Draw(client)
    end
-   
-   if hook.Call( "HUDShouldDraw", GAMEMODE, "TTTDisguise" ) then
+
+   if hook.Run( "HUDShouldDraw", "TTTDisguise" ) then
        DISGUISE.Draw(client)
    end
 
-   if hook.Call( "HUDShouldDraw", GAMEMODE, "TTTPickupHistory" ) then
-       hook.Call( "HUDDrawPickupHistory", GAMEMODE )
+   if hook.Run( "HUDShouldDraw", "TTTPickupHistory" ) then
+       hook.Run( "HUDDrawPickupHistory" )
    end
 
    -- Draw bottom left info panel
-   if hook.Call( "HUDShouldDraw", GAMEMODE, "TTTInfoPanel" ) then
+   if hook.Run( "HUDShouldDraw", "TTTInfoPanel" ) then
        InfoPaint(client)
    end
 end

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
@@ -127,11 +127,11 @@ local function RoundStateChange(o, n)
    -- players, which hooking code may not expect
    if n == ROUND_PREP then
       -- can enter PREP from any phase due to ttt_roundrestart
-      hook.Call("TTTPrepareRound", GAMEMODE)
+      hook.Run("TTTPrepareRound")
    elseif (o == ROUND_PREP) and (n == ROUND_ACTIVE) then
-      hook.Call("TTTBeginRound", GAMEMODE)
+      hook.Run("TTTBeginRound")
    elseif (o == ROUND_ACTIVE) and (n == ROUND_POST) then
-      hook.Call("TTTEndRound", GAMEMODE)
+      hook.Run("TTTEndRound")
    end
 
    -- whatever round state we get, clear out the voice flags

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_lang.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_lang.lua
@@ -143,7 +143,7 @@ function LANG.SetActiveLanguage(lang_name)
 
       -- some interface elements will want to know so they can update themselves
       if old_name != lang_name then
-         hook.Call("TTTLanguageChanged", GAMEMODE, old_name, lang_name)
+         hook.Run("TTTLanguageChanged", old_name, lang_name)
       end
    else
       MsgN(Format("The language '%s' does not exist on this server. Falling back to English...", lang_name))

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -148,7 +148,7 @@ function GM:HUDDrawTargetID()
 
    local L = GetLang()
 
-   if hook.Call( "HUDShouldDraw", GAMEMODE, "TTTPropSpec" ) then
+   if hook.Run( "HUDShouldDraw", "TTTPropSpec" ) then
       DrawPropSpecLabels(client)
    end
 

--- a/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
@@ -88,7 +88,7 @@ local function IdentifyBody(ply, rag)
          end
          SCORE:HandleBodyFound(ply, deadply)
       end
-      hook.Call( "TTTBodyFound", GAMEMODE, ply, deadply, rag )
+      hook.Run( "TTTBodyFound", ply, deadply, rag )
       CORPSE.SetFound(rag, true)
    end
 

--- a/garrysmod/gamemodes/terrortown/gamemode/gamemsg.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/gamemsg.lua
@@ -255,7 +255,7 @@ local function MuteTeam(ply, cmd, args)
 
    -- remove all ifs
    LANG.Msg(ply, MuteModes[t])
-   
+
 end
 concommand.Add("ttt_mute_team", MuteTeam)
 
@@ -364,7 +364,7 @@ local function RadioCommand(ply, cmd, args)
          name = LANG.NameParam(msg_target)
       end
 
-      if hook.Call("TTTPlayerRadioCommand", GAMEMODE, ply, msg_name, msg_target) then
+      if hook.Run("TTTPlayerRadioCommand", ply, msg_name, msg_target) then
          return
       end
 

--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -310,7 +310,7 @@ local function WinChecker()
       if CurTime() > GetGlobalFloat("ttt_round_end", 0) then
          EndRound(WIN_TIMELIMIT)
       else
-         local win = hook.Call("TTTCheckForWin", GAMEMODE)
+         local win = hook.Run("TTTCheckForWin")
          if win != WIN_NONE then
             EndRound(win)
          end
@@ -327,7 +327,7 @@ local function NameChangeKick()
    if GetRoundState() == ROUND_ACTIVE then
       for _, ply in ipairs(player.GetHumans()) do
          if ply.spawn_nick then
-            if ply.has_spawned and ply.spawn_nick != ply:Nick() and not hook.Call("TTTNameChangeKick", GAMEMODE, ply) then
+            if ply.has_spawned and ply.spawn_nick != ply:Nick() and not hook.Run("TTTNameChangeKick", ply) then
                local t = GetConVar("ttt_namechange_bantime"):GetInt()
                local msg = "Changed name during a round"
                if t > 0 then
@@ -442,7 +442,7 @@ function PrepareRound()
    -- Check playercount
    if CheckForAbort() then return end
 
-   local delay_round, delay_length = hook.Call("TTTDelayRoundStartForVote", GAMEMODE)
+   local delay_round, delay_length = hook.Run("TTTDelayRoundStartForVote")
 
    if delay_round then
       delay_length = delay_length or 30
@@ -468,7 +468,7 @@ function PrepareRound()
 
    -- New look. Random if no forced model set.
    GAMEMODE.playermodel = GAMEMODE.force_plymodel == "" and GetRandomPlayerModel() or GAMEMODE.force_plymodel
-   GAMEMODE.playercolor = hook.Call("TTTPlayerColor", GAMEMODE, GAMEMODE.playermodel)
+   GAMEMODE.playercolor = hook.Run("TTTPlayerColor", GAMEMODE.playermodel)
 
    if CheckForAbort() then return end
 
@@ -762,7 +762,7 @@ function EndRound(type)
 
    -- server plugins might want to start a map vote here or something
    -- these hooks are not used by TTT internally
-   hook.Call("TTTEndRound", GAMEMODE, type)
+   hook.Run("TTTEndRound", type)
 
    ents.TTT.TriggerRoundStateOutputs(ROUND_POST, type)
 end

--- a/garrysmod/gamemodes/terrortown/gamemode/karma.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/karma.lua
@@ -334,7 +334,7 @@ end
 local reason = "Karma too low"
 function KARMA.CheckAutoKick(ply)
    if ply:GetBaseKarma() <= config.kicklevel:GetInt() then
-      if hook.Call("TTTKarmaLow", GAMEMODE, ply) == false then
+      if hook.Run("TTTKarmaLow", ply) == false then
          return
       end
       ServerLog(ply:Nick() .. " autokicked/banned for low karma.\n")

--- a/garrysmod/gamemodes/terrortown/gamemode/player.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player.lua
@@ -85,9 +85,9 @@ function GM:PlayerSpawn(ply)
    ply:UnSpectate()
 
    -- ye olde hooks
-   hook.Call("PlayerLoadout", GAMEMODE, ply)
-   hook.Call("PlayerSetModel", GAMEMODE, ply)
-   hook.Call("TTTPlayerSetColor", GAMEMODE, ply)
+   hook.Run("PlayerLoadout", ply)
+   hook.Run("PlayerSetModel", ply)
+   hook.Run("TTTPlayerSetColor", ply)
 
    ply:SetupHands()
 

--- a/garrysmod/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player_ext.lua
@@ -265,8 +265,8 @@ end
 -- Preps a player for a new round, spawning them if they should. If dead_only is
 -- true, only spawns if player is dead, else just makes sure he is healed.
 function plymeta:SpawnForRound(dead_only)
-   hook.Call("PlayerSetModel", GAMEMODE, self)
-   hook.Call("TTTPlayerSetColor", GAMEMODE, self)
+   hook.Run("PlayerSetModel", self)
+   hook.Run("TTTPlayerSetColor", self)
 
    -- wrong alive status and not a willing spec who unforced after prep started
    -- (and will therefore be "alive")

--- a/garrysmod/gamemodes/terrortown/gamemode/shared.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/shared.lua
@@ -174,7 +174,7 @@ function GM:Move(ply, mv)
          basemul = 120 / 220
          slowed = true
       end
-      local mul = hook.Call("TTTPlayerSpeedModifier", GAMEMODE, ply, slowed, mv) or 1
+      local mul = hook.Run("TTTPlayerSpeedModifier", ply, slowed, mv) or 1
       mul = basemul * mul
       mv:SetMaxClientSpeed(mv:GetMaxClientSpeed() * mul)
       mv:SetMaxSpeed(mv:GetMaxSpeed() * mul)

--- a/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -118,7 +118,7 @@ end
 
 local function ColorForPlayer(ply)
    if IsValid(ply) then
-      local c = hook.Call("TTTScoreboardColorForPlayer", GAMEMODE, ply)
+      local c = hook.Run("TTTScoreboardColorForPlayer", ply)
 
       -- verify that we got a proper color
       if c and istable(c) and c.r and c.b and c.g and c.a then
@@ -139,7 +139,7 @@ function PANEL:Paint(width, height)
 
    local ply = self.Player
 
-   local c = hook.Call("TTTScoreboardRowColorForPlayer", GAMEMODE, ply)
+   local c = hook.Run("TTTScoreboardRowColorForPlayer", ply)
 
    surface.SetDrawColor(c)
    surface.DrawRect(0, 0, width, SB_ROW_HEIGHT)

--- a/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
@@ -178,7 +178,7 @@ end
 
 function GM:UpdatePlayerLoadouts()
    for _, ply in player.Iterator() do
-      hook.Call("PlayerLoadout", GAMEMODE, ply)
+      hook.Run("PlayerLoadout", ply)
    end
 end
 
@@ -431,7 +431,7 @@ local function OrderEquipment(ply, cmd, args)
                       net.Send(ply)
                    end)
 
-      hook.Call("TTTOrderedEquipment", GAMEMODE, ply, id, is_item)
+      hook.Run("TTTOrderedEquipment", ply, id, is_item)
    end
 end
 concommand.Add("ttt_order_equipment", OrderEquipment)


### PR DESCRIPTION
Essentially, `hook.Call(name, GAMEMODE, ...)` is `hook.Run`, so i think it's a good practice to call it everywhere instead of `hook.Call`