### PR TITLE
Change LocalPlayer function to cache local player instance

### DIFF
--- a/garrysmod/lua/includes/extensions/client/globals.lua
+++ b/garrysmod/lua/includes/extensions/client/globals.lua
@@ -12,3 +12,13 @@ function ScreenScaleH( height )
 end
 
 SScale = ScreenScale
+
+local localPly = nil
+C_LocalPlayer = LocalPlayer
+function LocalPlayer()
+	if ( not localPly ) then
+		localPly = C_LocalPlayer()
+		if ( not localPly:IsValid() ) then localPly = nil end
+	end
+	return localPly or NULL
+end


### PR DESCRIPTION
It's not a huge difference and does not allow it to be jitted, but any improvement for a function that is used either in Think/Paint hooks is a win, benchmark result:
```
New: 4.50590 ms (Average: 0.45059 ns)
Old: 317.08870 ms (Average: 31.70887 ns)
Fastest vs slowest: 6937.2% slower (70.37x difference)
```