### PR TITLE
ENT:BeingLookedAtByLocalPlayer optimization

### DIFF
--- a/garrysmod/gamemodes/base/entities/entities/prop_effect.lua
+++ b/garrysmod/gamemodes/base/entities/entities/prop_effect.lua
@@ -58,6 +58,12 @@ function ENT:Initialize()
 		local tab = ents.FindByClassAndParent( "prop_dynamic", self )
 		if ( tab && IsValid( tab[ 1 ] ) ) then self.AttachedEntity = tab[ 1 ] end
 
+		-- Selectively inherit BeingLookedAtByLocalPlayer from base_gmodentity so we don't have to copy paste it
+		local base_gmodentity = scripted_ents.Get( "base_gmodentity" )
+		if ( base_gmodentity ) then
+			self.BeingLookedAtByLocalPlayer = base_gmodentity.BeingLookedAtByLocalPlayer
+			self.MaxWorldTipDistance = base_gmodentity.MaxWorldTipDistance
+		end
 	end
 
 	-- Set collision bounds exactly
@@ -94,51 +100,6 @@ function ENT:DrawTranslucent( flags )
 	end
 
 	render.DrawSprite( self:GetPos(), 16, 16, color_white )
-
-end
-
--- Copied from base_gmodentity.lua
-ENT.MaxWorldTipDistance = 256
-
-local lastLookedFrame = nil
-local lastLooked = nil
-
-function ENT:BeingLookedAtByLocalPlayer()
-
-	local currentFrame = FrameNumber()
-
-	if ( currentFrame ~= lastLookedFrame ) then
-		lastLookedFrame = currentFrame
-
-		local trace = nil
-		local viewer = GetViewEntity()
-
-		-- If we're spectating a player, perform an eye trace
-		if ( viewer:IsPlayer() ) then
-			trace = viewer:GetEyeTrace()
-		else
-			-- If we're not spectating a player, perform a manual trace from the entity's position
-			local startPos = viewer:GetPos()
-			local endPos = viewer:GetForward()
-			endPos:Mul(32768)
-			endPos:Add(startPos)
-
-			trace = util.TraceLine( {
-				start = startpos,
-				endpos = endpos,
-				filter = viewer
-			} )
-		end
-
-		lastLooked = trace.Entity
-		local distance = lastLooked.MaxWorldTipDistance
-
-		if ( !distance || trace.Fraction * 32768 > distance ) then
-			lastLooked = nil
-		end
-	end
-
-	return self == lastLooked
 
 end
 

--- a/garrysmod/gamemodes/base/entities/entities/prop_effect.lua
+++ b/garrysmod/gamemodes/base/entities/entities/prop_effect.lua
@@ -99,31 +99,47 @@ end
 
 -- Copied from base_gmodentity.lua
 ENT.MaxWorldTipDistance = 256
+
+local lastLookedFrame = nil
+local lastLooked = nil
+
 function ENT:BeingLookedAtByLocalPlayer()
-	local ply = LocalPlayer()
-	if ( !IsValid( ply ) ) then return false end
 
-	local view = ply:GetViewEntity()
-	local dist = self.MaxWorldTipDistance
-	dist = dist * dist
+	local currentFrame = FrameNumber()
 
-	-- If we're spectating a player, perform an eye trace
-	if ( view:IsPlayer() ) then
-		return view:EyePos():DistToSqr( self:GetPos() ) <= dist && view:GetEyeTrace().Entity == self
+	if ( currentFrame ~= lastLookedFrame ) then
+		lastLookedFrame = currentFrame
+
+		local trace = nil
+		local viewer = GetViewEntity()
+
+		-- If we're spectating a player, perform an eye trace
+		if ( viewer:IsPlayer() ) then
+			trace = viewer:GetEyeTrace()
+		else
+			-- If we're not spectating a player, perform a manual trace from the entity's position
+			local startPos = viewer:GetPos()
+			local endPos = viewer:GetForward()
+			endPos:Mul(32768)
+			endPos:Add(startPos)
+
+			trace = util.TraceLine( {
+				start = startpos,
+				endpos = endpos,
+				filter = viewer
+			} )
+		end
+
+		lastLooked = trace.Entity
+		local distance = lastLooked.MaxWorldTipDistance
+
+		if ( !distance || trace.Fraction * 32768 > distance ) then
+			lastLooked = nil
+		end
 	end
 
