### PR TITLE
`string.ToColor` `.rgb` support without alpha input

### DIFF
--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -343,6 +343,7 @@ end
 function string.ToColor( str )
 
 	local r, g, b, a = string.match( str, "(%d+) (%d+) (%d+) (%d+)" )
+	if ( !a ) then r, g, b = string.match( str, "(%d+) (%d+) (%d+)" )
 	return Color( tonumber( r ) or 255, tonumber( g ) or 255, tonumber( b ) or 255, tonumber( a ) or 255 )
 
 end

--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -343,7 +343,7 @@ end
 function string.ToColor( str )
 
 	local r, g, b, a = string.match( str, "(%d+) (%d+) (%d+) (%d+)" )
-	if ( !a ) then r, g, b = string.match( str, "(%d+) (%d+) (%d+)" )
+	if ( !a ) then r, g, b = string.match( str, "(%d+) (%d+) (%d+)" ) end
 	return Color( tonumber( r ) or 255, tonumber( g ) or 255, tonumber( b ) or 255, tonumber( a ) or 255 )
 
 end


### PR DESCRIPTION
`string.ToColor` by default returns `Color(255, 255, 255, 255)` as fallback, if argument to input has no alpha value. This pull request allow to input string of color without alpha value. For example string `"128 0 0"` as argument will return same Color.