### PR TITLE
TTT: Fix prepare state hooks running before map cleanup

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -275,12 +275,10 @@ end
 
 -- Used to be in Think/Tick, now in a timer
 function WaitingForPlayersChecker()
-   if GetRoundState() == ROUND_WAIT then
-      if EnoughPlayers() then
-         timer.Create("wait2prep", 1, 1, PrepareRound)
+   if GetRoundState() == ROUND_WAIT and EnoughPlayers() then
+      timer.Create("wait2prep", 1, 1, PrepareRound)
 
-         timer.Stop("waitingforply")
-      end
+      timer.Stop("waitingforply")
    end
 end
 
@@ -367,6 +365,28 @@ function StopWinChecks()
    timer.Stop("winchecker")
 end
 
+local function StopRoundTimers()
+   -- remove all timers
+   timer.Stop("wait2prep")
+   timer.Stop("prep2begin")
+   timer.Stop("end2prep")
+   timer.Stop("winchecker")
+end
+
+-- Make sure we have the players to do a round, people can leave during our
+-- preparations so we'll call this numerous times
+local function CheckForAbort()
+   if not EnoughPlayers() then
+      LANG.Msg("round_minplayers")
+      StopRoundTimers()
+
+      WaitForPlayers()
+      return true
+   end
+
+   return false
+end
+
 local function SpawnEntities()
    local et = ents.TTT
    -- Spawn weapons from script if there is one
@@ -400,6 +420,13 @@ local function CleanUp()
    game.CleanUpMap(false, nil, function()
       et.FixParentedPostCleanup()
       SpawnEntities()
+
+      if CheckForAbort() then return end
+
+      -- Tell hooks and map we started prep
+      hook.Call("TTTPrepareRound")
+
+      et.TriggerRoundStateOutputs(ROUND_PREP)
    end)
 
    -- Strip players now, so that their weapons are not seen by ReplaceEntities
@@ -413,28 +440,6 @@ local function CleanUp()
    hook.Remove("PlayerSay", "ULXMeCheck")
 end
 
-
-local function StopRoundTimers()
-   -- remove all timers
-   timer.Stop("wait2prep")
-   timer.Stop("prep2begin")
-   timer.Stop("end2prep")
-   timer.Stop("winchecker")
-end
-
--- Make sure we have the players to do a round, people can leave during our
--- preparations so we'll call this numerous times
-local function CheckForAbort()
-   if not EnoughPlayers() then
-      LANG.Msg("round_minplayers")
-      StopRoundTimers()
-
-      WaitForPlayers()
-      return true
-   end
-
-   return false
-end
 
 function GM:TTTDelayRoundStartForVote()
    -- Can be used for custom voting systems
@@ -503,11 +508,6 @@ function PrepareRound()
 
    -- In case client's cleanup fails, make client set all players to innocent role
    timer.Simple(1, SendRoleReset)
-
-   -- Tell hooks and map we started prep
-   hook.Call("TTTPrepareRound")
-
-   ents.TTT.TriggerRoundStateOutputs(ROUND_PREP)
 end
 
 function SetRoundEnd(endtime)


### PR DESCRIPTION
Before the callback change to game.CleanUpMap, the TTTPrepareRound hook and the RoundPreparation output only ran after a map cleanup.

There are a couple of maps made before the change that relied on this behaviour, most notably including [ttt_minecraft_b5](https://github.com/user-attachments/assets/b9069a80-40c4-4a2f-928e-b21556c8ab15)

This forces the hooks to run after the map cleanup by moving them into the game.CleanUpMap callback.

Quick method of testing:
- Open this map in TTT: https://steamcommunity.com/sharedfiles/filedetails/?id=2956730580
- Step outside into the view of the UAV above.
- If you aren't shot by a HL2 sniper, the issue is fixed.