### PR TITLE
Add check for checking weapon GetHeadshotMultiplier

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/player.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player.lua
@@ -768,7 +768,7 @@ function GM:ScalePlayerDamage(ply, hitgroup, dmginfo)
 
       local wep = util.WeaponFromDamage(dmginfo)
 
-      if IsValid(wep) then
+      if IsValid(wep) and wep.GetHeadshotMultiplier then
          local s = wep:GetHeadshotMultiplier(ply, dmginfo) or 2
          dmginfo:ScaleDamage(s)
       end

--- a/garrysmod/gamemodes/terrortown/gamemode/player.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player.lua
@@ -768,8 +768,8 @@ function GM:ScalePlayerDamage(ply, hitgroup, dmginfo)
 
       local wep = util.WeaponFromDamage(dmginfo)
 
-      if IsValid(wep) and wep.GetHeadshotMultiplier then
-         local s = wep:GetHeadshotMultiplier(ply, dmginfo) or 2
+      if IsValid(wep) then
+         local s = wep.GetHeadshotMultiplier and wep:GetHeadshotMultiplier(ply, dmginfo) or 2
          dmginfo:ScaleDamage(s)
       end
    elseif (hitgroup == HITGROUP_LEFTARM or


### PR DESCRIPTION
Covers odd edge case on weapons that don't have a GetHeadshotMultiplier

```
[ERROR] gamemodes/terrortown/gamemode/player.lua:772: attempt to call method 'GetHeadshotMultiplier' (a nil value)
  1. unknown - gamemodes/terrortown/lua/terrortown/gamemode/player.lua:772
```