### PR TITLE
Fix cookie library ignoring call order

### DIFF
--- a/garrysmod/lua/includes/modules/cookie.lua
+++ b/garrysmod/lua/includes/modules/cookie.lua
@@ -7,13 +7,22 @@ end
 
 module( "cookie", package.seeall )
 
-local CachedEntries = {}
-local BufferedWrites = {}
-local BufferedDeletes = {}
+local CachedEntries = {
+	--[[
+		key:
+			1 = number expireTime - if the SysTime exired then the cookie is fetched from SQL
+			2 = string cookieValue
+	]]
+}
+local BufferedQueue = {
+	--[[
+		key = value (false for delete else for insert it's a string value)
+	]]
+}
 
 local function GetCache( key )
 
-	if ( BufferedDeletes[ key ] ) then return nil end
+	if ( BufferedQueue[ key ] == false ) then return nil end
 
 	local entry = CachedEntries[ key ]
 
@@ -35,8 +44,7 @@ end
 local function FlushCache()
 
 	CachedEntries = {}
-	BufferedWrites = {}
-	BufferedDeletes = {}
+	BufferedQueue = {}
 
 end
 
@@ -44,16 +52,15 @@ local function CommitToSQLite()
 
 	sql.Begin()
 
-	for k, v in pairs( BufferedWrites ) do
-		sql.Query( "INSERT OR REPLACE INTO cookies ( key, value ) VALUES ( " .. SQLStr( k ) .. ", " .. SQLStr( v ) .. " )" )
+	for k, v in pairs( BufferedQueue ) do
+		if ( v == false ) then
+			sql.Query( "DELETE FROM cookies WHERE key = " .. SQLStr( k ) )
+		else
+			sql.Query( "INSERT OR REPLACE INTO cookies ( key, value ) VALUES ( " .. SQLStr( k ) .. ", " .. SQLStr( v ) .. " )" )
+		end
 	end
 
-	for k, v in pairs( BufferedDeletes ) do
-		sql.Query( "DELETE FROM cookies WHERE key = " .. SQLStr( k ) )
-	end
-
-	BufferedWrites = {}
-	BufferedDeletes = {}
+	BufferedQueue = {}
 
 	sql.Commit()
 
@@ -69,14 +76,21 @@ local function SetCache( key, value )
 
 	if ( value == nil ) then return Delete( key ) end
 
-	if CachedEntries[ key ] then
-		CachedEntries[ key ][ 1 ] = SysTime() + 30
-		CachedEntries[ key ][ 2 ] = value
-	else
-		CachedEntries[ key ] = { SysTime() + 30, value }
+	local strValue = tostring( value )
+
+	-- It is unlikely that this could ever happen but with a invalid __tostring method tostring may silently fail
+	if ( strValue == nil ) then
+		error( "bad argument #2 to 'value' (string expected, got " .. type( value ) .. ")", 2 )
 	end
 
-	BufferedWrites[ key ] = value
+	if CachedEntries[ key ] then
+		CachedEntries[ key ][ 1 ] = SysTime() + 30
+		CachedEntries[ key ][ 2 ] = strValue
+	else
+		CachedEntries[ key ] = { SysTime() + 30, strValue }
+	end
+
+	BufferedQueue[ key ] = strValue
 
 	ScheduleCommit()
 
@@ -106,8 +120,7 @@ end
 function Delete( name )
 
 	CachedEntries[ name ] = nil
-	BufferedWrites[ name ] = nil
-	BufferedDeletes[ name ] = true
+	BufferedQueue[ name ] = false
 
 	ScheduleCommit()
 

--- a/garrysmod/lua/includes/modules/cookie.lua
+++ b/garrysmod/lua/includes/modules/cookie.lua
@@ -80,7 +80,7 @@ local function SetCache( key, value )
 
 	-- It is unlikely that this could ever happen but with a invalid __tostring method tostring may silently fail
 	if ( strValue == nil ) then
-		error( "bad argument #2 to 'value' (string expected, got " .. type( value ) .. ")", 2 )
+		error( "bad argument #2 to 'cookie.Set' (string expected, got " .. type( value ) .. ")", 2 )
 	end
 
 	if CachedEntries[ key ] then

--- a/garrysmod/lua/includes/modules/cookie.lua
+++ b/garrysmod/lua/includes/modules/cookie.lua
@@ -7,18 +7,15 @@ end
 
 module( "cookie", package.seeall )
 
-local CachedEntries = {
-	--[[
-		key:
-			1 = number expireTime - if the SysTime exired then the cookie is fetched from SQL
-			2 = string cookieValue
-	]]
-}
-local BufferedQueue = {
-	--[[
-		key = value (false for delete else for insert it's a string value)
-	]]
-}
+--[[
+	key:
+		1 = number expireTime - if the SysTime expired then the cookie is fetched from SQL
+		2 = string cookieValue
+]]
+local CachedEntries = {}
+
+-- key = value (false for delete, else string value for insert)
+local BufferedQueue = {}
 
 local function GetCache( key )
 
@@ -27,10 +24,9 @@ local function GetCache( key )
 	local entry = CachedEntries[ key ]
 
 	if ( entry == nil || SysTime() > entry[ 1 ] ) then
-		local name = SQLStr( key )
-		local val = sql.QueryValue( "SELECT value FROM cookies WHERE key = " .. name )
+		local val = sql.QueryValue( "SELECT value FROM cookies WHERE key = " .. SQLStr( key ) )
 
-		if !val then
+		if ( !val ) then
 			return false
 		end
 
@@ -78,7 +74,7 @@ local function SetCache( key, value )
 
 	local strValue = tostring( value )
 
-	-- It is unlikely that this could ever happen but with a invalid __tostring method tostring may silently fail
+	-- It is unlikely that this could ever happen, but with an invalid __tostring method tostring() may silently fail
 	if ( strValue == nil ) then
 		error( "bad argument #2 to 'cookie.Set' (string expected, got " .. type( value ) .. ")", 2 )
 	end
@@ -143,4 +139,3 @@ concommand.Add( "lua_cookieclear", function( ply, command, arguments )
 	FlushCache()
 
 end )
-


### PR DESCRIPTION
As of right now the cookie library ignored any Set that was made immediately (made in a 0.1s time window) after a Delete as it uses two seperate queues.
Soo this PR simplifies the Queues merging them into one- and ensures that cookies will preserve the right value for the call order.

Example:
`lua_run cookie.Delete("Hello") cookie.Set("Hello", "World") print(cookie.GetString("Hello"))`

I encountered this issue in https://github.com/Mantibro/SlashCo/commit/6ea795c6f7ca36fba582bff4f8e8fe5bef5a4f2c as we set the cookie instantly after having called `Delete`

This also adds a guard to `cookie.Set` as previously it accepted any value and silently depended on later SQLStr to use `tostring` for the value which in a really obscure case could fail when a developer messed up a metatable's `__tostring` method to return `nil`
Example of this:
`lua_run local mt = { __tostring = function() return nil end } local ud = newproxy() debug.setmetatable(ud, mt) print(tostring(ud))`