### PR TITLE
Add `SELF` to `lua_run` globals

### DIFF
--- a/garrysmod/gamemodes/base/entities/entities/lua_run.lua
+++ b/garrysmod/gamemodes/base/entities/entities/lua_run.lua
@@ -26,6 +26,7 @@ end
 
 function ENT:SetupGlobals( activator, caller )
 
+	SELF = self
 	ACTIVATOR = activator
 	CALLER = caller
 
@@ -37,6 +38,7 @@ end
 
 function ENT:KillGlobals()
 
+	SELF = nil
 	ACTIVATOR = nil
 	CALLER = nil
 	TRIGGER_PLAYER = nil


### PR DESCRIPTION
As `ACTIVATOR` and `CALLER` are already present and resemble the incumbent entity I/O system, I believe `SELF` should be available within `lua_run` as well. For instance, it would be handy in situations that demand the location of the `lua_run` entity. Having access to the `lua_run` entity from within itself opens up more possibilities with entity I/O and Lua for mapping.