### PR TITLE
Add `math.Cot` function

### DIFF
--- a/garrysmod/lua/includes/extensions/math.lua
+++ b/garrysmod/lua/includes/extensions/math.lua
@@ -267,3 +267,12 @@ function math.IsNearlyEqual( a, b, tolerance )
 
 	return math.abs( a - b ) <= tolerance
 end
+
+--[[---------------------------------------------------------
+	Name: cot( num )
+	Desc: Calculate cotangent of num
+-----------------------------------------------------------]]
+function math.cot( num )
+	return 1 / math.tan( num )
+end
+

--- a/garrysmod/lua/includes/extensions/math.lua
+++ b/garrysmod/lua/includes/extensions/math.lua
@@ -269,10 +269,10 @@ function math.IsNearlyEqual( a, b, tolerance )
 end
 
 --[[---------------------------------------------------------
-	Name: cot( num )
+	Name: Cot( num )
 	Desc: Calculate cotangent of num
 -----------------------------------------------------------]]
-function math.cot( num )
+function math.Cot( num )
 	return 1 / math.tan( num )
 end
 


### PR DESCRIPTION
Returns cotangent of number. Useful for calculations of scaling factor using FOV.
Usage example:
```lua
local viewSetup = render.GetViewSetup()
local fov = viewSetup.fov
local factor = math.Cot( math.rad( fov * 0.5 ) )
```