### PR TITLE
Don't call MsgAll in the PlayerDeath hook if SendDeathNotice returned anything 

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/cl_deathnotice.lua
+++ b/garrysmod/gamemodes/base/gamemode/cl_deathnotice.lua
@@ -205,7 +205,7 @@ end
 -----------------------------------------------------------]]
 function GM:AddDeathNotice( attacker, team1, inflictor, victim, team2, flags )
 
-	if ( !hook.Run( "ShouldAddDeathNotice", attacker, inflictor, victim, flags ) ) then
+	if ( hook.Run( "ShouldAddDeathNotice", attacker, inflictor, victim, flags ) == false ) then
 		return
 	end
 

--- a/garrysmod/gamemodes/base/gamemode/cl_deathnotice.lua
+++ b/garrysmod/gamemodes/base/gamemode/cl_deathnotice.lua
@@ -205,10 +205,6 @@ end
 -----------------------------------------------------------]]
 function GM:AddDeathNotice( attacker, team1, inflictor, victim, team2, flags )
 
-	if ( hook.Run( "ShouldAddDeathNotice", attacker, inflictor, victim, flags ) == false ) then
-		return
-	end
-
 	if ( inflictor == "suicide" ) then attacker = nil end
 
 	local Death = {}

--- a/garrysmod/gamemodes/base/gamemode/cl_deathnotice.lua
+++ b/garrysmod/gamemodes/base/gamemode/cl_deathnotice.lua
@@ -205,6 +205,10 @@ end
 -----------------------------------------------------------]]
 function GM:AddDeathNotice( attacker, team1, inflictor, victim, team2, flags )
 
+	if ( !hook.Run( "ShouldAddDeathNotice", attacker, inflictor, victim, flags ) ) then
+		return
+	end
+
 	if ( inflictor == "suicide" ) then attacker = nil end
 
 	local Death = {}

--- a/garrysmod/gamemodes/base/gamemode/npc.lua
+++ b/garrysmod/gamemodes/base/gamemode/npc.lua
@@ -15,7 +15,7 @@ DEATH_NOTICE_FRIENDLY_ATTACKER = 2
 --DEATH_NOTICE_PENETRATION = 8
 function GM:SendDeathNotice( attacker, inflictor, victim, flags )
 
-	if ( !hook.Run( "ShouldAddDeathNotice", attacker, inflictor, victim, flags ) ) then
+	if ( hook.Run( "ShouldAddDeathNotice", attacker, inflictor, victim, flags ) == false ) then
 		return false
 	end
 

--- a/garrysmod/gamemodes/base/gamemode/npc.lua
+++ b/garrysmod/gamemodes/base/gamemode/npc.lua
@@ -15,10 +15,6 @@ DEATH_NOTICE_FRIENDLY_ATTACKER = 2
 --DEATH_NOTICE_PENETRATION = 8
 function GM:SendDeathNotice( attacker, inflictor, victim, flags )
 
-	if ( hook.Run( "ShouldAddDeathNotice", attacker, inflictor, victim, flags ) == false ) then
-		return false
-	end
-
 	net.Start( "DeathNoticeEvent" )
 
 		if ( isstring( attacker ) ) then
@@ -52,8 +48,6 @@ function GM:SendDeathNotice( attacker, inflictor, victim, flags )
 		net.WriteUInt( flags, 8 )
 
 	net.Broadcast()
-
-	return true
 
 end
 
@@ -133,7 +127,7 @@ function GM:OnNPCKilled( ent, attacker, inflictor )
 			local flags = 0
 			if ( ent:IsNPC() and ent:Disposition( attacker ) != D_HT ) then flags = flags + DEATH_NOTICE_FRIENDLY_VICTIM end
 
-			self:SendDeathNotice( attacker, InflictorClass, self:GetDeathNoticeEntityName( ent ), flags )
+			hook.Run( "SendDeathNotice", attacker, InflictorClass, self:GetDeathNoticeEntityName( ent ), flags )
 
 			return
 		end
@@ -150,7 +144,7 @@ function GM:OnNPCKilled( ent, attacker, inflictor )
 	if ( IsValid( Entity( 1 ) ) and ent:IsNPC() and ent:Disposition( Entity( 1 ) ) == D_LI ) then flags = flags + DEATH_NOTICE_FRIENDLY_VICTIM end
 	if ( IsValid( Entity( 1 ) ) and AttackerClass:IsNPC() and AttackerClass:Disposition( Entity( 1 ) ) == D_LI ) then flags = flags + DEATH_NOTICE_FRIENDLY_ATTACKER end
 
-	self:SendDeathNotice( self:GetDeathNoticeEntityName( AttackerClass ), InflictorClass, self:GetDeathNoticeEntityName( ent ), flags )
+	hook.Run( "SendDeathNotice", self:GetDeathNoticeEntityName( AttackerClass ), InflictorClass, self:GetDeathNoticeEntityName( ent ), flags )
 
 end
 

