### PR TITLE
TTT: Use replicated convars instead of global nwvars

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/admin.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/admin.lua
@@ -92,7 +92,7 @@ end
 concommand.Add("ttt_print_karma", PrintKarma)
 
 
-CreateConVar("ttt_highlight_admins", "1")
+CreateConVar("ttt_highlight_admins", "1", FCVAR_REPLICATED)
 local function ApplyHighlightAdmins(cv, old, new)
    SetGlobalBool("ttt_highlight_admins", tobool(tonumber(new)))
 end

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
@@ -351,7 +351,7 @@ function CheckIdle()
 
    if GetRoundState() == ROUND_ACTIVE and client:IsTerror() and client:Alive() then
       local idle_limit = ttt_idle_limit:GetInt()
-      if idle_limit <= 0 then idle_limit = 300 end -- networking sucks sometimes
+      if idle_limit <= 0 then return end
 
 
       if client:GetAngles() != idle.ang then

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
@@ -86,7 +86,9 @@ function GM:HUDClear()
 end
 
 KARMA = {}
-function KARMA.IsEnabled() return GetGlobalBool("ttt_karma", false) end
+
+local ttt_karma = CreateConVar("ttt_karma", "1", FCVAR_REPLICATED)
+function KARMA.IsEnabled() return ttt_karma:GetBool() end
 
 function GetRoundState() return GAMEMODE.round_state end
 
@@ -97,7 +99,7 @@ local function RoundStateChange(o, n)
       GAMEMODE:CleanUpMap()
 
       -- show warning to spec mode players
-      if GetConVar("ttt_spectator_mode"):GetBool() and IsValid(LocalPlayer())then
+      if GetConVar("ttt_spectator_mode"):GetBool() and IsValid(LocalPlayer()) then
          LANG.Msg("spec_mode_warning")
       end
 
@@ -330,6 +332,7 @@ end
 
 
 -- Simple client-based idle checking
+local ttt_idle_limit = CreateConVar("ttt_idle_limit", "180", FCVAR_REPLICATED)
 local idle = {ang = nil, pos = nil, mx = 0, my = 0, t = 0}
 function CheckIdle()
    local client = LocalPlayer()
@@ -347,7 +350,7 @@ function CheckIdle()
    end
 
    if GetRoundState() == ROUND_ACTIVE and client:IsTerror() and client:Alive() then
-      local idle_limit = GetGlobalInt("ttt_idle_limit", 300) or 300
+      local idle_limit = ttt_idle_limit:GetInt()
       if idle_limit <= 0 then idle_limit = 300 end -- networking sucks sometimes
 
 

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_popups.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_popups.lua
@@ -105,7 +105,7 @@ local function IdlePopup()
    local inner = vgui.Create("DPanel", dframe)
    inner:StretchToParent(5, 25, 5, 45)
 
-   local idle_limit = GetGlobalInt("ttt_idle_limit", 300) or 300
+   local idle_limit = GetConVar("ttt_idle_limit"):GetInt()
 
    local text = vgui.Create("DLabel", inner)
    text:SetWrap(true)

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_voice.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_voice.lua
@@ -445,6 +445,13 @@ end
 --- voicechat stuff
 VOICE = {}
 
+local loc_voice = CreateConVar("ttt_locational_voice", "0", FCVAR_REPLICATED)
+
+local voice_drain = CreateConVar("ttt_voice_drain", "0", FCVAR_REPLICATED)
+local voice_drain_normal = CreateConVar("ttt_voice_drain_normal", "0.2", FCVAR_REPLICATED)
+local voice_drain_admin = CreateConVar("ttt_voice_drain_admin", "0", FCVAR_REPLICATED)
+local voice_drain_recharge = CreateConVar("ttt_voice_drain_recharge", "0.05", FCVAR_REPLICATED)
+
 local MutedState = nil
 
 -- voice popups, copied from base gamemode and modified
@@ -455,8 +462,8 @@ g_VoicePanelList = nil
 -- 5 at 5000
 local function VoiceNotifyThink(pnl)
    if not (IsValid(pnl) and LocalPlayer() and IsValid(pnl.ply)) then return end
