### PR TITLE
Improve emoji stripping regex

### DIFF
--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -13,7 +13,7 @@ function StripWeirdSymbols( name )
 	var ret = name.replace( /[\u2100-\u23FF\u2580-\u259F\u25A0-\u25FF\u2600-\u26FF\u2700-\u27BF\u2B00-\u2BFF]/g, "" );
 
 	// Emojis
-	ret = ret.replace( /\p{Extended_Pictographic}(\u200D\p{Extended_Pictographic})*/gu, "" );
+	ret = ret.replace( /([\uD83C|\uD83D|\uD83E][\uDC00-\uDFFF])/g, "" );
 	return ret;
 }
 
@@ -718,4 +718,5 @@ function ReceiveFoundServers( data )
 
 	UpdateDigest( RootScope, 60 );
 }
+
 

--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -13,7 +13,7 @@ function StripWeirdSymbols( name )
 	var ret = name.replace( /[\u2100-\u23FF\u2580-\u259F\u25A0-\u25FF\u2600-\u26FF\u2700-\u27BF\u2B00-\u2BFF]/g, "" );
 
 	// Emojis
-	ret = ret.replace( /\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|\uD83E[\uDD10-\uDFFF]/g, "" );
+	ret = ret.replace( /\p{Extended_Pictographic}(\u200D\p{Extended_Pictographic})*/gu, "" );
 	return ret;
 }
 
@@ -718,3 +718,4 @@ function ReceiveFoundServers( data )
 
 	UpdateDigest( RootScope, 60 );
 }
+

--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -718,5 +718,3 @@ function ReceiveFoundServers( data )
 
 	UpdateDigest( RootScope, 60 );
 }
-
-


### PR DESCRIPTION
Improves the emoji filtering server browser code to properly filter all emojis as some are able to pass through right now
Example:
```js
function StripWeirdSymbolsOld( name )
{
	// Weird symbols
	var ret = name.replace( /[\u2100-\u23FF\u2580-\u259F\u25A0-\u25FF\u2600-\u26FF\u2700-\u27BF\u2B00-\u2BFF]/g, "" );

	// Emojis
	ret = ret.replace( /\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|\uD83E[\uDD10-\uDFFF]/g, "" );
	return ret;
}

function StripWeirdSymbolsNew( name )
{
	// Weird symbols
	var ret = name.replace( /[\u2100-\u23FF\u2580-\u259F\u25A0-\u25FF\u2600-\u26FF\u2700-\u27BF\u2B00-\u2BFF]/g, "" );

	// Emojis
    ret = ret.replace( /([\uD83C|\uD83D|\uD83E][\uDC00-\uDFFF])/g, "" );
    return ret;
}

let ret = "EMOJIRP | 50K 👋 🤌 🚀| COOL 🌍 | ❤🤏🤎 ™ © RP!";
console.log("original: " + ret);
console.log("old: " + StripWeirdSymbolsOld( ret ));
console.log("new: " + StripWeirdSymbolsNew( ret ));
```

```
original: EMOJIRP | 50K 👋 🤌 🚀| COOL 🌍 | ❤🤏🤎 ™ © RP!
old: EMOJIRP | 50K  🤌 | COOL  | 🤏🤎  © RP!
new: EMOJIRP | 50K   | COOL  |   © RP!
```