### PR TITLE
Adding a cooldown to the camera

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_camera.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_camera.lua
@@ -84,7 +84,6 @@ end
 function SWEP:PrimaryAttack()
 
 	self:DoShootEffect()
-	self:SetNextPrimaryFire( CurTime() + 0.75 )
 
 	-- If we're multiplayer this can be done totally clientside
 	if ( !game.SinglePlayer() && SERVER ) then return end
@@ -160,6 +159,9 @@ function SWEP:ShouldDropOnDie() return false end
 -- The effect when a weapon is fired successfully
 --
 function SWEP:DoShootEffect()
+
+	if ( self.NextShootEffect && self.NextShootEffect > CurTime() ) then return end
+	self.NextShootEffect = CurTime() + 0.75
 
 	local owner = self:GetOwner()
 

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_camera.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_camera.lua
@@ -161,7 +161,7 @@ function SWEP:ShouldDropOnDie() return false end
 function SWEP:DoShootEffect()
 
 	if ( self.NextShootEffect && self.NextShootEffect > CurTime() ) then return end
-	self.NextShootEffect = CurTime() + 0.75
+	self.NextShootEffect = CurTime() + 0.4
 
 	local owner = self:GetOwner()
 

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_camera.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_camera.lua
@@ -84,6 +84,7 @@ end
 function SWEP:PrimaryAttack()
 
 	self:DoShootEffect()
+	self:SetNextPrimaryFire( CurTime() + 0.75 )
 
 	-- If we're multiplayer this can be done totally clientside
 	if ( !game.SinglePlayer() && SERVER ) then return end


### PR DESCRIPTION
**_Hello,_**
I added a cooldown to the camera to avoid sound and effect spam. Some users who don't have powerful PCs find that players spam the camera a lot, which can cause their PCs to **crash** or **freeze**. 

## Why a cooldown of 0.75 seconds?
I decided to set a ‘high’ cooldown to avoid disturbing players during their gaming sessions. Anything less than this value is too fast and the effect will not end with a ‘rest’ period.


Nevertheless, I propose two solutions for the system: 
## Solution 1
Either we stick with the current code, which limits the total use of the camera with a cooldown of 0.75 seconds.

## Solution 2
Or I create a cooldown only on the DoShootEffect function, which allows players to spam photos but greatly limits the spamming of effects and sound, which can be annoying for the jo