### PR TITLE
Optimize path functions in string.lua

### DIFF
--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -76,9 +76,9 @@ function string.PatternSafe( str )
 end
 
 --[[---------------------------------------------------------
-	Name: explode(seperator ,string)
+	Name: explode(separator ,string)
 	Desc: Takes a string and turns it into a table
-	Usage: string.explode( " ", "Seperate this string")
+	Usage: string.explode( " ", "Separate this string")
 -----------------------------------------------------------]]
 local totable = string.ToTable
 local string_sub = string.sub
@@ -108,7 +108,7 @@ function string.Split( str, delimiter )
 end
 
 --[[---------------------------------------------------------
-	Name: Implode( seperator, Table)
+	Name: Implode( separator, Table)
 	Desc: Takes a table and turns it into a string
 	Usage: string.Implode( " ", { "This", "Is", "A", "Table" } )
 -----------------------------------------------------------]]
@@ -123,9 +123,15 @@ end
 -----------------------------------------------------------]]
 function string.GetExtensionFromFilename( path )
 	for i = #path, 1, -1 do
-		local c = string.sub( path, i, i )
-		if ( c == "/" or c == "\\" ) then return nil end
-		if ( c == "." ) then return string.sub( path, i + 1 ) end
+		local c = path:byte(i)
+
+		if c == 47 or c == 92 then -- / or \
+			return nil
+		end
+
+		if c == 46 then -- .
+			return path:sub(i + 1)
+		end
 	end
 
 	return nil
@@ -136,9 +142,13 @@ end
 -----------------------------------------------------------]]
 function string.StripExtension( path )
 	for i = #path, 1, -1 do
-		local c = string.sub( path, i, i )
-		if ( c == "/" or c == "\\" ) then return path end
-		if ( c == "." ) then return string.sub( path, 1, i - 1 ) end
+		local c = path:byte(i)
+
+		if c == 47 or c == 92 then -- / or \
+			return path
+		elseif c == 46 then -- .
+			return path:sub(1, i - 1)
+		end
 	end
 
 	return path
@@ -146,13 +156,16 @@ end
 
 --[[---------------------------------------------------------
 	Name: GetPathFromFilename( path )
-	Desc: Returns path from filepath
+	Desc: Returns path from file path
 	Usage: string.GetPathFromFilename("garrysmod/lua/modules/string.lua")
 -----------------------------------------------------------]]
 function string.GetPathFromFilename( path )
 	for i = #path, 1, -1 do
-		local c = string.sub( path, i, i )
-		if ( c == "/" or c == "\\" ) then return string.sub( path, 1, i ) end
+		local c = path:byte(i)
+
+		if c == 47 or c == 92 then -- / or \
+			return path:sub(1, i)
+		end
 	end
 
 	return ""
@@ -165,8 +178,11 @@ end
 -----------------------------------------------------------]]
 function string.GetFileFromFilename( path )
 	for i = #path, 1, -1 do
-		local c = string.sub( path, i, i )
-		if ( c == "/" or c == "\\" ) then return string.sub( path, i + 1 ) end
+		local c = path:byte(i)
+
+		if c == 47 or c == 92 then -- / or \
+			return path:sub(i + 1)
+		end
 	end
 
 	return path
@@ -176,7 +192,7 @@ end
 	Name: FormattedTime( TimeInSeconds, Format )
 	Desc: Given a time in seconds, returns formatted time
 			If 'Format' is not specified the function returns a table
-			conatining values for hours, mins, secs, ms
+			containing values for hours, mins, secs, ms
 
 	Examples: string.FormattedTime( 123.456, "%02i:%02i:%02i")	==> "02:03:45"
 			  string.FormattedTime( 123.456, "%02i:%02i")		==> "02:03"

--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -123,14 +123,14 @@ end
 -----------------------------------------------------------]]
 function string.GetExtensionFromFilename( path )
 	for i = #path, 1, -1 do
-		local c = path:byte(i)
+		local c = string.byte( path, i )
 
-		if c == 47 or c == 92 then -- / or \
+		if ( c == 47 or c == 92 ) then -- Slash
 			return nil
 		end
 
-		if c == 46 then -- .
-			return path:sub(i + 1)
+		if ( c == 46 ) then -- Point
+			return string.sub( path, i + 1 )
 		end
 	end
 
@@ -142,12 +142,12 @@ end
 -----------------------------------------------------------]]
 function string.StripExtension( path )
 	for i = #path, 1, -1 do
