### PR TITLE
Add `:Left()` angle/vector functions

### DIFF
--- a/garrysmod/lua/includes/extensions/angle.lua
+++ b/garrysmod/lua/includes/extensions/angle.lua
@@ -17,3 +17,9 @@ function meta:SnapTo( component, degrees )
 	return self
 
 end
+
+function meta:Left()
+	local vec = self:Right()
+	vec:Mul( -1 )
+	return vec
+end

--- a/garrysmod/lua/includes/extensions/angle.lua
+++ b/garrysmod/lua/includes/extensions/angle.lua
@@ -23,3 +23,15 @@ function meta:Left()
 	vec:Mul( -1 )
 	return vec
 end
+
+function meta:Backward()
+	local vec = self:Forward()
+	vec:Mul( -1 )
+	return vec
+end
+
+function meta:Down()
+	local vec = self:Up()
+	vec:Mul( -1 )
+	return vec
+end

--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -30,6 +30,18 @@ function meta:GetLeft()
 	return vec
 end
 
+function meta:GetBackward()
+	local vec = self:GetForward()
+	vec:Mul( -1 )
+	return vec
+end
+
+function meta:GetDown()
+	local vec = self:GetUp()
+	vec:Mul( -1 )
+	return vec
+end
+
 --
 -- Entity index accessor. This used to be done in engine, but it's done in Lua now because it's faster
 --

--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -24,6 +24,12 @@ function meta:SetShouldPlayPickupSound( bPlaySound )
 	self.m_bPlayPickupSound = tobool( bPlaySound ) or false
 end
 
+function meta:GetLeft()
+	local vec = self:GetRight()
+	vec:Mul( -1 )
+	return vec
+end
+
 --
 -- Entity index accessor. This used to be done in engine, but it's done in Lua now because it's faster
 --

--- a/garrysmod/lua/includes/extensions/vmatrix.lua
+++ b/garrysmod/lua/includes/extensions/vmatrix.lua
@@ -1,0 +1,12 @@
+local meta = FindMetaTable( "VMatrix" )
+
+function meta:GetLeft()
+	local vec = self:GetRight()
+	vec:Mul( -1 )
+	return vec
+end
+
+function meta:SetLeft( vec )
+	if ( !isvector( vec ) ) then error( "bad argument #1 to 'SetLeft' (Vector expected, got " .. type( vec ) .. ")", 2 ) end
+	self:SetRight( vec * -1 )
+end

--- a/garrysmod/lua/includes/extensions/vmatrix.lua
+++ b/garrysmod/lua/includes/extensions/vmatrix.lua
@@ -6,7 +6,29 @@ function meta:GetLeft()
 	return vec
 end
 
+function meta:GetBackward()
+	local vec = self:GetForward()
+	vec:Mul( -1 )
+	return vec
+end
+
+function meta:GetDown()
+	local vec = self:GetUp()
+	vec:Mul( -1 )
+	return vec
+end
+
 function meta:SetLeft( vec )
 	if ( !isvector( vec ) ) then error( "bad argument #1 to 'SetLeft' (Vector expected, got " .. type( vec ) .. ")", 2 ) end
 	self:SetRight( vec * -1 )
+end
+
+function meta:SetBackward( vec )
+	if ( !isvector( vec ) ) then error( "bad argument #1 to 'SetBackward' (Vector expected, got " .. type( vec ) .. ")", 2 ) end
+	self:SetForward( vec * -1 )
+end
+
+function meta:SetDown( vec )
+	if ( !isvector( vec ) ) then error( "bad argument #1 to 'SetDown' (Vector expected, got " .. type( vec ) .. ")", 2 ) end
+	self:SetUp( vec * -1 )
 end

--- a/garrysmod/lua/includes/init.lua
+++ b/garrysmod/lua/includes/init.lua
@@ -110,6 +110,7 @@ include( "extensions/game.lua" )
 include( "extensions/motionsensor.lua" )
 include( "extensions/weapon.lua" )
 include( "extensions/coroutine.lua" )
+include( "extensions/vmatrix.lua" )
 
 if ( CLIENT ) then
 


### PR DESCRIPTION
### Summary

Adds `:Left()` variants of `:Right()` angle/vector functions.

