### PR TITLE
[Terrotown] Optimize distance checks by replacing Distance with DistToSqr

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
@@ -466,6 +466,7 @@ if SERVER then
       net.Send(ply)
    end
 
+   local distanceMax = 256 ^ 2
    local function ReceiveC4Config(ply, cmd, args)
       if not (IsValid(ply) and ply:IsTerror() and #args == 2) then return end
       local idx = tonumber(args[1])
@@ -476,7 +477,7 @@ if SERVER then
       local bomb = ents.GetByIndex(idx)
       if IsValid(bomb) and bomb:GetClass() == "ttt_c4" and (not bomb:GetArmed()) then
 
-         if bomb:GetPos():Distance(ply:GetPos()) > 256 then
+         if bomb:GetPos():DistToSqr(ply:GetPos()) > distanceMax then
             -- These cases should never arise in normal play, so no messages
             return
          elseif time < C4_MINIMUM_TIME or time > C4_MAXIMUM_TIME then
@@ -512,7 +513,7 @@ if SERVER then
 
       local bomb = ents.GetByIndex(idx)
       if IsValid(bomb) and bomb:GetClass() == "ttt_c4" and not bomb.DisarmCausedExplosion and bomb:GetArmed() then
-         if bomb:GetPos():Distance(ply:GetPos()) > 256 then
+         if bomb:GetPos():DistToSqr(ply:GetPos()) > distanceMax then
             return
          elseif bomb.SafeWires[wire] or ply:IsTraitor() or ply == bomb:GetOwner() then
             LANG.Msg(ply, "c4_disarmed")
@@ -540,7 +541,7 @@ if SERVER then
 
       local bomb = ents.GetByIndex(idx)
       if IsValid(bomb) and bomb:GetClass() == "ttt_c4" and (not bomb:GetArmed()) then
-         if bomb:GetPos():Distance(ply:GetPos()) > 256 then
+         if bomb:GetPos():DistToSqr(ply:GetPos()) > distanceMax then
             return
          elseif not ply:CanCarryType(WEAPON_EQUIP1) then
             LANG.Msg(ply, "c4_no_room")
@@ -571,7 +572,7 @@ if SERVER then
 
       local bomb = ents.GetByIndex(idx)
       if IsValid(bomb) and bomb:GetClass() == "ttt_c4" and (not bomb:GetArmed()) then
-         if bomb:GetPos():Distance(ply:GetPos()) > 256 then
+         if bomb:GetPos():DistToSqr(ply:GetPos()) > distanceMax then
             return
          else
             -- spark to show onlookers we destroyed this bomb

--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
@@ -466,7 +466,6 @@ if SERVER then
       net.Send(ply)
    end
 
-   local distanceMax = 256 ^ 2
    local function ReceiveC4Config(ply, cmd, args)
       if not (IsValid(ply) and ply:IsTerror() and #args == 2) then return end
       local idx = tonumber(args[1])
@@ -477,7 +476,7 @@ if SERVER then
       local bomb = ents.GetByIndex(idx)
       if IsValid(bomb) and bomb:GetClass() == "ttt_c4" and (not bomb:GetArmed()) then
 
-         if bomb:GetPos():DistToSqr(ply:GetPos()) > distanceMax then
+         if bomb:GetPos():DistToSqr(ply:GetPos()) > 65536 then
             -- These cases should never arise in normal play, so no messages
             return
          elseif time < C4_MINIMUM_TIME or time > C4_MAXIMUM_TIME then
@@ -513,7 +512,7 @@ if SERVER then
 
       local bomb = ents.GetByIndex(idx)
       if IsValid(bomb) and bomb:GetClass() == "ttt_c4" and not bomb.DisarmCausedExplosion and bomb:GetArmed() then
-         if bomb:GetPos():DistToSqr(ply:GetPos()) > distanceMax then
+         if bomb:GetPos():DistToSqr(ply:GetPos()) > 65536 then
             return
          elseif bomb.SafeWires[wire] or ply:IsTraitor() or ply == bomb:GetOwner() then
             LANG.Msg(ply, "c4_disarmed")
@@ -541,7 +540,7 @@ if SERVER then
 
       local bomb = ents.GetByIndex(idx)
       if IsValid(bomb) and bomb:GetClass() == "ttt_c4" and (not bomb:GetArmed()) then
-         if bomb:GetPos():DistToSqr(ply:GetPos()) > distanceMax then
+         if bomb:GetPos():DistToSqr(ply:GetPos()) > 65536 then
             return
          elseif not ply:CanCarryType(WEAPON_EQUIP1) then
             LANG.Msg(ply, "c4_no_room")
@@ -572,7 +571,7 @@ if SERVER then
 
       local bomb = ents.GetByIndex(idx)
       if IsValid(bomb) and bomb:GetClass() == "ttt_c4" and (not bomb:GetArmed()) then
-         if bomb:GetPos():DistToSqr(ply:GetPos()) > distanceMax then
+         if bomb:GetPos():DistToSqr(ply:GetPos()) > 65536 then
             return
          else
             -- spark to show onlookers we destroyed this bomb

--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_traitor_button/init.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_traitor_button/init.lua
@@ -82,7 +82,7 @@ function ENT:TraitorUse(ply)
    if not (IsValid(ply) and ply:IsActiveTraitor()) then return false end
    if not self:IsUsable() then return false end
 
-   if self:GetPos():Distance(ply:GetPos()) > self:GetUsableRange() then return false end
+   if self:GetPos():DistToSqr(ply:GetPos()) > self:GetUsableRange() ^ 2 then return false end
 
    local use, message = hook.Run("TTTCanUseTraitorButton", self, ply)
    if not use then

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
@@ -334,6 +334,7 @@ end
 -- Simple client-based idle checking
 local ttt_idle_limit = CreateConVar("ttt_idle_limit", "180", FCVAR_REPLICATED)
 local idle = {ang = nil, pos = nil, mx = 0, my = 0, t = 0}
+local distanceMax = 100
 function CheckIdle()
    local client = LocalPlayer()
    if not IsValid(client) then return end
@@ -363,7 +364,7 @@ function CheckIdle()
          idle.mx = gui.MouseX()
          idle.my = gui.MouseY()
          idle.t = CurTime()
-      elseif client:GetPos():Distance(idle.pos) > 10 then
+      elseif client:GetPos():DistToSqr(idle.pos) > distanceMax then
          -- Even if players don't move their mouse, they might still walk
          idle.pos = client:GetPos()
          idle.t = CurTime()

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
@@ -334,7 +334,6 @@ end
 -- Simple client-based idle checking
 local ttt_idle_limit = CreateConVar("ttt_idle_limit", "180", FCVAR_REPLICATED)
 local idle = {ang = nil, pos = nil, mx = 0, my = 0, t = 0}
-local distanceMax = 100
 function CheckIdle()
    local client = LocalPlayer()
    if not IsValid(client) then return end
@@ -364,7 +363,7 @@ function CheckIdle()
          idle.mx = gui.MouseX()
          idle.my = gui.MouseY()
          idle.t = CurTime()
-      elseif client:GetPos():DistToSqr(idle.pos) > distanceMax then
+      elseif client:GetPos():DistToSqr(idle.pos) > 100 then
          -- Even if players don't move their mouse, they might still walk
          idle.pos = client:GetPos()
          idle.t = CurTime()

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_radar.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_radar.lua
@@ -115,6 +115,7 @@ local GetPTranslation = LANG.GetParamTranslation
 local FormatTime = util.SimpleTime
 
 local near_cursor_dist = 180
+local near_cursor_distsqrt = near_cursor_dist ^ 2
 
 function RADAR:Draw(client)
    if not client then return end
@@ -172,8 +173,8 @@ function RADAR:Draw(client)
       if not scrpos.visible then
          continue
       end
-      md = mpos:Distance(Vector(scrpos.x, scrpos.y, 0))
-      if md < near_cursor_dist then
+      md = mpos:DistToSqr(Vector(scrpos.x, scrpos.y, 0))
+      if md < near_cursor_distsqrt then
          alpha = math.Clamp(alpha * (md / near_cursor_dist), 40, 230)
       end
 

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_radar.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_radar.lua
@@ -165,7 +165,7 @@ function RADAR:Draw(client)
 
    local mpos = Vector(ScrW() / 2, ScrH() / 2, 0)
 
-   local role, alpha, scrpos, md
+   local role, alpha, scrpos
    for k, tgt in pairs(RADAR.targets) do
       alpha = alpha_base
 
@@ -173,8 +173,9 @@ function RADAR:Draw(client)
       if not scrpos.visible then
          continue
       end
-      md = mpos:DistToSqr(Vector(scrpos.x, scrpos.y, 0))
-      if md < near_cursor_distsqrt then
+      local md_sqrt = mpos:DistToSqr(Vector(scrpos.x, scrpos.y, 0))
+      if md_sqrt < near_cursor_distsqrt then
+         local md = math.sqrt(md_sqrt)
          alpha = math.Clamp(alpha * (md / near_cursor_dist), 40, 230)
       end
 

--- a/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
@@ -124,7 +124,7 @@ local function IdentifyCommand(ply, cmd, args)
    ply.search_id = nil
 
    local rag = Entity(eidx)
-   if IsValid(rag) and rag.player_ragdoll and rag:GetPos():Distance(ply:GetPos()) < 128 then
+   if IsValid(rag) and rag.player_ragdoll and rag:GetPos():DistToSqr(ply:GetPos()) < 16384 then
       if not CORPSE.GetFound(rag, false) then
          IdentifyBody(ply, rag)
       end
@@ -144,7 +144,7 @@ local function CallDetective(ply, cmd, args)
    local rag = Entity(eidx)
    if not (IsValid(rag) and rag.player_ragdoll) then return end
 
-   if ((rag.last_detective_call or 0) < (CurTime() - 5)) and (rag:GetPos():Distance(ply:GetPos()) < 128) then
+   if ((rag.last_detective_call or 0) < (CurTime() - 5)) and (rag:GetPos():DistToSqr(ply:GetPos()) < 16384) then
 
       rag.last_detective_call = CurTime()
 


### PR DESCRIPTION
Hello,
Only in the Terrotown gamemode, I modified the ``Distance`` using ``DistToSqr``. In some cases, this is useful when dealing with convar spam, general spam or in a hook/function because it is much more expensive. The only instance where I'm unsure of its 100% effectiveness is in ``gamemodes/terrotown/gamemode/cl_init.lua L.338``, since it's executed only once, I included it just in case.