-		local c = path:byte(i)
+		local c = string.byte( path, i )
 
-		if c == 47 or c == 92 then -- / or \
+		if ( c == 47 or c == 92 ) then -- Slash
 			return path
-		elseif c == 46 then -- .
-			return path:sub(1, i - 1)
+		elseif ( c == 46 ) then -- Point
+			return string.sub( path, 1, i - 1 )
 		end
 	end
 
@@ -161,10 +161,10 @@ end
 -----------------------------------------------------------]]
 function string.GetPathFromFilename( path )
 	for i = #path, 1, -1 do
-		local c = path:byte(i)
+		local c = string.byte( path, i )
 
-		if c == 47 or c == 92 then -- / or \
-			return path:sub(1, i)
+		if ( c == 47 or c == 92 ) then -- Slash
+			return string.sub( path, 1, i )
 		end
 	end
 
@@ -178,10 +178,10 @@ end
 -----------------------------------------------------------]]
 function string.GetFileFromFilename( path )
 	for i = #path, 1, -1 do
-		local c = path:byte(i)
+		local c = string.byte( path, i )
 
-		if c == 47 or c == 92 then -- / or \
-			return path:sub(i + 1)
+		if ( c == 47 or c == 92 ) then -- Slash
+			return string.sub( path, i + 1 )
 		end
 	end
 

--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -2,6 +2,12 @@
 local string = string
 local math = math
 
+-- Allow these, but no more
+local string_sub = string.sub
+local string_gsub = string.gsub
+local string_len = string.len
+local string_byte = string.byte
+
 --[[---------------------------------------------------------
 	Name: string.ToTable( string )
 -----------------------------------------------------------]]
@@ -12,7 +18,7 @@ function string.ToTable( input )
 	local str = tostring( input )
 
 	for i = 1, #str do
-		tbl[i] = string.sub( str, i, i )
+		tbl[i] = string_sub( str, i, i )
 	end
 
 	return tbl
@@ -41,11 +47,11 @@ local javascript_escape_replacements = {
 
 function string.JavascriptSafe( str )
 
-	str = string.gsub( str, ".", javascript_escape_replacements )
+	str = string_gsub( str, ".", javascript_escape_replacements )
 
 	-- U+2028 and U+2029 are treated as line separators in JavaScript, handle separately as they aren't single-byte
-	str = string.gsub( str, "\226\128\168", "\\\226\128\168" )
-	str = string.gsub( str, "\226\128\169", "\\\226\128\169" )
+	str = string_gsub( str, "\226\128\168", "\\\226\128\168" )
+	str = string_gsub( str, "\226\128\169", "\\\226\128\169" )
 
 	return str
 
@@ -72,20 +78,18 @@ local pattern_escape_replacements = {
 }
 
 function string.PatternSafe( str )
-	return ( string.gsub( str, ".", pattern_escape_replacements ) )
+	return ( string_gsub( str, ".", pattern_escape_replacements ) )
 end
 
 --[[---------------------------------------------------------
-	Name: explode(separator ,string)
+	Name: Explode( separator, string )
 	Desc: Takes a string and turns it into a table
-	Usage: string.explode( " ", "Separate this string")
+	Usage: string.Explode( " ", "Separate this string")
 -----------------------------------------------------------]]
-local totable = string.ToTable
-local string_sub = string.sub
+local string_ToTable = string.ToTable
 local string_find = string.find
-local string_len = string.len
 function string.Explode( separator, str, withpattern )
-	if ( separator == "" ) then return totable( str ) end
+	if ( separator == "" ) then return string_ToTable( str ) end
 	if ( withpattern == nil ) then withpattern = false end
 
 	local ret = {}
@@ -108,7 +112,7 @@ function string.Split( str, delimiter )
 end
 
 --[[---------------------------------------------------------
-	Name: Implode( separator, Table)
+	Name: Implode( separator, Table )
 	Desc: Takes a table and turns it into a string
 	Usage: string.Implode( " ", { "This", "Is", "A", "Table" } )
 -----------------------------------------------------------]]
@@ -123,14 +127,14 @@ end
 -----------------------------------------------------------]]
 function string.GetExtensionFromFilename( path )
 	for i = #path, 1, -1 do
-		local c = string.byte( path, i )
+		local c = string_byte( path, i )
 
 		if ( c == 47 or c == 92 ) then -- Slash
 			return nil
 		end
 
 		if ( c == 46 ) then -- Point
-			return string.sub( path, i + 1 )
+			return string_sub( path, i + 1 )
 		end
 	end
 