-	-- If we're not spectating a player, perform a manual trace from the entity's position
-	local pos = view:GetPos()
+	return self == lastLooked
 
-	if ( pos:DistToSqr( self:GetPos() ) <= dist ) then
-		return util.TraceLine( {
-			start = pos,
-			endpos = pos + ( view:GetAngles():Forward() * dist ),
-			filter = view
-		} ).Entity == self
-	end
-
-	return false
 end
 
 function ENT:PhysicsUpdate( physobj )

--- a/garrysmod/gamemodes/sandbox/entities/entities/base_gmodentity.lua
+++ b/garrysmod/gamemodes/sandbox/entities/entities/base_gmodentity.lua
@@ -14,7 +14,7 @@ if ( CLIENT ) then
 
 		local currentFrame = FrameNumber()
 
-		if ( currentFrame ~= lastLookedFrame ) then
+		if ( currentFrame != lastLookedFrame ) then
 			lastLookedFrame = currentFrame
 
 			local trace = nil

--- a/garrysmod/gamemodes/sandbox/entities/entities/base_gmodentity.lua
+++ b/garrysmod/gamemodes/sandbox/entities/entities/base_gmodentity.lua
@@ -7,40 +7,56 @@ ENT.Spawnable = false
 if ( CLIENT ) then
 	ENT.MaxWorldTipDistance = 256
 
+	local lastLookedFrame = nil
+	local lastLooked = nil
+
 	function ENT:BeingLookedAtByLocalPlayer()
-		local ply = LocalPlayer()
-		if ( !IsValid( ply ) ) then return false end
 
-		local view = ply:GetViewEntity()
-		local dist = self.MaxWorldTipDistance
-		dist = dist * dist
+		local currentFrame = FrameNumber()
 
-		-- If we're spectating a player, perform an eye trace
-		if ( view:IsPlayer() ) then
-			return view:EyePos():DistToSqr( self:GetPos() ) <= dist && view:GetEyeTrace().Entity == self
+		if ( currentFrame ~= lastLookedFrame ) then
+			lastLookedFrame = currentFrame
+
+			local trace = nil
+			local viewer = GetViewEntity()
+
+			-- If we're spectating a player, perform an eye trace
+			if ( viewer:IsPlayer() ) then
+				trace = viewer:GetEyeTrace()
+			else
+				-- If we're not spectating a player, perform a manual trace from the entity's position
+				local startPos = viewer:GetPos()
+				local endPos = viewer:GetForward()
+				endPos:Mul(32768)
+				endPos:Add(startPos)
+
+				trace = util.TraceLine( {
+					start = startpos,
+					endpos = endpos,
+					filter = viewer
+				} )
+			end
+
+			lastLooked = trace.Entity
+			local distance = lastLooked.MaxWorldTipDistance
+
+			if ( !distance || trace.Fraction * 32768 > distance ) then
+				lastLooked = nil
+			end
 		end
 
-		-- If we're not spectating a player, perform a manual trace from the entity's position
-		local pos = view:GetPos()
+		return self == lastLooked
 
-		if ( pos:DistToSqr( self:GetPos() ) <= dist ) then
-			return util.TraceLine( {
-				start = pos,
-				endpos = pos + ( view:GetAngles():Forward() * dist ),
-				filter = view
-			} ).Entity == self
-		end
-
-		return false
 	end
 
 	function ENT:Think()
-		local text = self:GetOverlayText()
+		if ( self:BeingLookedAtByLocalPlayer() ) then
+			local text = self:GetOverlayText()
 
-		if ( text != "" && self:BeingLookedAtByLocalPlayer() && !self:GetNoDraw() ) then
-			AddWorldTip( self:EntIndex(), text, 0.5, self:GetPos(), self )
-
-			halo.Add( { self }, color_white, 1, 1, 1, true, true )
+			if ( text != "" && !self:GetNoDraw() ) then
+				AddWorldTip( nil, text, nil, nil, self )
+				halo.Add( { self }, color_white, 1, 1, 1, true, true )
+			end
 		end
 	end
 end

--- a/garrysmod/gamemodes/sandbox/entities/entities/base_gmodentity.lua
+++ b/garrysmod/gamemodes/sandbox/entities/entities/base_gmodentity.lua
@@ -50,6 +50,7 @@ if ( CLIENT ) then
 	end
 
 	function ENT:Think()
