### PR TITLE
Add PostEntityCreated hook

### DIFF
--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -727,4 +727,3 @@ function vehicle:GetCameraDistance()
 	return self:GetDTFloat( 3 )
 
 end
-

--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -165,6 +165,23 @@ end
 
 hook.Add( "EntityRemoved", "DoDieFunction", DoDieFunction )
 
+--[[---------------------------------------------------------
+	PostEntityCreated, 
+	the entity will likely have it's model set, etc, by now
+-----------------------------------------------------------]]
+local function DoPostEntityCreated( ent )
+
+    timer.Simple( 0, function()
+
+        if not IsValid( ent ) then return end
+        hook.Run( "PostEntityCreated", ent )
+
+    end )
+
+end
+
+hook.Add( "OnEntityCreated", "DoPostEntityCreated", DoPostEntityCreated )
+
 function meta:PhysWake()
 
 	local phys = self:GetPhysicsObject()
@@ -710,3 +727,4 @@ function vehicle:GetCameraDistance()
 	return self:GetDTFloat( 3 )
 
 end
+


### PR DESCRIPTION
Adds a hook that runs after entities are setup, their models are set, ETC

Many, many addons create their own timer.Simple inside of OnEntityCreated. (feels like I've done it in almost a dozen places!)
Will just be able to use this hook when this is merged.

*billions of timers must be removed from garry's mod*