-   if not (GetGlobalBool("ttt_locational_voice", false) and (not pnl.ply:IsSpec()) and (pnl.ply != LocalPlayer())) then return end
-   if LocalPlayer():IsActiveTraitor() && pnl.ply:IsActiveTraitor() then return end
+   if not (loc_voice:GetBool() and (not pnl.ply:IsSpec()) and (pnl.ply != LocalPlayer())) then return end
+   if LocalPlayer():IsActiveTraitor() and pnl.ply:IsActiveTraitor() then return end
 
    local d = LocalPlayer():GetPos():Distance(pnl.ply:GetPos())
 
@@ -626,7 +633,7 @@ function VOICE.InitBattery()
 end
 
 local function GetRechargeRate()
-   local r = GetGlobalFloat("ttt_voice_drain_recharge", 0.05)
+   local r = voice_drain_recharge:GetFloat()
    if LocalPlayer().voice_battery < battery_min then
       r = r / 2
    end
@@ -634,16 +641,16 @@ local function GetRechargeRate()
 end
 
 local function GetDrainRate()
-   if not GetGlobalBool("ttt_voice_drain", false) then return 0 end
+   if not voice_drain:GetBool() then return 0 end
 
    if GetRoundState() != ROUND_ACTIVE then return 0 end
    local ply = LocalPlayer()
    if (not IsValid(ply)) or ply:IsSpec() then return 0 end
 
    if ply:IsAdmin() or ply:IsDetective() then
-      return GetGlobalFloat("ttt_voice_drain_admin", 0)
+      return voice_drain_admin:GetFloat()
    else
-      return GetGlobalFloat("ttt_voice_drain_normal", 0)
+      return voice_drain_normal:GetFloat()
    end
 end
 
@@ -652,7 +659,7 @@ local function IsTraitorChatting(client)
 end
 
 function VOICE.Tick()
-   if not GetGlobalBool("ttt_voice_drain", false) then return end
+   if not voice_drain:GetBool() then return end
 
    local client = LocalPlayer()
    if VOICE.IsSpeaking() and (not IsTraitorChatting(client)) then
@@ -672,7 +679,7 @@ function VOICE.IsSpeaking() return LocalPlayer().speaking end
 function VOICE.SetSpeaking(state) LocalPlayer().speaking = state end
 
 function VOICE.CanSpeak()
-   if not GetGlobalBool("ttt_voice_drain", false) then return true end
+   if not voice_drain:GetBool() then return true end
 
    return LocalPlayer().voice_battery > battery_min or IsTraitorChatting(LocalPlayer())
 end

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_voice.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_voice.lua
@@ -686,6 +686,8 @@ end
 
 local speaker = surface.GetTextureID("voice/icntlk_sv")
 function VOICE.Draw(client)
+   if not voice_drain:GetBool() then return end
+
    local b = client.voice_battery
    if b >= battery_max then return end
 

--- a/garrysmod/gamemodes/terrortown/gamemode/gamemsg.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/gamemsg.lua
@@ -93,28 +93,28 @@ CreateConVar("ttt_limit_spectator_chat", "1", FCVAR_ARCHIVE + FCVAR_NOTIFY)
 CreateConVar("ttt_limit_spectator_voice", "1", FCVAR_ARCHIVE + FCVAR_NOTIFY)
 
 function GM:PlayerCanSeePlayersChat(text, team_only, listener, speaker)
-	if (not IsValid(listener)) then return false end
-	if (not IsValid(speaker)) then
-		if isentity(speaker) then
-			return true
-		else
-			return false
-		end
-	end
+   if (not IsValid(listener)) then return false end
+   if (not IsValid(speaker)) then
+      if isentity(speaker) then
+         return true
+      else
+         return false
+      end
+   end
 
-	local sTeam = speaker:Team() == TEAM_SPEC
-	local lTeam = listener:Team() == TEAM_SPEC
+   local sTeam = speaker:Team() == TEAM_SPEC
+   local lTeam = listener:Team() == TEAM_SPEC
 
