### PR TITLE
Try to fix rare prop_effect error

### DIFF
--- a/garrysmod/gamemodes/base/entities/entities/prop_effect.lua
+++ b/garrysmod/gamemodes/base/entities/entities/prop_effect.lua
@@ -26,6 +26,7 @@ function ENT:Initialize()
 		self.AttachedEntity:SetSkin( self:GetSkin() )
 		self.AttachedEntity:Spawn()
 		self.AttachedEntity:SetParent( self )
+		self.AttachedEntity:SetTransmitWithParent( true )
 		self.AttachedEntity:DrawShadow( false )
 
 		self:SetModel( "models/props_junk/watermelon01.mdl" )


### PR DESCRIPTION
Sometimes i see errors where AttachedEntity is nil for some players. This is probably because prop_effect was networked, but its children isn't

Simply adding `:SetTransmitWithParent(true)` should fix this and make it more reliable