### PR TITLE
Fix minor logic errors in base Lua

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/entities/gmod_dynamite.lua
+++ b/garrysmod/gamemodes/sandbox/entities/entities/gmod_dynamite.lua
@@ -43,7 +43,8 @@ if ( SERVER ) then
 
 	function ENT:HandleQueuedExplosions()
 
-		for k, v in ipairs( self.QueuedExplosions ) do
+		for k = #self.QueuedExplosions, 1, -1 do
+			local v = self.QueuedExplosions[ k ]
 			if ( v.when <= CurTime() ) then
 				self:Explode( 0, v.player )
 				table.remove( self.QueuedExplosions, k )

--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -297,7 +297,7 @@ end
 -----------------------------------------------------------]]
 function string.TrimLeft( s, char )
 	if ( char ) then char = string.PatternSafe( char ) else char = "%s" end
-	return string.match( s, "^" .. char .. "*(.+)$" ) or s
+	return string.match( s, "^" .. char .. "*(.-)$" ) or s
 end
 
 function string.NiceSize( size )

--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -796,8 +796,8 @@ if ( !table.move ) then
 		local buffer = { unpack( sourceTbl, from, to ) }
 
 		dest = math.floor( dest - 1 )
-		for i, v in ipairs( buffer ) do
-			destTbl[ dest + i ] = v
+		for i = 1, to - from + 1 do
+			destTbl[ dest + i ] = buffer[ i ]
 		end
 
 		return destTbl

--- a/garrysmod/lua/vgui/dcolorpalette.lua
+++ b/garrysmod/lua/vgui/dcolorpalette.lua
@@ -102,8 +102,8 @@ end
 -- This stuff could be better
 function PANEL:NetworkColorChange()
 
-	for id, pnl in pairs( g_ColorPalettePanels ) do
-		if ( !IsValid( pnl ) ) then table.remove( g_ColorPalettePanels, id ) end
+	for id = #g_ColorPalettePanels, 1, -1 do
+		if ( !IsValid( g_ColorPalettePanels[ id ] ) ) then table.remove( g_ColorPalettePanels, id ) end
 	end
 
 	for id, pnl in pairs( g_ColorPalettePanels ) do


### PR DESCRIPTION
While reading through the base Lua code, I came across a few small bugs and fixed them:

`string.TrimLeft("   ")` returned `" "` instead of `""` because it used `(.+)` in its pattern. Unlike `Trim` and `TrimRight`, which use `(.-)`, this prevented strings made up entirely of the trim character from being fully trimmed due to backtracking. Switching to `(.-)` makes its behavior consistent with the other trim functions.

The `table.move` polyfill used `ipairs` to copy the buffer, which stops at the first `nil`. As a result, moving a range containing a `nil` would drop everything after it. The implementation now matches the behavior of the built-in `table.move` and preserves `nil` values correctly.

`gmod_dynamite` removed entries from `QueuedExplosions` while iterating forwards, causing the next queued explosion to be skipped if two exploded on the same tick. Iterating backwards fixes the issue.

`DColorPalette` had the same remove-while-iterating pattern when cleaning up invalid panels, which could leave some invalid panels behind. Switched it to iterate backwards as well.
