### PR TITLE
Fix stale gamemode details on server list refresh

### DIFF
--- a/garrysmod/html/js/menu/control.Menu.js
+++ b/garrysmod/html/js/menu/control.Menu.js
@@ -241,6 +241,11 @@ function GetGamemodeInfo( name )
 	return GamemodeDetails[nameL];
 }
 
+function ResetGamemodeInfo()
+{
+	GamemodeDetails = {};
+}
+
 function UpdateAddonMaps( inmaps )
 {
 	gScope.AddonMapList = inmaps;

--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -77,6 +77,7 @@ function ControllerServers( $scope, $element, $rootScope, $location )
 		//
 		ServerTypes[ RootScope.ServerType ].gamemodes = {};
 		ServerTypes[ RootScope.ServerType ].list.length = 0;
+		GamemodeDetails = {};
 
 		if ( !IN_ENGINE ) TestUpdateServers( RootScope.ServerType, RequestNum[ RootScope.ServerType ] );
 

--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -77,7 +77,7 @@ function ControllerServers( $scope, $element, $rootScope, $location )
 		//
 		ServerTypes[ RootScope.ServerType ].gamemodes = {};
 		ServerTypes[ RootScope.ServerType ].list.length = 0;
-		GamemodeDetails = {};
+		ResetGamemodeInfo();
 
 		if ( !IN_ENGINE ) TestUpdateServers( RootScope.ServerType, RequestNum[ RootScope.ServerType ] );
 


### PR DESCRIPTION
When you refresh the server list, it doesn't clear the existing details on gamemode display name, workshop ID, tag, etc, before it re-calculates. It just adds on top of it which means servers adding multiple times, and then re-calculates with this bad data. This continues until the user restarts Gmod.
This doesn't make much difference for highly populated gamemodes, but for lower population gamemodes it can prevent accurate calculations until you restart Gmod. 

This PR fixes the bug by clearing the stale gamemode details on refresh, resulting in the re-calculation being based on current data instead of stale data.

https://github.com/Facepunch/garrysmod-issues/issues/6916 should be partially improved by this PR.