### PR TITLE
[TTT] Fix undefined variables and malformed patterns

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_flame.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_flame.lua
@@ -209,7 +209,7 @@ function ENT:BackupDraw()
    side.r = side.r + 0.1
 
    cam.Start3D2D(vstart, side, 1)
-   draw.DrawText("FIRE! IT BURNS!", "Default", 0, 0, COLOR_RED, ALIGN_CENTER)
+   draw.DrawText("FIRE! IT BURNS!", "Default", 0, 0, COLOR_RED, TEXT_ALIGN_CENTER)
    cam.End3D2D()
 
    render.SetMaterial(fakefire)

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -414,7 +414,7 @@ local function TraitorMenuPopup()
          if ItemIsWeapon(item) then
             local slot = vgui.Create("SimpleIconLabelled")
             slot:SetIcon("vgui/ttt/slotcap")
-            slot:SetIconColor(color_slot[ply:GetRole()] or COLOR_GREY)
+            slot:SetIconColor(color_slot[ply:GetRole()] or COLOR_LGRAY)
             slot:SetIconSize(16)
 
             slot:SetIconText(item.slot)

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_voice.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_voice.lua
@@ -18,7 +18,7 @@ local function LastWordsRecv()
    local death_type = net.ReadUInt(2)
 
    -- only append "--" if there's no ending interpunction
-   local final = string.match(words, "[\\.\\!\\?]$") != nil
+   local final = string.match(words, "[.!?]$") != nil
    local lastWordsStr = words .. (final and " " or "-- ")
 
    -- add optional context relating to death type

--- a/garrysmod/gamemodes/terrortown/gamemode/gamemsg.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/gamemsg.lua
@@ -269,7 +269,7 @@ local LastWordContext = {
 
 local function LastWordsMsg(ply, words)
    -- only append "--" if there's no ending interpunction
-   local final = string.match(words, "[\\.\\!\\?]$") != nil
+   local final = string.match(words, "[.!?]$") != nil
 
    -- add optional context relating to death type
    local death_type = ply.death_type

--- a/garrysmod/gamemodes/terrortown/gamemode/karma.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/karma.lua
@@ -207,7 +207,7 @@ function KARMA.RoundIncrement()
          KARMA.GiveReward(ply, bonus)
 
          if IsDebug() then
-            print(ply, "gets roundincr", incr)
+            print(ply, "gets roundincr", bonus)
          end
       end
    end


### PR DESCRIPTION
While looking through the TTT codebase, I came across a few small issues and cleaned them up:

`cl_equip.lua` used `COLOR_GREY` as a fallback color for slot icons, but that constant isn't defined anywhere. TTT already defines `COLOR_LGRAY`, so I replaced it with that.

`ttt_flame.lua` passed `ALIGN_CENTER` to `draw.DrawText`, which isn't a valid constant. Since `BackupDraw` is assigned to `self.Draw`, this code is still used, and the text was always left-aligned. Replaced it with `TEXT_ALIGN_CENTER`.

`karma.lua` had a debug print that referenced `incr`, which isn't defined in that scope, so it always printed `nil`. It looks like `bonus` was intended instead.

The last words punctuation check in `gamemsg.lua` and `cl_voice.lua` used `"[\\.\\!\\?]$"`, but Lua patterns use `%` for escaping, not `\`. The old pattern still matched `.`, `!`, and `?`, but it also matched a trailing backslash. I simplified it to `"[.!?]$"` since no escaping is needed inside a character class.