### PR TITLE
Menu: Show game language name

### DIFF
--- a/garrysmod/html/css/menu/NavBar.css
+++ b/garrysmod/html/css/menu/NavBar.css
@@ -82,7 +82,7 @@
 	margin-left: -1px;
 }
 
-#NavBar .button SPAN, UL.gamemode_list LI SPAN, UL.language_list LI SPAN
+#NavBar .button SPAN, UL.gamemode_list LI SPAN
 {
 	color: #333;
 	position: relative;
@@ -91,7 +91,7 @@
 	padding-right: 10px;
 }
 
-#NavBar .button IMG, UL.gamemode_list LI IMG, UL.language_list LI IMG
+#NavBar .button IMG, UL.gamemode_list LI IMG
 {
 	position: absolute;
 	left: 5px;
@@ -254,10 +254,11 @@ UL.language_list
 UL.language_list LI
 {
 	display: inline-block;
-	width: 26px;
-	height: 24px;
-	padding: 0;
+	width: auto; 
+	height: auto;
+	padding: 5px;
 	background-color: transparent;
+	position: static;
 }
 
 UL.language_list LI IMG
@@ -268,6 +269,43 @@ UL.language_list LI IMG
 UL.language_list LI:hover
 {
 	background-color: #fff;
+}
+
+UL.language_list LI .lang_name
+{
+	visibility: hidden;
+	display: inline-block;
+	box-sizing: border-box;
+	pointer-events: none;
+	position: absolute;
+	bottom: 100%;
+	left: 50%;
+	-webkit-transform: translate(-50%, 0%);
+	margin-bottom: 8px;
+	background: white;
+	border-radius: 4px;
+	padding: 4px 8px;
+	font-size: 15px;
+	font-weight: bold;
+	text-shadow: none;
+	color: black;
+	text-align: center;
+	width: -webkit-max-content;
+	max-width: 100%;
+	white-space: normal;
+	text-transform: capitalize;
+}
+UL.language_list LI .lang_name div:not(:empty) + div
+{
+	font-size: 12px;
+}
+UL.language_list LI:hover .lang_name
+{
+	visibility: visible;
+}
+html.AWESOMIUM UL.language_list LI .lang_name
+{
+	display: none !important;
 }
 
 ::-webkit-scrollbar
@@ -297,7 +335,6 @@ UL.language_list LI:hover
 	list-style: none;
 	margin: 3px;
 	/*cursor: pointer;*/
-	display: none;
 }
 
 UL.games_list.popup LI

--- a/garrysmod/html/js/menu/common.js
+++ b/garrysmod/html/js/menu/common.js
@@ -3,6 +3,7 @@
 
 var IN_ENGINE		= navigator.userAgent.indexOf( "Valve Source Client" ) != -1;
 var IS_AWESOMIUM 	= navigator.userAgent.toLowerCase().indexOf("awesomium") != -1;
