### PR TITLE
Added `STUDIO_SKIP_DECALS` for Halos

### DIFF
--- a/garrysmod/lua/includes/modules/halo.lua
+++ b/garrysmod/lua/includes/modules/halo.lua
@@ -9,7 +9,7 @@ local rt_Blur		= render.GetScreenEffectTexture( 1 )
 
 local List = {}
 local RenderEnt = NULL
-local flags = bit.bor( STUDIO_RENDER, STUDIO_SKIP_DECALS )
+local modelFlags = bit.bor( STUDIO_RENDER, STUDIO_SKIP_DECALS )
 
 function Add( entities, color, blurx, blury, passes, add, ignorez )
 
@@ -74,7 +74,7 @@ function Render( entry )
 
 						RenderEnt = v
 
-						v:DrawModel( flags )
+						v:DrawModel( modelFlags )
 					end
 
 					RenderEnt = NULL

--- a/garrysmod/lua/includes/modules/halo.lua
+++ b/garrysmod/lua/includes/modules/halo.lua
@@ -9,7 +9,7 @@ local rt_Blur		= render.GetScreenEffectTexture( 1 )
 
 local List = {}
 local RenderEnt = NULL
-local flags = bit.band( STUDIO_RENDER, STUDIO_SKIP_DECALS )
+local flags = bit.bor( STUDIO_RENDER, STUDIO_SKIP_DECALS )
 
 function Add( entities, color, blurx, blury, passes, add, ignorez )
 

--- a/garrysmod/lua/includes/modules/halo.lua
+++ b/garrysmod/lua/includes/modules/halo.lua
@@ -9,6 +9,7 @@ local rt_Blur		= render.GetScreenEffectTexture( 1 )
 
 local List = {}
 local RenderEnt = NULL
+local flags = bit.band( STUDIO_RENDER, STUDIO_SKIP_DECALS )
 
 function Add( entities, color, blurx, blury, passes, add, ignorez )
 
@@ -73,7 +74,7 @@ function Render( entry )
 
 						RenderEnt = v
 
-						v:DrawModel()
+						v:DrawModel( flags )
 					end
 
 					RenderEnt = NULL


### PR DESCRIPTION
Default flag is a `STUDIO_RENDER`. So we combine it with `STUDIO_SKIP_DECALS`, using `bit.bor`, before the `Render` function.