### PR TITLE
Add returns for `PreDrawHalos`

### DIFF
--- a/garrysmod/lua/includes/modules/halo.lua
+++ b/garrysmod/lua/includes/modules/halo.lua
@@ -137,7 +137,8 @@ end
 
 hook.Add( "PostDrawEffects", "RenderHalos", function()
 
-	hook.Run( "PreDrawHalos" )
+	local call = hook.Run( "PreDrawHalos" )
+	if ( call ) then return end
 
 	if ( #List == 0 ) then return end
 
@@ -148,3 +149,4 @@ hook.Add( "PostDrawEffects", "RenderHalos", function()
 	List = {}
 
 end )
+


### PR DESCRIPTION
Returning return true in the [PreDrawHalos](https://wiki.facepunch.com/gmod/GM:PreDrawHalos) hook will avoid rendering the Halos effect and expand the use of `PreDrawHalos` to avoid artifacts when working with stencils.

**Returns**
1 [boolean](https://wiki.facepunch.com/gmod/boolean)
Return true to disable Hallos effect

