### PR TITLE
Optimize `Player:GetEyeTrace`*

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/obj_player_extend.lua
+++ b/garrysmod/gamemodes/base/gamemode/obj_player_extend.lua
@@ -185,10 +185,19 @@ function meta:GetEyeTrace()
 		self.LastPlayerTrace = framenum
 	end
 
-	local tr = util.TraceLine( util.GetPlayerTrace( self ) )
-	self.PlayerTrace = tr
+	local tracePlayer = self.PlayerTrace
 
-	return tr
+	if ( !tracePlayer ) then
+		tracePlayer = {}
+		self.PlayerTrace = tracePlayer
+	end
+
+	local trdata = util.GetPlayerTrace( self )
+	trdata.output = tracePlayer
+
+	util.TraceLine( trdata )
+
+	return tracePlayer
 end
 
 --[[---------------------------------------------------------
@@ -206,8 +215,17 @@ function meta:GetEyeTraceNoCursor()
 		self.LastPlayerAimTrace = framenum
 	end
 
-	local tr = util.TraceLine( util.GetPlayerTrace( self, self:EyeAngles():Forward() ) )
-	self.PlayerAimTrace = tr
+	local tracePlayerAim = self.PlayerAimTrace
 
-	return tr
+	if ( !tracePlayerAim ) then
+		tracePlayerAim = {}
+		self.PlayerAimTrace = tracePlayerAim
+	end
+
+	local trdata = util.GetPlayerTrace( self, self:EyeAngles():Forward() )
+	trdata.output = tracePlayerAim
+
+	util.TraceLine( trdata )
+
+	return tracePlayerAim
 end


### PR DESCRIPTION
Made these two utilize the `output` field with the [Trace structure](https://wiki.facepunch.com/gmod/Structures/Trace). And that rids of a (`C -> Lua`)-story with `util.TraceLine`.

Here's the performance increase:
<details><summary>Branch — Main</summary>

```
] speedtest_sv 
0.082094858612342 0.025344376551862 3.2x faster
0.039153424506853 0.017074022161352 2.3x faster
] speedtest_sv 
0.093949946837678 0.025120544811937 3.7x faster
0.032141552654087 0.015741309709857 2.0x faster
] speedtest_sv 
0.087140208750049 0.031215391730212 2.8x faster
0.028752100592359 0.02150611901161 1.3x faster
] speedtest_sv 
0.095091945510767 0.024662603344028 3.9x faster
0.027664917855579 0.02079236984093 1.3x faster
] speedtest_sv 
0.087887075882249 0.026455541260777 3.3x faster
0.02734744222446 0.023133467120762 1.2x faster
] speedtest_sv 
0.08515541505622 0.031631079247216 2.7x faster
0.030607848436129 0.02152096499436 1.4x faster
] speedtest_sv 
0.0861535218965 0.037725926165492 2.3x faster
0.029938637213699 0.024089320010137 1.2x faster

] speedtest_cl 
0.075460988320368 0.0034728179648634 21.7x faster
0.031687037182198 0.0018671678305004 17.0x faster
] speedtest_cl 
0.077420658043389 0.0041054852297546 18.9x faster
0.034624257769382 0.0018306238729615 18.9x faster
] speedtest_cl 
0.081952108778206 0.0032661162050343 25.1x faster
0.03888619681735 0.0020955675651181 18.6x faster
] speedtest_cl 
0.086225467812904 0.0036064318096148 23.9x faster
0.033333799268792 0.001940255745578 17.2x faster
] speedtest_cl 
0.084305768043442 0.0032729681970728 25.8x faster
0.039209382441834 0.0018945757986545 20.7x faster
] speedtest_cl 
0.080654798285577 0.0032455602289187 24.9x faster
0.036688991370327 0.0016775960507676 21.9x faster
] speedtest_cl 
0.081741981022357 0.0035767398441144 22.9x faster
0.040125265377652 0.0019425397429242 20.7x faster
```
</details>

<details><summary>Branch — x64</summary>

```
] speedtest_sv 
0.073313982589666 0.026776425274618 2.7x faster
0.022166179663937 0.016634341730289 1.3x faster
] speedtest_sv 
0.082615555663482 0.028452878223956 2.9x faster
0.022106795771998 0.017766061670884 1.2x faster
] speedtest_sv 
0.076650900517437 0.02875664967118 2.7x faster
0.023444075338535 0.018622560112304 1.3x faster
] speedtest_sv 
0.074406874600917 0.027776815454196 2.7x faster
0.023347005515174 0.094077788805519 0.2x faster
] speedtest_sv 
0.072975951204786 0.1098876080362 0.7x faster
0.028248460595937 0.01925979495272 1.5x faster
] speedtest_sv 
0.073285432641619 0.02740566612958 2.7x faster
0.022352325325205 0.016857031325058 1.3x faster
] speedtest_sv 
0.074548482343232 0.028383216350721 2.6x faster
0.02223469953925 0.017120832845015 1.3x faster

] speedtest_cl 
0.077714100582719 0.0034396977407407 22.6x faster
0.027599805776302 0.0021298261243298 13.0x faster
] speedtest_cl 
0.20006433194053 0.0045051818018666 44.4x faster
0.030489060518691 0.002873266771482 10.6x faster
] speedtest_cl 
0.073713681862329 0.0034282777615218 21.5x faster
0.02546883765405 0.002138962107705 11.9x faster
] speedtest_cl 
0.076753680330407 0.0036612453375879 21.0x faster
0.026828957179025 0.002191494012112 12.2x faster
] speedtest_cl 
0.081409605857963 0.0036463993646033 22.3x faster
0.025753195136602 0.0024084736172717 10.7x faster
] speedtest_cl 
0.083212820576632 0.0045520037166642 18.3x faster
0.03164704641149 0.0024701415050539 12.8x faster
] speedtest_cl 
0.079493333345027 0.0048317932075279 16.5x faster
0.13688443890974 0.0029303666675766 46.7x faster
```
</details>

Mostly somewhere around 1.4–2.5x faster on the server. And above 10x on the client.

Here's the code for test:
<details>

```lua
local CPlayer = FindMetaTable( 'Player' )

function CPlayer:GetEyeTrace_2()
	if ( CLIENT ) then
		local framenum = FrameNumber()

		if ( self.LastPlayerTrace == framenum ) then
			return self.PlayerTrace
		end

		self.LastPlayerTrace = framenum
	end

	local tracePlayer = self.PlayerTrace

	if ( !tracePlayer ) then
		tracePlayer = {}
		self.PlayerTrace = tracePlayer
	end

	local trdata = util.GetPlayerTrace( self )
	trdata.output = tracePlayer

	util.TraceLine( trdata )

	return tracePlayer
end

function CPlayer:GetEyeTraceNoCursor_2()
	if ( CLIENT ) then
		local framenum = FrameNumber()

		if ( self.LastPlayerAimTrace == framenum ) then
			return self.PlayerAimTrace
		end

		self.LastPlayerTrace = framenum
	end

	local tracePlayerAim = self.PlayerAimTrace

	if ( !tracePlayerAim ) then
		tracePlayerAim = {}
		self.PlayerAimTrace = tracePlayerAim
	end

	local trdata = util.GetPlayerTrace( self, self:EyeAngles():Forward() )
	trdata.output = tracePlayerAim

	util.TraceLine( trdata )

	return tracePlayerAim
end

concommand.Add( 'speedtest_' .. Either( SERVER, 'sv', 'cl' ), function( ply )

	local t1, t2

	-- [[ GetEyeTrace ]] --

	util.TimerCycle()

		ply:GetEyeTrace()

	t1 = util.TimerCycle()
	Msg( t1, ' ' )

	util.TimerCycle()

		ply:GetEyeTrace_2()

	t2 = util.TimerCycle()
	Msg( t2, ' ', Format( '%.1fx faster', t1 / t2 ), '\n' )

	-- [[ GetEyeTraceNoCursor ]] --

	util.TimerCycle()

		ply:GetEyeTraceNoCursor()

	t1 = util.TimerCycle()
	Msg( t1, ' ' )

	util.TimerCycle()

		ply:GetEyeTraceNoCursor_2()

	t2 = util.TimerCycle()
	Msg( t2, ' ', Format( '%.1fx faster', t1 / t2 ), '\n' )

end )
```
</details>