@@ -142,12 +146,12 @@ end
 -----------------------------------------------------------]]
 function string.StripExtension( path )
 	for i = #path, 1, -1 do
-		local c = string.byte( path, i )
+		local c = string_byte( path, i )
 
 		if ( c == 47 or c == 92 ) then -- Slash
 			return path
 		elseif ( c == 46 ) then -- Point
-			return string.sub( path, 1, i - 1 )
+			return string_sub( path, 1, i - 1 )
 		end
 	end
 
@@ -161,10 +165,10 @@ end
 -----------------------------------------------------------]]
 function string.GetPathFromFilename( path )
 	for i = #path, 1, -1 do
-		local c = string.byte( path, i )
+		local c = string_byte( path, i )
 
 		if ( c == 47 or c == 92 ) then -- Slash
-			return string.sub( path, 1, i )
+			return string_sub( path, 1, i )
 		end
 	end
 
@@ -178,10 +182,10 @@ end
 -----------------------------------------------------------]]
 function string.GetFileFromFilename( path )
 	for i = #path, 1, -1 do
-		local c = string.byte( path, i )
+		local c = string_byte( path, i )
 
 		if ( c == 47 or c == 92 ) then -- Slash
-			return string.sub( path, i + 1 )
+			return string_sub( path, i + 1 )
 		end
 	end
 
@@ -257,8 +261,8 @@ function string.NiceTime( seconds )
 
 end
 
-function string.Left( str, num ) return string.sub( str, 1, num ) end
-function string.Right( str, num ) return string.sub( str, -num ) end
+function string.Left( str, num ) return string_sub( str, 1, num ) end
+function string.Right( str, num ) return string_sub( str, -num ) end
 
 function string.Replace( str, tofind, toreplace )
 	local tbl = string.Explode( tofind, str )
@@ -314,13 +318,13 @@ end
 
 function string.SetChar( s, k, v )
 
-	return string.sub( s, 0, k - 1 ) .. v .. string.sub( s, k + 1 )
+	return string_sub( s, 0, k - 1 ) .. v .. string_sub( s, k + 1 )
 
 end
 
 function string.GetChar( s, k )
 
-	return string.sub( s, k, k )
+	return string_sub( s, k, k )
 
 end
 
@@ -332,21 +336,21 @@ function meta:__index( key )
 	if ( val ~= nil ) then
 		return val
 	elseif ( tonumber( key ) ) then
-		return string.sub( self, key, key )
+		return string_sub( self, key, key )
 	end
 
 end
 
 function string.StartsWith( str, start )
 
-	return string.sub( str, 1, string.len( start ) ) == start
+	return string_sub( str, 1, string_len( start ) ) == start
 
 end
 string.StartWith = string.StartsWith
 
 function string.EndsWith( str, endStr )
 
-	return endStr == "" or string.sub( str, -string.len( endStr ) ) == endStr
+	return endStr == "" or string_sub( str, -string_len( endStr ) ) == endStr
 
 end
 
@@ -380,7 +384,7 @@ function string.Comma( number, str )
 	end
 
 	local index = -1
-	while index ~= 0 do number, index = string.gsub( number, "^(-?%d+)(%d%d%d)", replace ) end
+	while index ~= 0 do number, index = string_gsub( number, "^(-?%d+)(%d%d%d)", replace ) end
 
 	return number
 
@@ -388,7 +392,7 @@ end
 
 function string.Interpolate( str, lookuptable )
 
-	return ( string.gsub( str, "{([_%a][_%w]*)}", lookuptable ) )
+	return ( string_gsub( str, "{([_%a][_%w]*)}", lookuptable ) )
 
 end
 
@@ -448,14 +452,14 @@ function string.NiceName( name )
 		if ( #word == 1 ) then
 			newParts[i] = string.upper( word )
 		else
-			newParts[i] = string.upper( string.sub( word, 1, 1 ) ) .. string.sub( word, 2 )
+			newParts[i] = string.upper( string_sub( word, 1, 1 ) ) .. string_sub( word, 2 )
 		end
 	end
 
 	return table.concat( newParts, " " )]]
 
 	local ret = table.concat( newParts, " " )
-	ret = string.upper( string.sub( ret, 1, 1 ) ) .. string.sub( ret, 2 )
+	ret = string.upper( string_sub( ret, 1, 1 ) ) .. string_sub( ret, 2 )
 	return ret
 
 end


### PR DESCRIPTION
Hi,