-	if (GetRoundState() != ROUND_ACTIVE) or   -- Round isn't active
-	(not GetConVar("ttt_limit_spectator_chat"):GetBool()) or   -- Spectators can chat freely
-	(not DetectiveMode()) or   -- Mumbling
-	(not sTeam and ((team_only and not speaker:IsSpecial()) or (not team_only))) or   -- If someone alive talks (and not a special role in teamchat's case)
-	(not sTeam and team_only and speaker:GetRole() == listener:GetRole()) or
-	(sTeam and lTeam) then   -- If the speaker and listener are spectators
-	   return true
-	end
+   if (GetRoundState() != ROUND_ACTIVE) or   -- Round isn't active
+   (not GetConVar("ttt_limit_spectator_chat"):GetBool()) or   -- Spectators can chat freely
+   (not DetectiveMode()) or   -- Mumbling
+   (not sTeam and ((team_only and not speaker:IsSpecial()) or (not team_only))) or   -- If someone alive talks (and not a special role in teamchat's case)
+   (not sTeam and team_only and speaker:GetRole() == listener:GetRole()) or
+   (sTeam and lTeam) then   -- If the speaker and listener are spectators
+      return true
+   end
 
-	return false
+   return false
 end
 
 local mumbles = {"mumble", "mm", "hmm", "hum", "mum", "mbm", "mble", "ham", "mammaries", "political situation", "mrmm", "hrm",
@@ -147,8 +147,8 @@ function GM:PlayerSay(ply, text, team_only)
          table.insert(filtered, 1, "[MUMBLED]")
          return table.concat(filtered, " ")
       elseif team_only and not team and ply:IsSpecial() then
-	     RoleChatMsg(ply, ply:GetRole(), text)
-		 return ""
+         RoleChatMsg(ply, ply:GetRole(), text)
+         return ""
       end
    end
 
@@ -164,7 +164,7 @@ function MuteForRestart(state)
 end
 
 
-local loc_voice = CreateConVar("ttt_locational_voice", "0")
+local loc_voice = CreateConVar("ttt_locational_voice", "0", FCVAR_REPLICATED)
 
 -- Of course voice has to be limited as well
 function GM:PlayerCanHearPlayersVoice(listener, speaker)

--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -64,7 +64,6 @@ CreateConVar("ttt_posttime_seconds", "30", FCVAR_NOTIFY)
 CreateConVar("ttt_firstpreptime", "60", FCVAR_NOTIFY)
 
 -- Haste mode
-local ttt_haste = CreateConVar("ttt_haste", "1", FCVAR_NOTIFY)
 CreateConVar("ttt_haste_starting_minutes", "5", FCVAR_NOTIFY)
 CreateConVar("ttt_haste_minutes_per_death", "0.5", FCVAR_NOTIFY)
 
@@ -99,19 +98,22 @@ CreateConVar("ttt_use_weapon_spawn_scripts", "1")
 CreateConVar("ttt_weapon_spawn_count", "0")
 
 CreateConVar("ttt_round_limit", "6", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED)
-CreateConVar("ttt_time_limit_minutes", "75", FCVAR_NOTIFY + FCVAR_REPLICATED)
+local time_limit_minutes = CreateConVar("ttt_time_limit_minutes", "75", FCVAR_NOTIFY + FCVAR_REPLICATED)
 
-CreateConVar("ttt_idle_limit", "180", FCVAR_NOTIFY)
+local idle_limit = CreateConVar("ttt_idle_limit", "180", FCVAR_NOTIFY + FCVAR_REPLICATED)
 
-CreateConVar("ttt_voice_drain", "0", FCVAR_NOTIFY)
-CreateConVar("ttt_voice_drain_normal", "0.2", FCVAR_NOTIFY)
-CreateConVar("ttt_voice_drain_admin", "0", FCVAR_NOTIFY)
-CreateConVar("ttt_voice_drain_recharge", "0.05", FCVAR_NOTIFY)
+local loc_voice = GetConVar("ttt_locational_voice")
+
+local voice_drain = CreateConVar("ttt_voice_drain", "0", FCVAR_NOTIFY + FCVAR_REPLICATED)
+local voice_drain_normal = CreateConVar("ttt_voice_drain_normal", "0.2", FCVAR_NOTIFY + FCVAR_REPLICATED)
+local voice_drain_admin = CreateConVar("ttt_voice_drain_admin", "0", FCVAR_NOTIFY + FCVAR_REPLICATED)
+local voice_drain_recharge = CreateConVar("ttt_voice_drain_recharge", "0.05", FCVAR_NOTIFY + FCVAR_REPLICATED)
+
+local highlight_admins = GetConVar("ttt_highlight_admins")
 
 CreateConVar("ttt_namechange_kick", "1", FCVAR_NOTIFY)
 CreateConVar("ttt_namechange_bantime", "10", FCVAR_NOTIFY)
 
-local ttt_detective = CreateConVar("ttt_sherlock_mode", "1", FCVAR_ARCHIVE + FCVAR_NOTIFY)
 local ttt_minply = CreateConVar("ttt_minimum_players", "2", FCVAR_ARCHIVE + FCVAR_NOTIFY)
 
 -- debuggery
@@ -171,7 +173,7 @@ function GM:Initialize()
       [OPEN_DOOR] = true,
       [OPEN_ROT] = true,
       [OPEN_BUT] = true,
-      [OPEN_NOTOGGLE]= true
+      [OPEN_NOTOGGLE] = true
    }
 
    -- More map config ent defaults
@@ -225,20 +227,19 @@ function GM:InitPostEntity()
    WEPS.ForcePrecache()
 end
 
--- Convar replication is broken in gmod, so we do this.
+-- Convar replication used to be broken in gmod, so we did this.
 -- I don't like it any more than you do, dear reader.
+-- These globals are now deprecated, you should use the actual convars instead.
 function GM:SyncGlobals()
-   SetGlobalBool("ttt_detective", ttt_detective:GetBool())
-   SetGlobalBool("ttt_haste", ttt_haste:GetBool())
-   SetGlobalInt("ttt_time_limit_minutes", GetConVar("ttt_time_limit_minutes"):GetInt())
-   SetGlobalBool("ttt_highlight_admins", GetConVar("ttt_highlight_admins"):GetBool())
-   SetGlobalBool("ttt_locational_voice", GetConVar("ttt_locational_voice"):GetBool())
-   SetGlobalInt("ttt_idle_limit", GetConVar("ttt_idle_limit"):GetInt())
+   SetGlobalInt("ttt_time_limit_minutes", time_limit_minutes:GetInt())
+   SetGlobalBool("ttt_highlight_admins", highlight_admins:GetBool())
+   SetGlobalBool("ttt_locational_voice", loc_voice:GetBool())
+   SetGlobalInt("ttt_idle_limit", idle_limit:GetInt())
 
-   SetGlobalBool("ttt_voice_drain", GetConVar("ttt_voice_drain"):GetBool())
-   SetGlobalFloat("ttt_voice_drain_normal", GetConVar("ttt_voice_drain_normal"):GetFloat())
-   SetGlobalFloat("ttt_voice_drain_admin", GetConVar("ttt_voice_drain_admin"):GetFloat())
-   SetGlobalFloat("ttt_voice_drain_recharge", GetConVar("ttt_voice_drain_recharge"):GetFloat())
+   SetGlobalBool("ttt_voice_drain", voice_drain:GetBool())
+   SetGlobalFloat("ttt_voice_drain_normal", voice_drain_normal:GetFloat())
+   SetGlobalFloat("ttt_voice_drain_admin", voice_drain_admin:GetFloat())
+   SetGlobalFloat("ttt_voice_drain_recharge", voice_drain_recharge:GetFloat())
 end
 
 function SendRoundState(state, ply)
@@ -704,7 +705,7 @@ function CheckForMapSwitch()
    local rounds_left = math.max(0, GetGlobalInt("ttt_rounds_left", 6) - 1)
    SetGlobalInt("ttt_rounds_left", rounds_left)
 
-   local time_left = math.max(0, (GetConVar("ttt_time_limit_minutes"):GetInt() * 60) - CurTime())
+   local time_left = math.max(0, (time_limit_minutes:GetInt() * 60) - CurTime())
    local switchmap = false
    local nextmap = string.upper(game.GetMapNext())
 

--- a/garrysmod/gamemodes/terrortown/gamemode/karma.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/karma.lua
@@ -7,10 +7,10 @@ KARMA.RememberedPlayers = {}
 
 -- Convars, more convenient access than GetConVar bla bla
 KARMA.cv = {}
-KARMA.cv.enabled     = CreateConVar("ttt_karma", "1", FCVAR_ARCHIVE)
+KARMA.cv.enabled     = CreateConVar("ttt_karma", "1", FCVAR_ARCHIVE + FCVAR_REPLICATED)
 KARMA.cv.strict      = CreateConVar("ttt_karma_strict", "1")
 KARMA.cv.starting    = CreateConVar("ttt_karma_starting", "1000")
-KARMA.cv.max         = CreateConVar("ttt_karma_max", "1000")
+KARMA.cv.max         = CreateConVar("ttt_karma_max", "1000", FCVAR_REPLICATED)
 KARMA.cv.ratio       = CreateConVar("ttt_karma_ratio", "0.001")
 KARMA.cv.killpenalty = CreateConVar("ttt_karma_kill_penalty", "15")
 KARMA.cv.roundheal   = CreateConVar("ttt_karma_round_increment", "5")
@@ -38,12 +38,11 @@ cvars.AddChangeCallback("ttt_karma_max", function(cvar, old, new)
 end)
 
 function KARMA.InitState()
-   SetGlobalBool("ttt_karma", config.enabled:GetBool())
    SetGlobalInt("ttt_karma_max", config.max:GetFloat())
 end
 
 function KARMA.IsEnabled()
-   return GetGlobalBool("ttt_karma", false)
+   return config.enabled:GetBool()
 end
 
 -- Compute penalty for hurting someone a certain amount
@@ -303,7 +302,7 @@ function KARMA.Remember(ply)
 end
 
 function KARMA.Recall(ply)
-   if config.persist:GetBool()then
+   if config.persist:GetBool() then
       ply.delay_karma_recall = not ply:IsFullyAuthenticated()
 
       if ply:IsFullyAuthenticated() then

--- a/garrysmod/gamemodes/terrortown/gamemode/shared.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/shared.lua
@@ -86,8 +86,11 @@ include("lang_shd.lua") -- uses some of util
 include("equip_items_shd.lua")
 include("radio_shd.lua")
 
-function DetectiveMode() return GetGlobalBool("ttt_detective", false) end
-function HasteMode() return GetGlobalBool("ttt_haste", false) end
+local ttt_detective = CreateConVar("ttt_sherlock_mode", "1", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED)
+function DetectiveMode() return ttt_detective:GetBool() end
+
+local ttt_haste = CreateConVar("ttt_haste", "1", FCVAR_NOTIFY + FCVAR_REPLICATED)
+function HasteMode() return ttt_haste:GetBool() end
 
 -- Create teams
 TEAM_TERROR = 1

--- a/garrysmod/gamemodes/terrortown/gamemode/util.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/util.lua
@@ -330,8 +330,9 @@ if CLIENT then
       min  = Color(255, 130, 0, 255),
    }
 
+   local karma_max = CreateConVar("ttt_karma_max", "1000", FCVAR_REPLICATED)
    function util.KarmaToString(karma)
-      local maxkarma = GetGlobalInt("ttt_karma_max", 1000)
+      local maxkarma = karma_max:GetInt()
 
       if karma > maxkarma * 0.89 then
          return "karma_max", karmacolors.max

--- a/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_main.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_main.lua
@@ -169,13 +169,12 @@ function PANEL:Init()
 
    -- the various score column headers
    self.cols = {}
-   self:AddColumn( GetTranslation("sb_ping"), nil, nil,         "ping" )
-   self:AddColumn( GetTranslation("sb_deaths"), nil, nil,       "deaths" )
-   self:AddColumn( GetTranslation("sb_score"), nil, nil,        "score" )
+   self:AddColumn( GetTranslation("sb_ping"), nil, nil,             "ping" )
+   self:AddColumn( GetTranslation("sb_deaths"), nil, nil,           "deaths" )
+   self:AddColumn( GetTranslation("sb_score"), nil, nil,            "score" )
 
-   if KARMA.IsEnabled() then
-      self:AddColumn( GetTranslation("sb_karma"), nil, nil,     "karma" )
-   end
+   local kh = self:AddColumn( GetTranslation("sb_karma"), nil, nil, "karma" )
+   kh.ShouldShow = KARMA.IsEnabled
 
    self.sort_headers = {}
    -- Reuse some translations
@@ -357,6 +356,10 @@ function PANEL:PerformLayout()
       v:SizeToContents()
       cx = cx - v.Width
       v:SetPos(cx - v:GetWide()/2, cy)
+
+      if v.ShouldShow then
+         v:SetVisible(v:ShouldShow())
+      end
    end
 
    -- sort headers

--- a/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_main.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_main.lua
@@ -25,6 +25,8 @@ surface.CreateFont("treb_small", {font = "Tahoma",
 CreateClientConVar("ttt_scoreboard_sorting", "name", true, false, "name | role | karma | score | deaths | ping")
 CreateClientConVar("ttt_scoreboard_ascending", "1", true, false, "Should scoreboard ordering be in ascending order")
 
+local time_limit_minutes = CreateConVar("ttt_time_limit_minutes", "75", FCVAR_REPLICATED)
+
 local logo = surface.GetTextureID("vgui/ttt/score_logo")
 
 local PANEL = {}
@@ -33,7 +35,7 @@ local max = math.max
 local floor = math.floor
 local function UntilMapChange()
    local rounds_left = max(0, GetGlobalInt("ttt_rounds_left", 6))
-   local time_left = floor(max(0, ((GetGlobalInt("ttt_time_limit_minutes") or 60) * 60) - CurTime()))
+   local time_left = floor(max(0, (time_limit_minutes:GetInt() * 60) - CurTime()))
 
    local h = floor(time_left / 3600)
    time_left = time_left - floor(h * 3600)

--- a/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -34,9 +34,8 @@ function PANEL:Init()
    self:AddColumn( GetTranslation("sb_deaths"), function(ply) return ply:Deaths() end )
    self:AddColumn( GetTranslation("sb_score"), function(ply) return ply:Frags() end )
 
-   if KARMA.IsEnabled() then
-      self:AddColumn( GetTranslation("sb_karma"), function(ply) return math.Round(ply:GetBaseKarma()) end )
-   end
+   local kc = self:AddColumn( GetTranslation("sb_karma"), function(ply) return math.Round(ply:GetBaseKarma()) end )
+   kc.ShouldShow = KARMA.IsEnabled
 
    -- Let hooks add their custom columns
    hook.Call("TTTScoreboardColumns", nil, self)
@@ -263,6 +262,10 @@ function PANEL:LayoutColumns()
       v:SizeToContents()
       cx = cx - v.Width
       v:SetPos(cx - v:GetWide()/2, (SB_ROW_HEIGHT - v:GetTall()) / 2)
+
+      if v.ShouldShow then
+         v:SetVisible(v:ShouldShow())
+      end
    end
 
    self.tag:SizeToContents()

--- a/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_row.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_row.lua
@@ -6,6 +6,8 @@ include("sb_info.lua")
 local GetTranslation = LANG.GetTranslation
 local GetPTranslation = LANG.GetParamTranslation
 
+local ttt_highlight_admins = CreateConVar("ttt_highlight_admins", "1", FCVAR_REPLICATED)
+
 local OpenedVoicePanels = {}
 local function HideVolumePanels()
    for _, pnl in pairs(OpenedVoicePanels) do
@@ -98,7 +100,7 @@ function GM:TTTScoreboardColorForPlayer(ply)
 
    if ply:SteamID() == "STEAM_0:0:1963640" then
       return namecolor.dev
-   elseif ply:IsAdmin() and GetGlobalBool("ttt_highlight_admins", true) then
+   elseif ply:IsAdmin() and ttt_highlight_admins:GetBool() then
       return namecolor.admin
    end
    return namecolor.default


### PR DESCRIPTION
While using global nwvars to network replicated cvars was necessary in 2010, convar replication has been working normally in GMod for a while now.

The main benefit is that changes to these convars will apply instantly instead of requiring a round restart to take effect.
I've also updated the behaviour of some of these convars to better take advantage of this:

- Idle checking can be disabled by setting ttt_idle_limit to 0 or less.
- Disabling ttt_voice_drain hides the voice drain HUD for clients, preventing the bar from appearing stuck if disabled mid-round.
- Toggling ttt_karma will also toggle the karma column of the scoreboard.

Most of the nwvars have been left alone for backwards compatibility, but I've removed the ones where a shared function was already used to access them (e.g. DetectiveMode, HasteMode, KARMA.IsEnabled), which should free up a bit of networking.