+if ( IS_AWESOMIUM ) document.documentElement.classList.add( "AWESOMIUM" );
 
 function UpdateDigest( scope, timeout )
 {

--- a/garrysmod/html/menu.html
+++ b/garrysmod/html/menu.html
@@ -65,27 +65,31 @@
 			<span ng-Localize="'problems'"></span>
 			<number ng-show="ProblemCount > 0" class="{{IfElse( ProblemSeverity > 0, 'severity' + ProblemSeverity, '' )}}">{{ProblemCount}}</number>
 		</div>
-		<div class="button smallicon" ng-click="TogglePopup('.kinect_settings')" ng-show="kinect.available"><img ng-src='img/kinect.png' loading="lazy"><span></span></div>
-		<div class="button smallicon hidelabel" ng-click="ToggleGames()"><img ng-src='img/games.png'><span ng-Localize="'games'"></span></div>
-		<div class="button smallicon" ng-click="ToggleLanguage()"><img style="margin-top: 9px;" ng-src='../resource/localization/{{Language}}.png'><span></span></div>
-		<div class="button bigicon" ng-click="ToggleGamemodes()"><img ng-src='../gamemodes/{{Gamemode}}/icon24.png'><span>{{GamemodeTitle}}</span></div>
+		<div class="button smallicon" ng-click="TogglePopup('kinect_settings')" ng-show="kinect.available"><img ng-src='img/kinect.png' loading="lazy"><span></span></div>
+		<div class="button smallicon hidelabel" ng-click="TogglePopup('games_list')"><img ng-src='img/games.png'><span ng-Localize="'games'"></span></div>
+		<div class="button smallicon" ng-click="TogglePopup('language_list')"><img style="margin-top: 9px;" ng-src='../resource/localization/{{Language}}.png'><span></span></div>
+		<div class="button bigicon" ng-click="TogglePopup('gamemode_list')"><img ng-src='../gamemodes/{{Gamemode}}/icon24.png'><span>{{GamemodeTitle}}</span></div>
 	</div>
 
 </div>
 
-<ul class="gamemode_list popup">
+<ul class="gamemode_list popup" ng-if="PopupOpen == 'gamemode_list'">
 	<li ng-repeat="gm in Gamemodes|filter:{menusystem:true}|orderBy:'name'" ng-click="SelectGamemode( gm )">
 		<img ng-src='../gamemodes/{{gm.name}}/icon24.png' loading="lazy"><span>{{gm.title}}</span>
 	</li>
 </ul>
 
-<ul class="language_list popup">
+<ul class="language_list popup" ng-if="PopupOpen == 'language_list'">
 	<li ng-repeat="lang in Languages" ng-click="SelectLanguage( lang )">
 		<img ng-src='../resource/localization/{{lang}}.png' loading="lazy">
+		<span class="lang_name">
+			<div lang="{{IfElse( Language == 'en-pt', 'en', Language ) }}" ng-if="lang != Language && !( ['en', 'en-pt'].includes(lang) && ['en', 'en-pt'].includes(Language) )">{{LanguageName(lang, Language)}}</div>
+			<div lang="{{::IfElse( lang == 'en-pt', 'en', lang ) }}">{{::LanguageName(lang, lang)}}</div>
+		</span>
 	</li>
 </ul>
 
-<ul class="games_list popup">
+<ul class="games_list popup" ng-if="PopupOpen == 'games_list'">
 
 	<li class="notowned"><img src='img/notowned.png' width="16" height="16" loading="lazy"> <span ng-Localize="'game_not_owned'"></span></li>
 	<li class="notinstalled"><img src='img/notinstalled.png' width="16" height="16" loading="lazy"> <span ng-Localize="'game_not_installed'"></span></li>
@@ -100,7 +104,7 @@
 
 </ul>
 
-<ul class="kinect_settings popup">
+<ul class="kinect_settings popup" ng-if="PopupOpen == 'kinect_settings'">
 
 	<li>
 		<div>


### PR DESCRIPTION
I've updated the Gmod language list to show the name of the languages on hover. It will show the language name in the language that your game is currently using, and below it will show the name of the language in that language (if different). 

https://github.com/user-attachments/assets/017c3c4f-8754-4d2d-af62-ded31e53b8a5

This feature is provided by CEF and requires no additional localisation work by the Gmod community. The tooltips are hidden on Awesomium, same as current game.

Additional technical changes made in this PR:
- The Gamemodes/Languages/Games/Kinect popup panels have been updated to store which one is open in `$scope.PopupOpen` and to not process when they're not open. This means opening one automatically closes any others, and it means that AngularJS is no longer processing the contents of these panels when they're not visible. The current game processes them multiple times every time you click anything anywhere, and 20+ times per second when the Server List is open. Now they're not processed at all unless they're open. This change was made so that AngularJS doesn't check "has the name of this language changed?" 20+ times per second when the panel isn't even open.
- When javascript receives the current and available languages from Lua, it now lowercases them. This change was made so that it didn't need to be done on every comparison or check.

Some example screenshots:

Gmod is in English, so the English variant is displayed with the native version below
<img width="734" height="240" alt="image" src="https://github.com/user-attachments/assets/f35728c4-461d-40a5-ab99-272caeb6bd52" />

Gmod is in German, so the German variant is displayed with the native version below
<img width="757" height="240" alt="image" src="https://github.com/user-attachments/assets/f0a040c9-5595-4a19-a058-d569a132a119" />

Gmod is in Korean, so the Korean variant is displayed with the native version below
<img width="767" height="244" alt="image" src="https://github.com/user-attachments/assets/da843515-e1db-4d1e-927b-6ddcd874b711" />