### PR TITLE
Add `Entity:Set/GetUseDistance`

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/player_shd.lua
+++ b/garrysmod/gamemodes/base/gamemode/player_shd.lua
@@ -107,12 +107,18 @@ function GM:FindUseEntity( ply, ent )
 
 	-- Simple fix to allow entities inside playerclip brushes to be used. Necessary for c1a0c map in Half-Life: Source 
 	if ( !IsValid( ent ) ) then
-		local traceEnt = util.TraceLine( {
+		local tr = util.TraceLine( {
 			start = ply:GetShootPos(),
-			endpos = ply:GetShootPos() + ply:GetAimVector() * 72,
+			endpos = ply:GetShootPos() + ply:GetAimVector() * 4096,
 			filter = ply
-		} ).Entity
-		if ( IsValid( traceEnt ) ) then return traceEnt end
+		} )
+
+		local traceEnt = tr.Entity
+
+		if ( IsValid( traceEnt ) && tr.StartPos:Distance(tr.HitPos) <= traceEnt:GetUseDistance() ) then
+			return traceEnt
+		end
+
 	end
 
 	return ent

--- a/garrysmod/gamemodes/base/gamemode/player_shd.lua
+++ b/garrysmod/gamemodes/base/gamemode/player_shd.lua
@@ -105,23 +105,22 @@ function GM:FindUseEntity( ply, ent )
 	-- ent is what the game found to use by default
 	-- return what you REALLY want it to use
 
-	-- Simple fix to allow entities inside playerclip brushes to be used. Necessary for c1a0c map in Half-Life: Source 
-	if ( !IsValid( ent ) ) then
-		local tr = util.TraceLine( {
-			start = ply:GetShootPos(),
-			endpos = ply:GetShootPos() + ply:GetAimVector() * 4096,
-			filter = ply
-		} )
+	-- this fixes entities inside playerclip brushes to be used. 
+	-- Necessary for c1a0c map in Half-Life: Source 
+	local startPos = ply:GetShootPos()
+	local tr = util.TraceLine( {
+		start = startPos,
+		endpos = startPos + ply:GetAimVector() * 4096,
+		filter = ply
+	} )
 
-		local traceEnt = tr.Entity
+	local traceEnt = tr.Entity
 
-		if ( IsValid( traceEnt ) && tr.StartPos:Distance(tr.HitPos) <= traceEnt:GetUseDistance() ) then
-			return traceEnt
-		end
-
+	if ( IsValid( traceEnt ) && tr.StartPos:Distance( tr.HitPos ) <= traceEnt:GetUseDistance() ) then
+		return traceEnt
 	end
 
-	return ent
+	return NULL
 
 end
 

--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -82,6 +82,16 @@ if ( SERVER ) then
 		return self.m_PlayerCreator or NULL
 	end
 
+	local DEFAULT_USE_DISTANCE = 72
+
+	function meta:SetUseDistance( dist )
+		self.m_fUseDistance = dist
+	end
+
+	function meta:GetUseDistance()
+		return self.m_fUseDistance or DEFAULT_USE_DISTANCE
+	end
+
 end
 
 --[[---------------------------------------------------------


### PR DESCRIPTION
This PR adds two server-only functions: 
- `Entity:SetUseDistance( float dist )` 
- `float Entity:GetUseDistance()`

This gives a way to easily change what the distance between the player and the entity has to be for them to pick it up. I had a situation with an addon I was working on where I needed exactly this, but instead I had to make a whole FindUseEntity hook with custom logic. 

Additionally, this could be used for the default wheel tool. While aiming at them, the halo and tool tip/overlay text appear at a farther distance than the wheel's use distance, so this can be used to fix the distance discrepancy. 