### PR TITLE
Fix case where PositionSpawnIcon would get wrong renderbounds size

### DIFF
--- a/garrysmod/lua/includes/util/client.lua
+++ b/garrysmod/lua/includes/util/client.lua
@@ -225,10 +225,7 @@ function PositionSpawnIcon( model, pos, noAngles )
 
 	local mn, mx = model:GetRenderBounds()
 	local middle = ( mn + mx ) * 0.5
-	local size = 0
-	size = math.max( size, math.abs( mn.x ) + math.abs( mx.x ) )
-	size = math.max( size, math.abs( mn.y ) + math.abs( mx.y ) )
-	size = math.max( size, math.abs( mn.z ) + math.abs( mx.z ) )
+	local size = math.max( 0, mx.x - mn.x, mx.y - mn.y, mx.z - mn.z )
 
 	model:SetPos( pos )
 	if ( !noAngles ) then model:SetAngles( angle_zero ) end


### PR DESCRIPTION
If a model's renderbounds have an axis that's positive in both the mins and maxs (common for a lot of TF2 hats for some reason, where the model origin is offset far from the renderbounds), the math in this func would assume the mins were negative anyway, and come back with a huge size value. This caused a lot of spawnicons to render way too zoomed out by default.

This PR fixes the issue with these models, letting the spawnicons render correctly, but shouldn't change anything for models that didn't have this problem.

<img width="1778" height="1040" alt="positionspawnicon_fix" src="https://github.com/user-attachments/assets/ff7cd969-cef4-4b3c-8ff9-2d71c1e836d6" />