Basically, avoid string comparison and escape, then allocating spaces for substrings.

Testing methodology:
```lua
local foo1 = {}
local foo2 = {}
local foo3 = {}
local foo4 = {}

foo1[1] = string.GetFileFromFilename
foo2[1] = string.GetPathFromFilename
foo3[1] = string.GetExtensionFromFilename
foo4[1] = string.StripExtension

function string.StripExtension(path)
    for i = #path, 1, -1 do
        local c = path:byte(i)

        if c == 47 or c == 92 then -- / or \
            return path
        elseif c == 46 then -- .
            return path:sub(1, i - 1)
        end
    end

    return path
end

function string.GetFileFromFilename(path)
    for i = #path, 1, -1 do
        local c = path:byte(i)

        if c == 47 or c == 92 then -- / or \
            return path:sub(i + 1)
        end
    end

    return path
end

function string.GetExtensionFromFilename(path)
    for i = #path, 1, -1 do
        local c = path:byte(i)

        if c == 47 or c == 92 then -- / or \
            return nil
        end

        if c == 46 then -- .
            return path:sub(i + 1)
        end
    end

    return nil
end

function string.GetPathFromFilename(path)
    for i = #path, 1, -1 do
        local c = path:byte(i)

        if c == 47 or c == 92 then -- / or \
            return path:sub(1, i)
        end
    end

    return ""
end

foo1[2] = string.GetFileFromFilename
foo2[2] = string.GetPathFromFilename
foo3[2] = string.GetExtensionFromFilename
foo4[2] = string.StripExtension

local t = {
"/aaa/bbb/ccc/te.st.mdl",
"aaa/bbb/ccc/te.st.mdl",
"/bbb/ccc/te.st.mdl",
"bbb////cc/te.st.mdl",
"/ccc/te.st.mdl",
"ccc///te.st.mdl",
"/te.st.mdl",
"te.st.mdl",
"te.st",
".mdl",
"."
}


function compare(bar)
  print("----------")
  print(bar[1], "~=", bar[2])
  for i = 1, #t do
    local o = bar[1](t[i])
    local n = bar[2](t[i])
    print(o == n, o, " = ", n)
  end
end

compare(foo1)
compare(foo2)
compare(foo3)
compare(foo4)
```

Results:
```
----------
function: 0x01090b18	~=	function: 0x01cd9028
true	te.st.mdl	 = 	te.st.mdl
true	te.st.mdl	 = 	te.st.mdl
true	te.st.mdl	 = 	te.st.mdl
true	te.st.mdl	 = 	te.st.mdl
true	te.st.mdl	 = 	te.st.mdl
true	te.st.mdl	 = 	te.st.mdl
true	te.st.mdl	 = 	te.st.mdl
true	te.st.mdl	 = 	te.st.mdl
true	te.st	 = 	te.st
true	.mdl	 = 	.mdl
true	.	 = 	.
----------
function: 0x01076638	~=	function: 0x01cfb510
true	/aaa/bbb/ccc/	 = 	/aaa/bbb/ccc/
true	aaa/bbb/ccc/	 = 	aaa/bbb/ccc/
true	/bbb/ccc/	 = 	/bbb/ccc/
true	bbb////cc/	 = 	bbb////cc/
true	/ccc/	 = 	/ccc/
true	ccc///	 = 	ccc///
true	/	 = 	/
true		 = 	
true		 = 	
true		 = 	
true		 = 	
----------
function: 0x01039368	~=	function: 0x01ce49b0
true	mdl	 = 	mdl
true	mdl	 = 	mdl
true	mdl	 = 	mdl
true	mdl	 = 	mdl
true	mdl	 = 	mdl
true	mdl	 = 	mdl
true	mdl	 = 	mdl
true	mdl	 = 	mdl
true	st	 = 	st
true	mdl	 = 	mdl
true		 = 	
----------
function: 0x01076618	~=	function: 0x01cd5a60
true	/aaa/bbb/ccc/te.st	 = 	/aaa/bbb/ccc/te.st
true	aaa/bbb/ccc/te.st	 = 	aaa/bbb/ccc/te.st
true	/bbb/ccc/te.st	 = 	/bbb/ccc/te.st
true	bbb////cc/te.st	 = 	bbb////cc/te.st
true	/ccc/te.st	 = 	/ccc/te.st
true	ccc///te.st	 = 	ccc///te.st
true	/te.st	 = 	/te.st
true	te.st	 = 	te.st
true	te	 = 	te
true		 = 	
true		 = 	
```