### PR TITLE
Entity __index optimizations

### DIFF
--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -27,6 +27,8 @@ end
 --
 -- Entity index accessor. This used to be done in engine, but it's done in Lua now because it's faster
 --
+local Entity_GetTable = meta.GetTable
+local Entity_GetOwner = meta.GetOwner
 function meta:__index( key )
 
 	--
@@ -38,7 +40,7 @@ function meta:__index( key )
 	--
 	-- Search the entity table
 	--
-	local tab = meta.GetTable( self )
+	local tab = Entity_GetTable( self )
 	if ( tab ) then
 		local tabval = tab[ key ]
 		if ( tabval != nil ) then return tabval end
@@ -48,7 +50,7 @@ function meta:__index( key )
 	-- Legacy: sometimes use self.Owner to get the owner.. so lets carry on supporting that stupidness
 	-- This needs to be retired, just like self.Entity was.
 	--
-	if ( key == "Owner" ) then return meta.GetOwner( self ) end
+	if ( key == "Owner" ) then return Entity_GetOwner( self ) end
 
 	return nil
 

--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -8,6 +8,9 @@ if ( !meta ) then return end
 --
 -- Entity index accessor. This used to be done in engine, but it's done in Lua now because it's faster
 --
+setmetatable(meta, { __index = entity })
+
+local Entity_GetTable = entity.GetTable
 function meta:__index( key )
 
 	--
@@ -17,15 +20,9 @@ function meta:__index( key )
 	if ( val ~= nil ) then return val end
 
 	--
-	-- Search the entity metatable
-	--
-	local entval = entity[key]
-	if ( entval ~= nil ) then return entval end
-
-	--
 	-- Search the entity table
 	--
-	local tab = entity.GetTable( self )
+	local tab = Entity_GetTable( self )
 	if ( tab ) then
 		return tab[ key ]
 	end

--- a/garrysmod/lua/includes/extensions/weapon.lua
+++ b/garrysmod/lua/includes/extensions/weapon.lua
@@ -10,6 +10,10 @@ if ( !meta ) then return end
 --
 -- Entity index accessor. This used to be done in engine, but it's done in Lua now because it's faster
 --
+setmetatable(meta, { __index = entity })
+
+local Entity_GetTable = entity.GetTable
+local Entity_GetOwner = entity.GetOwner
 function meta:__index( key )
 
 	--
@@ -19,15 +23,9 @@ function meta:__index( key )
 	if ( val != nil ) then return val end
 
 	--
-	-- Search the entity metatable
-	--
-	local val = entity[key]
-	if ( val != nil ) then return val end
-
-	--
 	-- Search the entity table
 	--
-	local tab = entity.GetTable( self )
+	local tab = Entity_GetTable( self )
 	if ( tab != nil ) then
 		local val = tab[ key ]
 		if ( val != nil ) then return val end
@@ -37,7 +35,7 @@ function meta:__index( key )
 	-- Legacy: sometimes use self.Owner to get the owner.. so lets carry on supporting that stupidness
 	-- This needs to be retired, just like self.Entity was.
 	--
-	if ( key == "Owner" ) then return entity.GetOwner( self ) end
+	if ( key == "Owner" ) then return Entity_GetOwner( self ) end
 	
 	return nil
 	


### PR DESCRIPTION
Quick summary of changes.

I only made a tiny adjustment to the actual Entity metatable, caching the calls to GetTable and GetOwner.

For both Player and Weapon, setting the metatable's metatable with __index pointing to Entity's gave ~33% speed increase in a microbenchmark on my machine.

I don't think there are any meaningful side effects unless addons are already doing strange changes to these metatables. Of course, manually indexing either would now check Entity as well.