### PR TITLE
Refactor cleanup tool UI to work with custom spawnmenu

### DIFF
--- a/garrysmod/lua/autorun/utilities_menu.lua
+++ b/garrysmod/lua/autorun/utilities_menu.lua
@@ -248,13 +248,11 @@ end
 -- Tool Menu
 hook.Add( "PopulateToolMenu", "PopulateUtilityMenus", function()
 
-	spawnmenu.AddToolMenuOption( "Utilities", "User", "User_Cleanup", "#spawnmenu.utilities.cleanup", "", "", User_Cleanup )
 	spawnmenu.AddToolMenuOption( "Utilities", "User", "Undo", "#spawnmenu.utilities.undo", "", "", Undo )
 	spawnmenu.AddToolMenuOption( "Utilities", "User", "PhysgunSettings", "#spawnmenu.utilities.physgunsettings", "", "", PhysgunSettings )
 	spawnmenu.AddToolMenuOption( "Utilities", "User", "SandboxClientSettings", "#spawnmenu.utilities.sandbox_settings", "", "", SandboxClientSettings )
 	spawnmenu.AddToolMenuOption( "Utilities", "User", "PlayerModelSelector", "#smwidget.playermodel_title", "", "", PlayerOptions )
 
-	spawnmenu.AddToolMenuOption( "Utilities", "Admin", "Admin_Cleanup", "#spawnmenu.utilities.cleanup", "", "", User_Cleanup )
 	spawnmenu.AddToolMenuOption( "Utilities", "Admin", "ServerSettings", "#spawnmenu.utilities.server_settings", "", "", ServerSettings )
 	spawnmenu.AddToolMenuOption( "Utilities", "Admin", "SandboxSettings", "#spawnmenu.utilities.sandbox_settings", "", "", SandboxSettings )
 	spawnmenu.AddToolMenuOption( "Utilities", "Admin", "PhysgunSVSettings", "#spawnmenu.utilities.physgunsettings", "", "", PhysgunSVSettings )

--- a/garrysmod/lua/autorun/utilities_menu.lua
+++ b/garrysmod/lua/autorun/utilities_menu.lua
@@ -11,12 +11,6 @@ local function Undo( pnl )
 
 end
 
-local function User_Cleanup( pnl )
-
-	-- This is added by the cleanup module dynamically
-
-end
-
 local function LoadInConvarDefaults( cvars )
 	for k, v in pairs( cvars ) do
 		local convar = GetConVar( k )

--- a/garrysmod/lua/includes/modules/cleanup.lua
+++ b/garrysmod/lua/includes/modules/cleanup.lua
@@ -233,37 +233,34 @@ if ( SERVER ) then
 
 else
 
-	function UpdateUI()
+	local function BuildPanel( pnl, command )
+		if ( !IsValid( pnl ) ) then return end
 
 		local cleanup_types_s = {}
-		for id, val in pairs( cleanup_types ) do
+
+		for _, val in ipairs( cleanup_types ) do
 			cleanup_types_s[ language.GetPhrase( "Cleanup_" .. val ) ] = val
 		end
 
-		local Panel = controlpanel.Get( "User_Cleanup" )
-		if ( IsValid( Panel ) ) then
-			Panel:Clear()
-			Panel:Help( "#spawnmenu.utilities.cleanup.help" )
-			Panel:Button( "#spawnmenu.utilities.cleanup.all", "gmod_cleanup" )
+		pnl:Clear()
+		pnl:Help( "#spawnmenu.utilities.cleanup.help" )
+		pnl:Button( "#spawnmenu.utilities.cleanup.all", command )
 
-			for key, val in SortedPairs( cleanup_types_s ) do
-				Panel:Button( key, "gmod_cleanup", val )
-			end
+		for key, val in SortedPairs( cleanup_types_s ) do
+			pnl:Button( key, command, val )
 		end
-
-		local AdminPanel = controlpanel.Get( "Admin_Cleanup" )
-		if ( IsValid( AdminPanel ) ) then
-			AdminPanel:Clear()
-			AdminPanel:Help( "#spawnmenu.utilities.cleanup.help" )
-			AdminPanel:Button( "#spawnmenu.utilities.cleanup.all", "gmod_admin_cleanup" )
-
-			for key, val in SortedPairs( cleanup_types_s ) do
-				AdminPanel:Button( key, "gmod_admin_cleanup", val )
-			end
-		end
-
 	end
 
-	hook.Add( "PostReloadToolsMenu", "BuildCleanupUI", UpdateUI )
+	hook.Add( "PopulateToolMenu", "Cleanup_RegisterToolMenu", function()
+
+		spawnmenu.AddToolMenuOption("Utilities", "User", "User_Cleanup", "#spawnmenu.utilities.cleanup", "", "", function( pnl )
+			BuildPanel( pnl, "gmod_cleanup" )
+		end)
+
+		spawnmenu.AddToolMenuOption("Utilities", "Admin", "Admin_Cleanup", "#spawnmenu.utilities.cleanup", "", "", function( pnl )
+			BuildPanel( pnl, "gmod_admin_cleanup" )
+		end)
+
+	end )
 
 end

--- a/garrysmod/lua/includes/modules/cleanup.lua
+++ b/garrysmod/lua/includes/modules/cleanup.lua
@@ -253,13 +253,13 @@ else
 
 	hook.Add( "PopulateToolMenu", "Cleanup_RegisterToolMenu", function()
 
-		spawnmenu.AddToolMenuOption("Utilities", "User", "User_Cleanup", "#spawnmenu.utilities.cleanup", "", "", function( pnl )
+		spawnmenu.AddToolMenuOption( "Utilities", "User", "User_Cleanup", "#spawnmenu.utilities.cleanup", "", "", function( pnl )
 			BuildPanel( pnl, "gmod_cleanup" )
-		end)
+		end )
 
-		spawnmenu.AddToolMenuOption("Utilities", "Admin", "Admin_Cleanup", "#spawnmenu.utilities.cleanup", "", "", function( pnl )
+		spawnmenu.AddToolMenuOption( "Utilities", "Admin", "Admin_Cleanup", "#spawnmenu.utilities.cleanup", "", "", function( pnl )
 			BuildPanel( pnl, "gmod_admin_cleanup" )
-		end)
+		end )
 
 	end )
 

--- a/garrysmod/lua/includes/modules/cleanup.lua
+++ b/garrysmod/lua/includes/modules/cleanup.lua
@@ -237,7 +237,6 @@ else
 		if ( !IsValid( pnl ) ) then return end
 
 		local cleanup_types_s = {}
-
 		for _, val in ipairs( cleanup_types ) do
 			cleanup_types_s[ language.GetPhrase( "Cleanup_" .. val ) ] = val
 		end
@@ -249,6 +248,14 @@ else
 		for key, val in SortedPairs( cleanup_types_s ) do
 			pnl:Button( key, command, val )
 		end
+	end
+
+	function UpdateUI()
+		local Panel = controlpanel.Get( "User_Cleanup" )
+		if ( IsValid( Panel ) ) then BuildPanel( Panel, "gmod_cleanup" ) end
+
+		local Panel = controlpanel.Get( "Admin_Cleanup" )
+		if ( IsValid( Panel ) ) then BuildPanel( Panel, "gmod_admin_cleanup" ) end
 	end
 
 	hook.Add( "PopulateToolMenu", "Cleanup_RegisterToolMenu", function()


### PR DESCRIPTION
The cleanup tool UI currently depends on `controlpanel.Get`, which only works with panels created by the default spawnmenu. As a result, the Cleanup tabs appear empty when using a custom spawnmenu with its own controlpanel.

By replacing this dependency with `spawnmenu.AddToolMenuOption`, the panel is now built directly from the provided instance, making the cleanup UI compatible with both default and custom spawnmenu implementations.

## Screenshots

<img width="642" height="600" alt="{3F800928-FBE6-4A63-9A60-F5EFFBDB5510}" src="https://github.com/user-attachments/assets/acf2a706-95dc-466e-857a-5c0b8b3be0c4" />

<img width="521" height="574" alt="{5A4D7CA2-029E-4573-9652-2359A6686F53}" src="https://github.com/user-attachments/assets/6bd60c7f-aad3-4095-87bb-59cfae41906e" />