--- a/garrysmod/gamemodes/base/gamemode/npc.lua
+++ b/garrysmod/gamemodes/base/gamemode/npc.lua
@@ -127,7 +127,7 @@ function GM:OnNPCKilled( ent, attacker, inflictor )
 			local flags = 0
 			if ( ent:IsNPC() and ent:Disposition( attacker ) != D_HT ) then flags = flags + DEATH_NOTICE_FRIENDLY_VICTIM end
 
-			self:SendDeathNotice( attacker, InflictorClass, self:GetDeathNoticeEntityName( ent ), flags )
+			hook.Run( "SendDeathNotice", attacker, InflictorClass, self:GetDeathNoticeEntityName( ent ), flags )
 
 			return
 		end
@@ -144,7 +144,7 @@ function GM:OnNPCKilled( ent, attacker, inflictor )
 	if ( IsValid( Entity( 1 ) ) and ent:IsNPC() and ent:Disposition( Entity( 1 ) ) == D_LI ) then flags = flags + DEATH_NOTICE_FRIENDLY_VICTIM end
 	if ( IsValid( Entity( 1 ) ) and AttackerClass:IsNPC() and AttackerClass:Disposition( Entity( 1 ) ) == D_LI ) then flags = flags + DEATH_NOTICE_FRIENDLY_ATTACKER end
 
-	self:SendDeathNotice( self:GetDeathNoticeEntityName( AttackerClass ), InflictorClass, self:GetDeathNoticeEntityName( ent ), flags )
+	hook.Run( "SendDeathNotice", self:GetDeathNoticeEntityName( AttackerClass ), InflictorClass, self:GetDeathNoticeEntityName( ent ), flags )
 
 end
 

--- a/garrysmod/gamemodes/base/gamemode/npc.lua
+++ b/garrysmod/gamemodes/base/gamemode/npc.lua
@@ -127,7 +127,7 @@ function GM:OnNPCKilled( ent, attacker, inflictor )
 			local flags = 0
 			if ( ent:IsNPC() and ent:Disposition( attacker ) != D_HT ) then flags = flags + DEATH_NOTICE_FRIENDLY_VICTIM end
 
-			hook.Run( "SendDeathNotice", attacker, InflictorClass, self:GetDeathNoticeEntityName( ent ), flags )
+			self:SendDeathNotice( attacker, InflictorClass, self:GetDeathNoticeEntityName( ent ), flags )
 
 			return
 		end
@@ -144,7 +144,7 @@ function GM:OnNPCKilled( ent, attacker, inflictor )
 	if ( IsValid( Entity( 1 ) ) and ent:IsNPC() and ent:Disposition( Entity( 1 ) ) == D_LI ) then flags = flags + DEATH_NOTICE_FRIENDLY_VICTIM end
 	if ( IsValid( Entity( 1 ) ) and AttackerClass:IsNPC() and AttackerClass:Disposition( Entity( 1 ) ) == D_LI ) then flags = flags + DEATH_NOTICE_FRIENDLY_ATTACKER end
 
-	hook.Run( "SendDeathNotice", self:GetDeathNoticeEntityName( AttackerClass ), InflictorClass, self:GetDeathNoticeEntityName( ent ), flags )
+	self:SendDeathNotice( self:GetDeathNoticeEntityName( AttackerClass ), InflictorClass, self:GetDeathNoticeEntityName( ent ), flags )
 
 end
 

--- a/garrysmod/gamemodes/base/gamemode/npc.lua
+++ b/garrysmod/gamemodes/base/gamemode/npc.lua
@@ -15,6 +15,10 @@ DEATH_NOTICE_FRIENDLY_ATTACKER = 2
 --DEATH_NOTICE_PENETRATION = 8
 function GM:SendDeathNotice( attacker, inflictor, victim, flags )
 
+	if ( !hook.Run( "ShouldAddDeathNotice", attacker, inflictor, victim, flags ) ) then
+		return false
+	end
+
 	net.Start( "DeathNoticeEvent" )
 
 		if ( isstring( attacker ) ) then
@@ -48,6 +52,8 @@ function GM:SendDeathNotice( attacker, inflictor, victim, flags )
 		net.WriteUInt( flags, 8 )
 
 	net.Broadcast()
+
+	return true
 
 end
 

--- a/garrysmod/gamemodes/base/gamemode/player.lua
+++ b/garrysmod/gamemodes/base/gamemode/player.lua
@@ -159,10 +159,8 @@ function GM:PlayerDeath( ply, inflictor, attacker )
 	player_manager.RunClass( ply, "Death", inflictor, attacker )
 
 	if ( attacker == ply ) then
