### PR TITLE
Add missing CS:S world soundscript

### DIFF
--- a/garrysmod/scripts/game_sounds_manifest.txt
+++ b/garrysmod/scripts/game_sounds_manifest.txt
@@ -142,6 +142,7 @@ game_sounds_manifest
 	// Counter-Strike: Source
 	"precache_file"		"scripts/sounds/cs_game_sounds_radio.txt"
 	"precache_file"		"scripts/sounds/cs_game_sounds_weapons.txt"
+	"precache_file"		"scripts/sounds/cs_game_sounds_world.txt"
 
 	// Day of Defeat
 	"precache_file"		"scripts/sounds/dod_game_sounds_weapons.txt"

--- a/garrysmod/scripts/sounds/cs_game_sounds_world.txt
+++ b/garrysmod/scripts/sounds/cs_game_sounds_world.txt
@@ -1,0 +1,44 @@
+"BrassBell.C"
+{
+	"channel"	"CHAN_STATIC"
+	"volume"	"1.0"
+	"pitch"		"100,100"
+	"soundlevel"	"SNDLVL_80db"
+	"wave"		"ambient/misc/brass_bell_C.wav"
+}
+
+"BrassBell.D"
+{
+	"channel"	"CHAN_STATIC"
+	"volume"	"1.0"
+	"pitch"		"100,100"
+	"soundlevel"	"SNDLVL_80db"
+	"wave"		"ambient/misc/brass_bell_D.wav"
+}
+
+"BrassBell.E"
+{
+	"channel"	"CHAN_STATIC"
+	"volume"	"1.0"
+	"pitch"		"100,100"
+	"soundlevel"	"SNDLVL_80db"
+	"wave"		"ambient/misc/brass_bell_E.wav"
+}
+
+"BrassBell.F"
+{
+	"channel"	"CHAN_STATIC"
+	"volume"	"1.0"
+	"pitch"		"100,100"
+	"soundlevel"	"SNDLVL_80db"
+	"wave"		"ambient/misc/brass_bell_F.wav"
+}
+
+"Door.GateInferno"
+{
+	"channel"	"CHAN_BODY"
+	"volume"	"1"
+	"soundlevel"  "SNDLVL_75dB"
+	"pitch"		"90,110"
+	"wave"	"doors/door_metal_gate_move2.wav"
+}

--- a/garrysmod/scripts/sounds/cs_game_sounds_world.txt
+++ b/garrysmod/scripts/sounds/cs_game_sounds_world.txt
@@ -1,3 +1,4 @@
+
 "BrassBell.C"
 {
 	"channel"	"CHAN_STATIC"


### PR DESCRIPTION
This should presumably fix the missing sounds for the metal bells from de_inferno (GMod already has the relevant surface properties defined) alongside the missing sound for the metal gate door contained within de_inferno being opened (it's located in the apartments).


The following/below is console output when on the map `de_inferno` attempting to interact with such things in current day GMod:
```
] developer 1
CSoundEmitterSystemBase::GetParametersForSound:  No such sound brassbell.f (x6)
CSoundEmitterSystemBase::GetParametersForSound:  No such sound brassbell.c
CSoundEmitterSystemBase::GetParametersForSound:  No such sound brassbell.f
CSoundEmitterSystemBase::GetParametersForSound:  No such sound brassbell.e
CSoundEmitterSystemBase::GetParametersForSound:  No such sound brassbell.d
CSoundEmitterSystemBase::GetParametersForSound:  No such sound brassbell.c
CSoundEmitterSystemBase::GetParametersForSound:  No such sound Door.GateInferno
```