### PR TITLE
Add dormancy check to `DynamicLight` creation

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/entities/gmod_light.lua
+++ b/garrysmod/gamemodes/sandbox/entities/entities/gmod_light.lua
@@ -57,7 +57,7 @@ function ENT:Think()
 	self.BaseClass.Think( self )
 
 	if ( CLIENT ) then
-
+		if ( self:IsDormant() ) then return end
 		if ( !self:GetOn() ) then return end
 
 		local noworld = self:GetLightWorld()

--- a/garrysmod/gamemodes/sandbox/entities/entities/gmod_light.lua
+++ b/garrysmod/gamemodes/sandbox/entities/entities/gmod_light.lua
@@ -57,6 +57,7 @@ function ENT:Think()
 	self.BaseClass.Think( self )
 
 	if ( CLIENT ) then
+
 		if ( self:IsDormant() ) then return end
 		if ( !self:GetOn() ) then return end
 


### PR DESCRIPTION
Currently `DynamicLight` is always created even if the entity is dormany, taking up scarce dlight slots which breaks other lamps. Only creating them when in PVS makes it so we're not hitting the dlight limit as much.