-
-		local bSent = hook.Run( "SendDeathNotice", nil, "suicide", ply, 0 )
-
-		if ( bSent != false ) then
+
+		if ( hook.Run( "SendDeathNotice", nil, "suicide", ply, 0 ) != nil ) then
 			MsgAll( attacker:Nick() .. " suicided!\n" )
 		end
 
@@ -170,10 +168,8 @@ function GM:PlayerDeath( ply, inflictor, attacker )
 	end
 
 	if ( attacker:IsPlayer() ) then
-
-		local bSent = hook.Run( "SendDeathNotice", attacker, inflictor:GetClass(), ply, 0 )
-
-		if ( bSent != false ) then
+
+		if ( hook.Run( "SendDeathNotice", attacker, inflictor:GetClass(), ply, 0 ) != nil ) then
 			MsgAll( attacker:Nick() .. " killed " .. ply:Nick() .. " using " .. inflictor:GetClass() .. "\n" )
 		end
 
@@ -185,10 +181,8 @@ function GM:PlayerDeath( ply, inflictor, attacker )
 
 	local flags = 0
 	if ( attacker:IsNPC() and attacker:Disposition( ply ) != D_HT ) then flags = flags + DEATH_NOTICE_FRIENDLY_ATTACKER end
-
-	local bSent = hook.Run( "SendDeathNotice", self:GetDeathNoticeEntityName( attacker ), inflictor:GetClass(), ply, 0 )
-
-	if ( bSent != false ) then
+
+	if ( hook.Run( "SendDeathNotice", self:GetDeathNoticeEntityName( attacker ), inflictor:GetClass(), ply, 0 ) != nil ) then
 		MsgAll( ply:Nick() .. " was killed by " .. attacker:GetClass() .. "\n" )
 	end
 

--- a/garrysmod/gamemodes/base/gamemode/player.lua
+++ b/garrysmod/gamemodes/base/gamemode/player.lua
@@ -160,18 +160,22 @@ function GM:PlayerDeath( ply, inflictor, attacker )
 
 	if ( attacker == ply ) then
 
-		self:SendDeathNotice( nil, "suicide", ply, 0 )
+		local bSent = self:SendDeathNotice( nil, "suicide", ply, 0 )
 
-		MsgAll( attacker:Nick() .. " suicided!\n" )
+		if ( bSent ) then
+			MsgAll( attacker:Nick() .. " suicided!\n" )
+		end
 
 		return
 	end
 
 	if ( attacker:IsPlayer() ) then
 
-		self:SendDeathNotice( attacker, inflictor:GetClass(), ply, 0 )
+		local bSent = self:SendDeathNotice( attacker, inflictor:GetClass(), ply, 0 )
 
-		MsgAll( attacker:Nick() .. " killed " .. ply:Nick() .. " using " .. inflictor:GetClass() .. "\n" )
+		if ( bSent ) then
+			MsgAll( attacker:Nick() .. " killed " .. ply:Nick() .. " using " .. inflictor:GetClass() .. "\n" )
+		end
 
 		return
 	end
@@ -182,9 +186,11 @@ function GM:PlayerDeath( ply, inflictor, attacker )
 	local flags = 0
 	if ( attacker:IsNPC() and attacker:Disposition( ply ) != D_HT ) then flags = flags + DEATH_NOTICE_FRIENDLY_ATTACKER end
 
-	self:SendDeathNotice( self:GetDeathNoticeEntityName( attacker ), inflictor:GetClass(), ply, 0 )
+	local bSent = self:SendDeathNotice( self:GetDeathNoticeEntityName( attacker ), inflictor:GetClass(), ply, 0 )
 
-	MsgAll( ply:Nick() .. " was killed by " .. attacker:GetClass() .. "\n" )
+	if ( bSent ) then
+		MsgAll( ply:Nick() .. " was killed by " .. attacker:GetClass() .. "\n" )
+	end
 
 end
 

--- a/garrysmod/gamemodes/base/gamemode/player.lua
+++ b/garrysmod/gamemodes/base/gamemode/player.lua
@@ -160,9 +160,9 @@ function GM:PlayerDeath( ply, inflictor, attacker )
 
 	if ( attacker == ply ) then
 
-		local bSent = self:SendDeathNotice( nil, "suicide", ply, 0 )
+		local bSent = hook.Run( "SendDeathNotice", nil, "suicide", ply, 0 )
 
-		if ( bSent ) then
+		if ( bSent != false ) then
 			MsgAll( attacker:Nick() .. " suicided!\n" )
 		end
 
@@ -171,9 +171,9 @@ function GM:PlayerDeath( ply, inflictor, attacker )
 
 	if ( attacker:IsPlayer() ) then
 
-		local bSent = self:SendDeathNotice( attacker, inflictor:GetClass(), ply, 0 )
+		local bSent = hook.Run( "SendDeathNotice", attacker, inflictor:GetClass(), ply, 0 )
 
