### PR TITLE
'Seamless' Singleplayer level transitions

### DIFF
--- a/garrysmod/lua/menu/loading.lua
+++ b/garrysmod/lua/menu/loading.lua
@@ -57,6 +57,25 @@ function PANEL:Paint( w, h )
 
 	surface.DrawTexturedRect( 0, 0, w, h )
 
+	if ( self.ShowBubble ) then -- HL2-like "LOADING" in middle of screen
+
+		local panelH = h * 0.0667
+		local panelW = panelH * 2.625
+		local panelX = ( w - panelW ) / 2
+		local panelY = ( h - panelH ) / 2
+		local cornerRadius = math.max( 8, math.floor( panelH * 0.15 ) )
+
+		draw.RoundedBox( cornerRadius, panelX, panelY, panelW, panelH, Color( 0, 0, 0, 128 ) )
+
+		surface.SetFont( "HudDefault" )
+		local text = "#GameUI_LoadingGame"
+		local tw, th = surface.GetTextSize( text )
+		surface.SetTextColor( 255, 255, 255, 255 )
+		surface.SetTextPos( panelX + ( panelW - tw ) / 2, panelY + ( panelH - th ) / 2 )
+		surface.DrawText( text )
+
+	end
+
 	if ( self.JavascriptRun && IsValid( self.HTML ) && !self.HTML:IsLoading() ) then
 
 		self:RunJavascript( self.JavascriptRun )
@@ -87,6 +106,8 @@ function PANEL:OnActivate( transition )
 		self.BGColor = Color( 255, 255, 255, 255 )
 		self.BGMaterial = engine.GetLastFrame()
 
+		self.ShowBubble = true
+
 		self:ShowURL( "about:blank" )
 	else
 		self:ShowURL( GetDefaultLoadingHTML() )
@@ -102,6 +123,8 @@ function PANEL:OnDeactivate()
 
 	self.BGColor = colGrey
 	self.BGMaterial = matBlank
+
+	self.ShowBubble = false
 
 	if ( IsValid( self.HTML ) ) then self.HTML:Remove() end
 	self.LoadedURL = nil

--- a/garrysmod/lua/menu/loading.lua
+++ b/garrysmod/lua/menu/loading.lua
@@ -5,11 +5,17 @@ g_ServerURL		= ""
 g_MaxPlayers	= ""
 g_SteamID		= ""
 
+local colGrey	= Color( 30, 30, 30, 255 )
+local matBlank	= Material( "vgui/white" )
+
 local PANEL = {}
 
 function PANEL:Init()
 
 	self:SetSize( ScrW(), ScrH() )
+
+	self.BGColor = colGrey
+	self.BGMaterial = matBlank
 
 end
 
@@ -44,10 +50,12 @@ function PANEL:PerformLayout()
 
 end
 
-function PANEL:Paint()
+function PANEL:Paint( w, h )
 
-	surface.SetDrawColor( 30, 30, 30, 255 )
-	surface.DrawRect( 0, 0, self:GetWide(), self:GetTall() )
+	surface.SetDrawColor( self.BGColor )
+	surface.SetMaterial( self.BGMaterial )
+
+	surface.DrawTexturedRect( 0, 0, w, h )
 
 	if ( self.JavascriptRun && IsValid( self.HTML ) && !self.HTML:IsLoading() ) then
 
@@ -67,7 +75,7 @@ function PANEL:RunJavascript( str )
 
 end
 
-function PANEL:OnActivate()
+function PANEL:OnActivate( transition )
 
 	g_ServerName	= ""
 	g_MapName		= ""
@@ -75,7 +83,14 @@ function PANEL:OnActivate()
 	g_MaxPlayers	= ""
 	g_SteamID		= ""
 
-	self:ShowURL( GetDefaultLoadingHTML() )
+	if ( transition ) then -- Singleplayer level transitions
+		self.BGColor = Color( 255, 255, 255, 255 )
+		self.BGMaterial = engine.GetLastFrame()
+
+		self:ShowURL( "about:blank" )
+	else
+		self:ShowURL( GetDefaultLoadingHTML() )
+	end
 
 	self.NumDownloadables = 0
 	self.CheckedSingleplayer = false
@@ -84,6 +99,9 @@ function PANEL:OnActivate()
 end
 
 function PANEL:OnDeactivate()
+
+	self.BGColor = colGrey
+	self.BGMaterial = matBlank
 
 	if ( IsValid( self.HTML ) ) then self.HTML:Remove() end
 	self.LoadedURL = nil

--- a/garrysmod/lua/menu/loading.lua
+++ b/garrysmod/lua/menu/loading.lua
@@ -51,6 +51,25 @@ function PANEL:Paint( w, h )
 
 	surface.DrawTexturedRect( 0, 0, w, h )
 
