### PR TITLE
Optimize lookup algorithms, duplicate filtering, and iteration in sandbox tools and TTT

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/inflator.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/inflator.lua
@@ -13,68 +13,66 @@ TOOL.Information = {
 }
 
 local ScaleYZ = {
-	"ValveBiped.Bip01_L_UpperArm",
-	"ValveBiped.Bip01_L_Forearm",
-	"ValveBiped.Bip01_L_Thigh",
-	"ValveBiped.Bip01_L_Calf",
-	"ValveBiped.Bip01_R_UpperArm",
-	"ValveBiped.Bip01_R_Forearm",
-	"ValveBiped.Bip01_R_Thigh",
-	"ValveBiped.Bip01_R_Calf",
-	"ValveBiped.Bip01_Spine2",
-	"ValveBiped.Bip01_Spine1",
-	"ValveBiped.Bip01_Spine",
-	"ValveBiped.Bip01_Spinebut",
+	["ValveBiped.Bip01_L_UpperArm"] = true,
+	["ValveBiped.Bip01_L_Forearm"] = true,
+	["ValveBiped.Bip01_L_Thigh"] = true,
+	["ValveBiped.Bip01_L_Calf"] = true,
+	["ValveBiped.Bip01_R_UpperArm"] = true,
+	["ValveBiped.Bip01_R_Forearm"] = true,
+	["ValveBiped.Bip01_R_Thigh"] = true,
+	["ValveBiped.Bip01_R_Calf"] = true,
+	["ValveBiped.Bip01_Spine2"] = true,
+	["ValveBiped.Bip01_Spine1"] = true,
+	["ValveBiped.Bip01_Spine"] = true,
+	["ValveBiped.Bip01_Spinebut"] = true,
 
 	-- Vortigaunt
-	"ValveBiped.spine4",
-	"ValveBiped.spine3",
-	"ValveBiped.spine2",
-	"ValveBiped.spine1",
-	"ValveBiped.hlp_ulna_R",
-	"ValveBiped.hlp_ulna_L",
-	"ValveBiped.arm1_L",
-	"ValveBiped.arm1_R",
-	"ValveBiped.arm2_L",
-	"ValveBiped.arm2_R",
-	"ValveBiped.leg_bone1_L",
-	"ValveBiped.leg_bone1_R",
-	"ValveBiped.leg_bone2_L",
-	"ValveBiped.leg_bone2_R",
-	"ValveBiped.leg_bone3_L",
-	"ValveBiped.leg_bone3_R",
+	["ValveBiped.spine4"] = true,
+	["ValveBiped.spine3"] = true,
+	["ValveBiped.spine2"] = true,
+	["ValveBiped.spine1"] = true,
+	["ValveBiped.hlp_ulna_R"] = true,
+	["ValveBiped.hlp_ulna_L"] = true,
+	["ValveBiped.arm1_L"] = true,
+	["ValveBiped.arm1_R"] = true,
+	["ValveBiped.arm2_L"] = true,
+	["ValveBiped.arm2_R"] = true,
+	["ValveBiped.leg_bone1_L"] = true,
+	["ValveBiped.leg_bone1_R"] = true,
+	["ValveBiped.leg_bone2_L"] = true,
+	["ValveBiped.leg_bone2_R"] = true,
+	["ValveBiped.leg_bone3_L"] = true,
+	["ValveBiped.leg_bone3_R"] = true,
 
 	-- Team Fortress 2
-	"bip_knee_L",
-	"bip_knee_R",
-	"bip_hip_R",
-	"bip_hip_L",
+	["bip_knee_L"] = true,
+	["bip_knee_R"] = true,
+	["bip_hip_R"] = true,
+	["bip_hip_L"] = true,
 }
 
 local ScaleXZ = {
-	"ValveBiped.Bip01_pelvis",
+	["ValveBiped.Bip01_pelvis"] = true,
 
 	-- Team Fortress 2
-	"bip_upperArm_L",
-	"bip_upperArm_R",
-	"bip_lowerArm_L",
-	"bip_lowerArm_R",
-	"bip_forearm_L",
-	"bip_forearm_R",
+	["bip_upperArm_L"] = true,
+	["bip_upperArm_R"] = true,
+	["bip_lowerArm_L"] = true,
+	["bip_lowerArm_R"] = true,
+	["bip_forearm_L"] = true,
+	["bip_forearm_R"] = true,
 }
 
 local function GetNiceBoneScale( name, scale )
-
-	if ( table.HasValue( ScaleYZ, name ) or string.find( name:lower(), "leg" ) or string.find( name:lower(), "arm" ) ) then
+	if ( ScaleYZ[ name ] or string.find( name:lower(), "leg" ) or string.find( name:lower(), "arm" ) ) then
 		return Vector( 0, scale, scale )
 	end
 
-	if ( table.HasValue( ScaleXZ, name ) ) then
+	if ( ScaleXZ[ name ] ) then
 		return Vector( scale, 0, scale )
 	end
 
 	return Vector( scale, scale, scale )
