### PR TITLE
Avoid to draw `RenderOverlay` on `propspawn` in Resolved depth buffer

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/effects/propspawn.lua
+++ b/garrysmod/gamemodes/sandbox/entities/effects/propspawn.lua
@@ -115,7 +115,9 @@ function EFFECT:RenderParent( flags )
 	render.PopCustomClipPlane()
 	render.EnableClipping( bClipping )
 
-	if ( !isDepthPass ) then
+	local rt = render.GetRenderTarget()
+
+	if ( !isDepthPass and ( !rt or rt:GetName() != "_rt_resolvedfullframedepth" ) ) then
 		self.SpawnEffect:RenderOverlay( self )
 	end
 


### PR DESCRIPTION
Existing check by `isDepthPass` helps for prop spawn, but it not enough for NPCs spawn. Thats why i added check by name of `render.GetRenderTarget()` for avoid calling `RenderOverlay` to `_rt_resolvedfullframedepth`.

As alternative: `if ( !isDepthPass and !rt ) then` check works too. 

Before (`RenderOverlay` force writting color `.rgb` values to resolved depth buffer):
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/31fa3c8d-bb39-438d-952a-a4d4dc60b316" />

After:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c3845fbe-9343-4505-af9d-639d48ac83e2" />