+	if ( self.ShowBubble ) then -- HL2-like "LOADING" in middle of screen
+
+		local panelH = h * 0.0667
+		local panelW = panelH * 2.625
+		local panelX = ( w - panelW ) / 2
+		local panelY = ( h - panelH ) / 2
+		local cornerRadius = math.max( 8, math.floor( panelH * 0.15 ) )
+
+		draw.RoundedBox( cornerRadius, panelX, panelY, panelW, panelH, Color( 0, 0, 0, 128 ) )
+
+		surface.SetFont( "HudDefault" )
+		local text = "#GameUI_LoadingGame"
+		local tw, th = surface.GetTextSize( text )
+		surface.SetTextColor( 255, 255, 255, 255 )
+		surface.SetTextPos( panelX + ( panelW - tw ) / 2, panelY + ( panelH - th ) / 2 )
+		surface.DrawText( text )
+
+	end
+
 	if ( self.JavascriptRun && IsValid( self.HTML ) && !self.HTML:IsLoading() ) then
 
 		self:RunJavascript( self.JavascriptRun )
@@ -75,6 +94,8 @@ function PANEL:OnActivate( transition )
 		self.BGColor = Color( 255, 255, 255, 255 )
 		self.BGMaterial = engine.GetLastFrame()
 
+		self.ShowBubble = true
+
 		self:ShowURL( "about:blank" )
 	else
 		self:ShowURL( GetDefaultLoadingHTML() )
@@ -89,6 +110,8 @@ function PANEL:OnDeactivate()
 
 	self.BGColor = colGrey
 	self.BGMaterial = matBlank
+
+	self.ShowBubble = false
 
 	if ( IsValid( self.HTML ) ) then self.HTML:Remove() end
 	self.LoadedURL = nil

--- a/garrysmod/lua/menu/loading.lua
+++ b/garrysmod/lua/menu/loading.lua
@@ -1,9 +1,15 @@
 
+local colGrey	= Color( 30, 30, 30, 255 )
+local matBlank	= Material( "vgui/white" )
+
 local PANEL = {}
 
 function PANEL:Init()
 
 	self:SetSize( ScrW(), ScrH() )
+
+	self.BGColor = colGrey
+	self.BGMaterial = matBlank
 
 end
 
@@ -40,8 +46,10 @@ end
 
 function PANEL:Paint( w, h )
 
-	surface.SetDrawColor( 30, 30, 30, 255 )
-	surface.DrawRect( 0, 0, w, h )
+	surface.SetDrawColor( self.BGColor )
+	surface.SetMaterial( self.BGMaterial )
+
+	surface.DrawTexturedRect( 0, 0, w, h )
 
 	if ( self.JavascriptRun && IsValid( self.HTML ) && !self.HTML:IsLoading() ) then
 
@@ -61,9 +69,16 @@ function PANEL:RunJavascript( str )
 
 end
 
-function PANEL:OnActivate()
+function PANEL:OnActivate( transition )
 
-	self:ShowURL( GetDefaultLoadingHTML() )
+	if ( transition ) then -- Singleplayer level transitions
+		self.BGColor = Color( 255, 255, 255, 255 )
+		self.BGMaterial = engine.GetLastFrame()
+
+		self:ShowURL( "about:blank" )
+	else
+		self:ShowURL( GetDefaultLoadingHTML() )
+	end
 
 	self.NumDownloadables = 0
 	self.CheckedSingleplayer = false
@@ -71,6 +86,9 @@ function PANEL:OnActivate()
 end
 
 function PANEL:OnDeactivate()
+
+	self.BGColor = colGrey
+	self.BGMaterial = matBlank
 
 	if ( IsValid( self.HTML ) ) then self.HTML:Remove() end
 	self.LoadedURL = nil


### PR DESCRIPTION
## Suggestion
'Seamless' level transitions for singleplayer's Source Engine level transitions, showing the freeze frame just like in the original games.

## Demos
https://github.com/user-attachments/assets/38debb33-d0d9-494a-801c-ad84e5403c7e

https://github.com/user-attachments/assets/17b0492a-6832-413d-9444-6a060e00584c

HL2's d1_trainstation_02 to d1_trainstation_03 & Portal's testchmb_a_01 to testchmb_a_02


## Required for functionality
The PR code would need these before merging.
- The loading panel needs its `:OnActivate()` function to be given a parameter `:OnActivate( transition )`, which is `true` when the player's singleplayer game experiences a changelevel2/trigger_changelevel. This is similar to https://wiki.facepunch.com/gmod/game.MapLoadType 
- Menu-state needs a function `engine.GetLastFrame()`, which returns a material of the final frame rendered prior to loading, excluding the hud/vgui/etc. 

<details><summary>How the demo gameplay works without that functionality</summary>

- To work around `:OnActivate( transition )` not currently being provided that flag - `transition = true` was added.
- To work around `engine.GetLastFrame()` not currently existing - A specific texture is updated every `PreDrawHUD` clientside, which stops getting updated when rendering stops and is therefore frozen at the final frame, and in menustate a dummy `GetLastFrame()` returns a material of that texture.

</details> 