+
 		if ( self:BeingLookedAtByLocalPlayer() ) then
 			local text = self:GetOverlayText()
 
@@ -58,6 +59,7 @@ if ( CLIENT ) then
 				halo.Add( { self }, color_white, 1, 1, 1, true, true )
 			end
 		end
+
 	end
 end
 

--- a/garrysmod/gamemodes/sandbox/entities/entities/base_gmodentity.lua
+++ b/garrysmod/gamemodes/sandbox/entities/entities/base_gmodentity.lua
@@ -31,8 +31,8 @@ if ( CLIENT ) then
 				endPos:Add(startPos)
 
 				trace = util.TraceLine( {
-					start = startpos,
-					endpos = endpos,
+					start = startPos,
+					endpos = endPos,
 					filter = viewer
 				} )
 			end

--- a/garrysmod/gamemodes/sandbox/entities/entities/base_gmodentity.lua
+++ b/garrysmod/gamemodes/sandbox/entities/entities/base_gmodentity.lua
@@ -5,30 +5,28 @@ DEFINE_BASECLASS( "base_anim" )
 ENT.Spawnable = false
 
 if ( CLIENT ) then
+
 	ENT.MaxWorldTipDistance = 256
 
 	local lastLookedFrame = nil
 	local lastLooked = nil
-
 	function ENT:BeingLookedAtByLocalPlayer()
 
 		local currentFrame = FrameNumber()
-
 		if ( currentFrame != lastLookedFrame ) then
 			lastLookedFrame = currentFrame
 
 			local trace = nil
 			local viewer = GetViewEntity()
-
-			-- If we're spectating a player, perform an eye trace
 			if ( viewer:IsPlayer() ) then
+				-- If we're spectating a player, perform an eye trace
 				trace = viewer:GetEyeTrace()
 			else
 				-- If we're not spectating a player, perform a manual trace from the entity's position
 				local startPos = viewer:GetPos()
 				local endPos = viewer:GetForward()
-				endPos:Mul(32768)
-				endPos:Add(startPos)
+				endPos:Mul( 32768 )
+				endPos:Add( startPos )
 
 				trace = util.TraceLine( {
 					start = startPos,
@@ -38,8 +36,8 @@ if ( CLIENT ) then
 			end
 
 			lastLooked = trace.Entity
-			local distance = lastLooked.MaxWorldTipDistance
 
+			local distance = lastLooked.MaxWorldTipDistance
 			if ( !distance || trace.Fraction * 32768 > distance ) then
 				lastLooked = nil
 			end
@@ -51,39 +49,33 @@ if ( CLIENT ) then
 
 	function ENT:Think()
 
-		if ( self:BeingLookedAtByLocalPlayer() ) then
-			local text = self:GetOverlayText()
+		if ( !self:BeingLookedAtByLocalPlayer() ) then return end
 
-			if ( text != "" && !self:GetNoDraw() ) then
-				AddWorldTip( nil, text, nil, nil, self )
-				halo.Add( { self }, color_white, 1, 1, 1, true, true )
-			end
+		local text = self:GetOverlayText()
+		if ( text != "" && !self:GetNoDraw() ) then
+			AddWorldTip( nil, text, nil, nil, self )
+			halo.Add( { self }, color_white, 1, 1, 1, true, true )
 		end
 
 	end
+
 end
 
 function ENT:SetOverlayText( text )
+
 	self:SetNWString( "GModOverlayText", text )
+
 end
 
 function ENT:GetOverlayText()
 
 	local txt = self:GetNWString( "GModOverlayText" )
+	if ( txt == "" ) then return "" end
 
-	if ( txt == "" ) then
-		return ""
-	end
-
-	if ( game.SinglePlayer() ) then
-		return txt
-	end
+	if ( game.SinglePlayer() ) then return txt end
 
 	local PlayerName = self:GetPlayerName()
-
-	if ( !PlayerName or PlayerName == "" ) then
-		return txt
-	end
+	if ( !PlayerName or PlayerName == "" ) then return txt end
 
 	return txt .. "\n(" .. PlayerName .. ")"
 


### PR DESCRIPTION
Caches `ENT:BeingLookedAtByLocalPlayer` result so it will make it pretty much zero cost
Used on Sandbox server for ~1 year now without any issues

Took it from https://github.com/Facepunch/garrysmod/pull/2109 with seems to be dead