### PR TITLE
Add basic I/O to `lua_run`

### DIFF
--- a/bin/garrysmod.fgd
+++ b/bin/garrysmod.fgd
@@ -22,8 +22,10 @@
 		1  : "Run code on spawn": 0
 	]
 
-	input RunCode(void) : "Run Code that was defined in the entity"
+	input RunCode(string) : "Run code that was defined in the entity, optionally with an input parameter"
 	input RunPassedCode(string) : "Run code that was passed as a variable"
+
+	output OnCodeOut(string) : "Fires when code runs and OUTPUT has a value"
 ]
 
 @PointClass base(Targetname) iconsprite("editor/env_skypaint.vmt") = env_skypaint : "Control the sky colours. Requires the skybox material be set to 'painted' in Map => Map Properties."

--- a/garrysmod/gamemodes/base/entities/entities/lua_run.lua
+++ b/garrysmod/gamemodes/base/entities/entities/lua_run.lua
@@ -11,12 +11,16 @@ function ENT:Initialize()
 
 	-- If the entity has its first spawnflag set, run the code automatically
 	if ( self:HasSpawnFlags( SF_LUA_RUN_ON_SPAWN ) ) then
-		self:RunCode( self, self, self:GetDefaultCode() )
+		self:RunCode( self, self, self:GetDefaultCode(), nil )
 	end
 
 end
 
 function ENT:KeyValue( key, value )
+
+	if ( key:lower() == "oncodeout" ) then
+		self:StoreOutput( key, value )
+	end
 
 	if ( key:lower() == "code" ) then
 		self:SetDefaultCode( value )
@@ -24,10 +28,12 @@ function ENT:KeyValue( key, value )
 
 end
 
-function ENT:SetupGlobals( activator, caller )
+function ENT:SetupGlobals( activator, caller, data )
 
 	ACTIVATOR = activator
 	CALLER = caller
+	INPUT = data
+	OUTPUT = nil
 
 	if ( IsValid( activator ) && activator:IsPlayer() ) then
 		TRIGGER_PLAYER = activator
@@ -40,14 +46,20 @@ function ENT:KillGlobals()
 	ACTIVATOR = nil
 	CALLER = nil
 	TRIGGER_PLAYER = nil
+	INPUT = nil
+	OUTPUT = nil
 
 end
 
-function ENT:RunCode( activator, caller, code )
+function ENT:RunCode( activator, caller, code, data )
 
-	self:SetupGlobals( activator, caller )
+	self:SetupGlobals( activator, caller, data )
 
 		RunString( code, "lua_run#" .. self:EntIndex() )
+
+		if ( OUTPUT != nil ) then
+			self:TriggerOutput("OnCodeOut", activator, OUTPUT)
+		end
 
 	self:KillGlobals()
 
@@ -55,8 +67,8 @@ end
 
 function ENT:AcceptInput( name, activator, caller, data )
 
-	if ( name == "RunCode" ) then self:RunCode( activator, caller, self:GetDefaultCode() ) return true end
-	if ( name == "RunPassedCode" ) then self:RunCode( activator, caller, data ) return true end
+	if ( name == "RunCode" ) then self:RunCode( activator, caller, self:GetDefaultCode(), data ) return true end
+	if ( name == "RunPassedCode" ) then self:RunCode( activator, caller, data, nil ) return true end
 
 	return false
 


### PR DESCRIPTION
# Changes
- Added `INPUT` and `OUTPUT` globals to `lua_run`'s `RunCode`
  - `INPUT` contains any data passed through the newly parameterized `RunCode` entity input [(see FGD)](https://github.com/Facepunch/garrysmod/commit/8568e44bcd25da82c6120028ee4a650e6c636250#diff-999f40a3fb81be4b7ef2312c9d674b5468cd042015b84f1c1f846be583174976R25)
    - `RunCode` can still be run without parameters
  - `OUTPUT` is initially `nil` but can be assigned within the `lua_run` code snippet
    - Assigning anything to `OUTPUT` triggers a new `OnCodeOut` output (passes the value of `OUTPUT`)

_These features support the basic entity I/O paradigm of passing in information from one entity, doing something with it and sending it to another._

## Examples
As text doesn't always paint the prettiest picture, I've made a [basic demonstration](https://github.com/user-attachments/files/29348844/luarun_test.zip) (VMF+BSP) of these features for you to experiment with:
1. The first (big button on left) uses a `lua_run` to get the activating player's name and puts it on a `point_worldtext` (using the new I/O features). The `lua_run` snippet is as follows: `if TRIGGER_PLAYER then OUTPUT = TRIGGER_PLAYER:Nick() end`

<img width="2160" height="1440" alt="image" src="https://github.com/user-attachments/assets/f08ec29c-bd48-49df-a837-29df327fc4e6" />

2. The second (small floating button) uses a `lua_run` to remap the `momentary_rot_button`'s `Position` output value from a linear curve to a cubic one. The `lua_run` snippet is as follows: `if INPUT then OUTPUT = INPUT * INPUT * INPUT end`

<img width="1078" height="1078" alt="gmod_4gAwaUJguc-ezgif com-optimize" src="https://github.com/user-attachments/assets/1102da25-9d68-4fc3-9a16-8237b67b9097" />

---

With these changes, `lua_run` can pull some real weight in Hammer as a robust data remapper for entity I/O (the applications for mappers are quite limitless).

_Also mentioning #2486 for posterity._

# On the Subject of Security
I've spent a fair bit of time working to determine whether these changes make `lua_run` any more "dangerous" than it already is. Here's what I've found: If you have the knowledge, the know-how and enough dedication, you can find a way to use `lua_run` to put virtually anything you want in a map without installing any addons. **If I wanted to find an entity by targetname and manually `ENT:Fire()` an input on it from within a `lua_run`, I can already do that** (albeit with a lot more effort than these new changes would allow). 

This PR aims to make the entity sit a little more comfortably in its Hammer environment.

## A Small Issue
One could easily set this up to loop infinitely by connecting a parameterized `lua_run`'s `OnCodeOut` output back up to its `RunCode` input. I haven't attempted any fixes for this as I'm sure there are many entities in similar situations, and—at the end of the day—I tend to believe it's a mapper's responsibility to clean up a mapper's mess.