-		if ( bSent ) then
+		if ( bSent != false ) then
 			MsgAll( attacker:Nick() .. " killed " .. ply:Nick() .. " using " .. inflictor:GetClass() .. "\n" )
 		end
 
@@ -186,9 +186,9 @@ function GM:PlayerDeath( ply, inflictor, attacker )
 	local flags = 0
 	if ( attacker:IsNPC() and attacker:Disposition( ply ) != D_HT ) then flags = flags + DEATH_NOTICE_FRIENDLY_ATTACKER end
 
-	local bSent = self:SendDeathNotice( self:GetDeathNoticeEntityName( attacker ), inflictor:GetClass(), ply, 0 )
+	local bSent = hook.Run( "SendDeathNotice", self:GetDeathNoticeEntityName( attacker ), inflictor:GetClass(), ply, 0 )
 
-	if ( bSent ) then
+	if ( bSent != false ) then
 		MsgAll( ply:Nick() .. " was killed by " .. attacker:GetClass() .. "\n" )
 	end
 

--- a/garrysmod/gamemodes/base/gamemode/player.lua
+++ b/garrysmod/gamemodes/base/gamemode/player.lua
@@ -160,7 +160,7 @@ function GM:PlayerDeath( ply, inflictor, attacker )
 
 	if ( attacker == ply ) then
 
-		if ( hook.Run( "SendDeathNotice", nil, "suicide", ply, 0 ) != nil ) then
+		if ( hook.Run( "SendDeathNotice", nil, "suicide", ply, 0 ) == nil ) then
 			MsgAll( attacker:Nick() .. " suicided!\n" )
 		end
 
@@ -169,7 +169,7 @@ function GM:PlayerDeath( ply, inflictor, attacker )
 
 	if ( attacker:IsPlayer() ) then
 
-		if ( hook.Run( "SendDeathNotice", attacker, inflictor:GetClass(), ply, 0 ) != nil ) then
+		if ( hook.Run( "SendDeathNotice", attacker, inflictor:GetClass(), ply, 0 ) == nil ) then
 			MsgAll( attacker:Nick() .. " killed " .. ply:Nick() .. " using " .. inflictor:GetClass() .. "\n" )
 		end
 
@@ -182,7 +182,7 @@ function GM:PlayerDeath( ply, inflictor, attacker )
 	local flags = 0
 	if ( attacker:IsNPC() and attacker:Disposition( ply ) != D_HT ) then flags = flags + DEATH_NOTICE_FRIENDLY_ATTACKER end
 
-	if ( hook.Run( "SendDeathNotice", self:GetDeathNoticeEntityName( attacker ), inflictor:GetClass(), ply, 0 ) != nil ) then
+	if ( hook.Run( "SendDeathNotice", self:GetDeathNoticeEntityName( attacker ), inflictor:GetClass(), ply, 0 ) == nil ) then
 		MsgAll( ply:Nick() .. " was killed by " .. attacker:GetClass() .. "\n" )
 	end
 

--- a/garrysmod/gamemodes/base/gamemode/player.lua
+++ b/garrysmod/gamemodes/base/gamemode/player.lua
@@ -159,7 +159,7 @@ function GM:PlayerDeath( ply, inflictor, attacker )
 	player_manager.RunClass( ply, "Death", inflictor, attacker )
 
 	if ( attacker == ply ) then
-
+
 		if ( hook.Run( "SendDeathNotice", nil, "suicide", ply, 0 ) == nil ) then
 			MsgAll( attacker:Nick() .. " suicided!\n" )
 		end
@@ -168,7 +168,7 @@ function GM:PlayerDeath( ply, inflictor, attacker )
 	end
 
 	if ( attacker:IsPlayer() ) then
-
+
 		if ( hook.Run( "SendDeathNotice", attacker, inflictor:GetClass(), ply, 0 ) == nil ) then
 			MsgAll( attacker:Nick() .. " killed " .. ply:Nick() .. " using " .. inflictor:GetClass() .. "\n" )
 		end
@@ -181,7 +181,7 @@ function GM:PlayerDeath( ply, inflictor, attacker )
 
 	local flags = 0
 	if ( attacker:IsNPC() and attacker:Disposition( ply ) != D_HT ) then flags = flags + DEATH_NOTICE_FRIENDLY_ATTACKER end
-
+
 	if ( hook.Run( "SendDeathNotice", self:GetDeathNoticeEntityName( attacker ), inflictor:GetClass(), ply, 0 ) == nil ) then
 		MsgAll( ply:Nick() .. " was killed by " .. attacker:GetClass() .. "\n" )
 	end


### PR DESCRIPTION
Also replaces all the ``GM:SendDeathNotice`` calls with the ``hook.Run``.