### PR TITLE
[Menu] Improve character rendering for non-Latin text

### DIFF
--- a/garrysmod/html/js/menu/control.Menu.js
+++ b/garrysmod/html/js/menu/control.Menu.js
@@ -290,13 +290,13 @@ function UpdateLanguages( lang )
 
 	for ( k in lang )
 	{
-		gScope.Languages.push( lang[k].substr( 0, lang[k].length - 4 ) )
+		gScope.Languages.push( lang[k].substr( 0, lang[k].length - 4 ).toLowerCase() )
 	}
 }
 
 function UpdateLanguage( lang )
 {
-	gScope.Language = lang;
+	gScope.Language = lang.toLowerCase();
 	gScope.$broadcast( "languagechanged" );
 	UpdateDigest( gScope, 50 );
 }

--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -449,6 +449,8 @@ function UpdateServer( address, ping, name, map, players, maxplayers, botplayers
 	UpdateDigest( RootScope, 50 );
 }
 
+var locToLang = { "jp": "ja", "cn": "zh-cn", "tw": "zh-tw", "hk": "zh-hk" };
+
 function AddServer( type, id, ping, name, desc, map, players, maxplayers, botplayers, pass, lastplayed, address, gamemode, workshopid, isAnon, version, isFav, loc, gmcat )
 {
 	if ( id != RequestNum[ type ] ) return;
@@ -484,6 +486,7 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 	{
 		ping:			parseInt( ping ),
 		name:			StripWeirdSymbols( name.trim() ),
+		nameLang:		undefined, // For server display name text formatting only
 		desc:			desc,
 		map:			map,
 		players:		parseInt( players ) - parseInt( botplayers ),
@@ -504,6 +507,9 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 	};
 
 	if ( data.flag == "eu" ) data.flag = "europeanunion";
+
+	// For server display name text formatting only, guess Japanese or Chinese variant based on server flag.
+	if ( data.flag != "" && locToLang[ data.flag ] ) data.nameLang = locToLang[ data.flag ];
 
 	if ( !IN_ENGINE && !version ) data.version_c = 0;
 

--- a/garrysmod/html/js/ngLocalize.js
+++ b/garrysmod/html/js/ngLocalize.js
@@ -1,6 +1,7 @@
 
 var languageCache = {};
 var languageCurrent = "";
+var languageCurrentAttr = "en";
 
 angular.module( "ngLocalize", [] )
 
@@ -39,6 +40,9 @@ angular.module( "ngLocalize", [] )
 
 		var updateElement = function( str )
 		{
+			if ( !IS_SPAWN_MENU && element.attr( "lang" ) != languageCurrentAttr )
+				element.attr( "lang", languageCurrentAttr );
+
 			if ( "placeholder" in element[0] )
 			{
 				if ( element.attr( "placeholder" ) != str )
@@ -63,6 +67,7 @@ angular.module( "ngLocalize", [] )
 			if ( languageCurrent != gScope.Language )
 			{
 				languageCurrent = gScope.Language;
+				languageCurrentAttr = ( languageCurrent == "" || languageCurrent == "en-pt" ) ? "en" : languageCurrent;
 				languageCache = {};
 			}
 			update();

--- a/garrysmod/html/js/ngLocalize.js
+++ b/garrysmod/html/js/ngLocalize.js
@@ -10,31 +10,27 @@ angular.module( "ngLocalize", [] )
 	return function( scope, element, attrs )
 	{
 		var strName = "";
-		var strSuffix = "";
 
 		var update = function()
 		{
-			var text = strName + ( strSuffix ? " " + strSuffix : "" );
 
 			if ( !IN_ENGINE )
 			{
-				updateElement( text );
+				updateElement( strName );
 				return;
 			}
 
 			var outStr_old = languageCache[ strName ] || language.Update( strName, function( outStr )
 			{
 				languageCache[ strName ] = outStr;
-				var updatedText = outStr + ( strSuffix ? " " + strSuffix : "" );
-				updateElement( updatedText );
+				updateElement( outStr );
 			} );
 
 			if ( outStr_old )
 			{
 				// Compatibility with Awesomium
 				languageCache[ strName ] = outStr_old;
-				var updatedText = outStr_old + ( strSuffix ? " " + strSuffix : "" );
-				updateElement( updatedText );
+				updateElement( outStr_old );
 			}
 		};
 
@@ -56,9 +52,7 @@ angular.module( "ngLocalize", [] )
 
 		scope.$watch( attrs.ngLocalize, function( value )
 		{
-			var parts = value.split( " " );
-			strName = parts.shift();
-			strSuffix = parts.join( " " );
+			strName = value;
 			update();
 		} );
 

--- a/garrysmod/html/template/servers.html
+++ b/garrysmod/html/template/servers.html
@@ -141,7 +141,8 @@
 								<a class='favbutton {{IfElse( server.favorite, "favorited", "" )}}' ng-click="ToggleFavorite( server );$event.stopPropagation();"></a>
 								<img class="flag" ng-src='asset://garrysmod/materials/flags16/{{server.flag}}.png' onerror="MissingFlag( this )" ng-if="server.flag" loading="lazy"/>
 								<img class="passworded" src='img/server-passworded.png' ng-if="server.pass" loading="lazy"/>
-								<span>{{server.name}}
+								<span>
+									<span ng-attr-lang="{{server.nameLang}}">{{server.name}}</span>
 									<tag class="{{IfElse( server.version_c > 0, 'future', '' )}}" ng-if="server.version_c != 0"><ver_str ng-Localize="server.version_c > 0 ? 'server_ver_new' : 'server_ver_old'"></ver_str>: {{server.version}}</tag>
 								</span>
 							</name>
@@ -165,7 +166,7 @@
 
 						<header>
 							<div class="cell" style="padding-bottom: 5px; padding-right: 8px;">
-								<name>{{CurrentGamemode.Selected.name}}</name>
+								<name ng-attr-lang="{{CurrentGamemode.Selected.nameLang}}">{{CurrentGamemode.Selected.name}}</name>
 								<address>{{CurrentGamemode.Selected.address}}</address>
 							</div>
 						</header>


### PR DESCRIPTION
Fixed a character rendering 'bug', where the menu didn't know what language was being used and therefore didn't know how it should render certain characters. This is most beneficial for languages that don't use Latin characters. 

The most notable improvements are for Chinese and Japanese.
<img width="473" height="419" alt="image" src="https://github.com/user-attachments/assets/1fb30306-00f1-4da2-bf94-e0749c297ad3" /> <img width="506" height="479" alt="image" src="https://github.com/user-attachments/assets/ad883a00-b1b4-4767-b63f-3153bea44ecd" />

- Set the `lang` attribute on translated strings in the menu system, using whatever the selected language is. The browser takes care of the rest.
- Remove the 'suffix' handling in ngLocalize.js - this does not appear to have ever been used.
- Set the `lang` attribute on servers that indicate their flag as Japan, China, Taiwan, or Hong Kong. 
- Note: Changes are not expected to have issues in Awesomium but have not been tested.