-
 end
 
 --Scale the specified bone by Scale

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/inflator.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/inflator.lua
@@ -64,6 +64,7 @@ local ScaleXZ = {
 }
 
 local function GetNiceBoneScale( name, scale )
+
 	if ( ScaleYZ[ name ] or string.find( name:lower(), "leg" ) or string.find( name:lower(), "arm" ) ) then
 		return Vector( 0, scale, scale )
 	end
@@ -73,6 +74,7 @@ local function GetNiceBoneScale( name, scale )
 	end
 
 	return Vector( scale, scale, scale )
+
 end
 
 --Scale the specified bone by Scale

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/material.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/material.lua
@@ -132,14 +132,15 @@ function TOOL.BuildCPanel( CPanel )
 	local filter = CPanel:TextEntry( "#spawnmenu.quick_filter_tool" )
 	filter:SetUpdateOnType( true )
 
-	-- Remove duplicate materials. table.HasValue is used to preserve material order
+	-- Remove duplicate materials. A lookup table is used to preserve material order efficiently.
 	local materials = {}
+	local seen = {}
 	for id, str in ipairs( list.Get( "OverrideMaterials" ) ) do
-		if ( !table.HasValue( materials, str ) ) then
-			table.insert( materials, str )
-		end
+	    if ( !seen[ str ] ) then
+	        seen[ str ] = true
+	        table.insert( materials, str )
+	    end
 	end
-
 	local matlist = CPanel:MatSelect( "material_override", materials, true, 0.25, 0.25 )
 
 	filter.OnValueChange = function( s, txt )

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/material.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/material.lua
@@ -141,6 +141,7 @@ function TOOL.BuildCPanel( CPanel )
 	        table.insert( materials, str )
 	    end
 	end
+
 	local matlist = CPanel:MatSelect( "material_override", materials, true, 0.25, 0.25 )
 
 	filter.OnValueChange = function( s, txt )

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/material.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/material.lua
@@ -132,7 +132,7 @@ function TOOL.BuildCPanel( CPanel )
 	local filter = CPanel:TextEntry( "#spawnmenu.quick_filter_tool" )
 	filter:SetUpdateOnType( true )
 
-	-- Remove duplicate materials. A lookup table is used to preserve material order efficiently.
+	-- Remove duplicate materials, preserving order
 	local materials = {}
 	local seen = {}
 	for id, str in ipairs( list.Get( "OverrideMaterials" ) ) do

--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/paint.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/paint.lua
@@ -139,12 +139,13 @@ function TOOL.BuildCPanel( CPanel )
 
 	-- Remove duplicates.
 	local Options = {}
+	local seen = {}
 	for id, str in ipairs( list.Get( "PaintMaterials" ) ) do
-		if ( !table.HasValue( Options, str ) ) then
-			table.insert( Options, str )
-		end
+	    if ( !seen[ str ] ) then
+	        seen[ str ] = true
+	        table.insert( Options, str )
+	    end
 	end
-
 	table.sort( Options )
 
 	local listbox = vgui.Create( "DListView" )

--- a/garrysmod/gamemodes/terrortown/gamemode/init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/init.lua
@@ -564,12 +564,15 @@ function SpawnWillingPlayers(dead_only)
       local num_spawns = #GetSpawnEnts()
 
       local to_spawn = {}
-      for _, ply in RandomPairs(player.GetAll()) do
+      for _, ply in player.Iterator() do
          if IsValid(ply) and ply:ShouldSpawn() then
             table.insert(to_spawn, ply)
             GAMEMODE:PlayerSpawnAsSpectator(ply)
          end
       end
+
+      -- Shuffle the table of queued players to randomize the spawn order
+      table.Shuffle(to_spawn)
 
       local sfn = function()
                      local c = 0


### PR DESCRIPTION
### Description
This PR introduces several optimizations to core sandbox tools and the TTT gamemode by replacing inefficient $O(N)$ and $O(N^2)$ lookup algorithms with $O(1)$ and $O(N)$ alternatives, and switching to modern iterator patterns [1].

### Changes
1. **`stools/inflator.lua`**
   * Converted `ScaleYZ` and `ScaleXZ` from sequential array-like tables into lookup dictionaries.
   * Replaced expensive $O(N)$ `table.HasValue` scans inside `GetNiceBoneScale` with instant $O(1)$ key lookups. This significantly reduces CPU overhead when manipulating ragdoll bone scales in Sandbox.
2. **`stools/material.lua` & `stools/paint.lua`**
   * Optimized duplicate filtering from $O(N^2)$ to $O(N)$ complexity by utilizing a temporary `seen` lookup table.
   * This preserves the original order of materials and paints without performing sequential searches using `table.HasValue`.
3. **`terrortown/gamemode/init.lua`**
   * Replaced the expensive `RandomPairs(player.GetAll())` call inside `SpawnWillingPlayers` with `player.Iterator()` [1].
   * The queued table of spawning players (`to_spawn`) is now randomized using the fast, built-in in-place `table.Shuffle()`. This avoids multiple garbage allocations (both tables and generator closure) during spawn waves.