### PR TITLE
`base.fgd` Static prop scale & Render color

### DIFF
--- a/bin/base.fgd
+++ b/bin/base.fgd
@@ -5573,6 +5573,9 @@
 	]
 	lightmapresolutionx(integer) : "Lightmap Resolution X" : 32 : "The resolution of the generated lightmap in the X (or U) direction (only used if Generate Lightmaps is Yes)"
 	lightmapresolutiony(integer) : "Lightmap Resolution Y" : 32 : "The resolution of the generated lightmap in the Y (or V) direction (only used if Generate Lightmaps is Yes)"
+
+	uniformscale(float) : "Uniform Scale Override" : 1 : "Resize the static prop."
+	rendercolor(color255) : "Color (R G B)" : "255 255 255"
 ]
 
 @BaseClass base(Parentname, Global, Angles, Studiomodel, BreakableProp, DXLevelChoice, BaseFadeProp, RenderFields, GMODModelScale, GMODLightOrigin, Shadow) = prop_dynamic_base


### PR DESCRIPTION
Added `uniformscale` and `rendercolor` from CS:GO `base.fgd`:

```cpp
uniformscale(float) : "Uniform Scale Override" : 1 : "Resize the static prop."
rendercolor(color255) : "Color (R G B)" : "255 255 255"
```

Using Render color in Gmod:
<img width="1920" height="1080" alt="image-1012" src="https://github.com/user-attachments/assets/a3ad2aae-52e8-4ff8-9c6c-d54219ff5646" />

We can compile maps with scaled static props for Gmod, using VBSP++ with `-staticpropformat 11` and VRAD++ by ficool2.