_Optional extra:_ For consistency, the second commit adds `:Backward()` and `:Down()` variants of `:Forward()` and `:Up()`.

---
### Background

The [Source Engine's 3D coordinate system](https://developer.valvesoftware.com/wiki/Coordinates) uses the 'Right-hand rule'.
Coordinates are (X,Y,Z), where X is forward, Y is left, and Z is up.
<img height="170" alt="[x/y axis graph]" src="https://github.com/user-attachments/assets/7caaa978-3e8d-4b36-bb32-7031bc8c58a3" /> <img height="170" alt="[right-hand rule]" src="https://github.com/user-attachments/assets/6789cc63-2d41-4ee0-8eb9-41cea35abefd" /> <details><summary><mark>(Click to view more images)</mark> </summary>
<img alt="[ingame image]" src="https://github.com/user-attachments/assets/a8f72aa2-4b82-422b-846d-ea4d5a8e648f" />
<img alt="[ingame image]" src="https://github.com/user-attachments/assets/362b4cef-40ed-4767-8ed0-8165de8ba135" />
<img alt="[ingame image]" src="https://github.com/user-attachments/assets/94707f3a-9d9a-4764-966e-1ca5a435f339" />
<img alt="[ingame image]" src="https://github.com/user-attachments/assets/80b7ff25-a31b-4b6a-9693-f08ec54769ca" />
<img alt="[x/y axis graph]" src="https://github.com/user-attachments/assets/7caaa978-3e8d-4b36-bb32-7031bc8c58a3" />
<img alt="[right-hand rule]" src="https://github.com/user-attachments/assets/6789cc63-2d41-4ee0-8eb9-41cea35abefd" /> </details>
#### Gmod's functions

Gmod angles/vectors have functions for `:Forward()`, `:Right()`, `:Up()`. 
`Forward` is X in the positive direction
`Right` is Y in the negative direction
`Up` is Z in the positive direction

<img width="187" height="83" alt="Image" src="https://github.com/user-attachments/assets/ddea0938-b530-43a6-bf21-c30cf60d843b" />

#### Problem
Developers need to use `(+Forward, -Right, +Up)` as there is no `:Left()`.
Gmod providing `Forward`/`Right`/`Up` and not providing their opposites implies they are the positive directions, and developers may not realise that isn't the case until they encounter unexpected issues or research it.
Even once they are aware, because there is no `:Left()` they must continue to use `(+,-,+)` which is unintuitive. 

---

### PR Details - `:Left()`

Adding a `:Left()` allows developers to use `(+Forward, +Left, +Up)` when working with angles/vectors. This is more intuitive for use with Source's coordinate system.
_Optional extra:_ For consistency, `:Backward()` and `:Down()` variants are included in the second commit.

<img width="586" height="119" alt="image" src="https://github.com/user-attachments/assets/df42c9ee-c5b6-4e21-8537-0f29abdf9ca4" />

Developers can still use `:Right()`. It hasn't been removed or changed. There are no changes to Gmod's coordinates system.

#### Function list
"`Left`" functions as the positive direction opposite the existing negative direction "`Right`" functions.
- `Angle:Left()`, as related to [`Angle:Right()`](https://wiki.facepunch.com/gmod/Angle:Right) 
- `Entity:GetLeft()`, as related to [`Entity:GetRight()`](https://wiki.facepunch.com/gmod/Entity:GetRight)
- `VMatrix:GetLeft()`, as related to [`VMatrix:GetRight()`](https://wiki.facepunch.com/gmod/VMatrix:GetRight)
- `VMatrix:SetLeft()`, as related to [`VMatrix:SetRight()`](https://wiki.facepunch.com/gmod/VMatrix:SetRight)

As per the existing positive direction Forward/Up versions of the above, the second commit includes negative direction Backward/Down versions of above too.

#### Demo
Demo of `Entity:Get*()`. The red/green/blue lines correspond to the X/Y/Z axis and are drawn in the positive direction.

https://github.com/user-attachments/assets/81166f56-252f-4628-be46-395e95fe9ea9

Credit to @marchc1 and @Grocel for code collaboration
Original suggestion https://github.com/Facepunch/garrysmod-requests/issues/3168