### PR TITLE
Add `env_detail_controller` from `csgo.fgd` to `garrysmod.fgd`

### DIFF
--- a/bin/garrysmod.fgd
+++ b/bin/garrysmod.fgd
@@ -193,3 +193,9 @@
 
 	rendercolor(color255) : "Ball Color (R G B)" : "255 255 255" : "The ball color"
 ]
+
+@PointClass base(Angles) = env_detail_controller : "An entity that lets you control the fade distances for detail props."
+[
+	fademindist(float) : "Start Fade Dist/Pixels" : 400 : "Distance at which the prop starts to fade."
+	fademaxdist(float) : "End Fade Dist/Pixels" : 1200 : "Maximum distance at which the prop is visible."
+]


### PR DESCRIPTION
`env_detail_controller` works fine in Gmod.
https://developer.valvesoftware.com/wiki/Env_detail_controller

APC as `prop_detail`.
`fademindist`/`fademaxdist`:
`400`/`800` params:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ffa8a242-4ee9-4b3c-a554-b2b3c10d3ae8" />

`800`/`1200` params:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1fa31770-7bf3-4ea6-ad5f-f6b85a7d7cc5" />

