### PR TITLE
Restore cursor position in Spawnmenu on Linux

### DIFF
--- a/garrysmod/lua/autorun/client/linux_cursor.lua
+++ b/garrysmod/lua/autorun/client/linux_cursor.lua
@@ -1,0 +1,40 @@
+if ( SERVER ) then return end
+
+if ( not system.IsLinux() ) then return end
+
+local lastX = ScrW() / 2
+local lastY = ScrH() / 2
+local forceFrames = 3
+
+hook.Add( "OnSpawnMenuClose", "SaveMenuCursorLinux", function()
+
+	lastX, lastY = input.GetCursorPos()
+
+end )
+
+hook.Add( "OnSpawnMenuOpen", "RestoreMenuCursorLinux", function()
+
+	local framesCount = 0
+
+	hook.Add( "Think", "ForceCursorPosLinuxFix", function()
+
+		if ( not g_SpawnMenu:IsVisible() ) then
+
+			hook.Remove( "Think", "ForceCursorPosLinuxFix" )
+			return
+
+		end
+
+		input.SetCursorPos( lastX, lastY )
+
+		framesCount = forceFrames + 1
+
+		if ( framesCount >= forceFrames ) then
+
+			hook.Remove( "Think", "ForceCursorPosLinuxFix" )
+
+		end
+
+	end )
+
+end )

--- a/garrysmod/lua/autorun/client/linux_cursor.lua
+++ b/garrysmod/lua/autorun/client/linux_cursor.lua
@@ -1,3 +1,4 @@
+
 if ( SERVER ) then return end
 
 if ( not system.IsLinux() ) then return end


### PR DESCRIPTION
<hr></hr>
Adds a file to `/lua/autorun/client` for restoring the cursors position in the spawnmenu only on Linux.
<hr></hr>
Opening this since I think it would be useful. On Windows, the cursor's position is saved when you re-open the spawnmenu when you opened it before, but on Linux, this behavior doesn't apply.

I would have to guess it's something with the actual C++ code (_yk, the code we can't touch..._), and not the Lua code.

I tired multiple ways and it seems that this works the best from what I can figure out by myself, since VGUI seems to reset the cursor to the center, when, we don't want that, so I had to add a temp frame-override, I don't know of any other ways to do it lol. If you have something better please let me know.

I think I got formatting correct and line endings correct? lol.