### PR TITLE
Fix a few runtime edge cases

### DIFF
--- a/garrysmod/gamemodes/base/gamemode/npc.lua
+++ b/garrysmod/gamemodes/base/gamemode/npc.lua
@@ -111,7 +111,7 @@ function GM:OnNPCKilled( ent, attacker, inflictor )
 	if ( IsValid( inflictor ) and attacker == inflictor and ( inflictor:IsPlayer() or inflictor:IsNPC() ) ) then
 
 		inflictor = inflictor:GetActiveWeapon()
-		if ( !IsValid( attacker ) ) then inflictor = attacker end
+		if ( !IsValid( inflictor ) ) then inflictor = attacker end
 
 	end
 

--- a/garrysmod/gamemodes/sandbox/entities/effects/lasertracer.lua
+++ b/garrysmod/gamemodes/sandbox/entities/effects/lasertracer.lua
@@ -10,7 +10,7 @@ function EFFECT:Init( data )
 	local attid = data:GetAttachment()
 
 	if ( IsValid( ent ) && attid > 0 ) then
-		if ( ent.Owner == LocalPlayer() && LocalPlayer():GetViewModel() == LocalPlayer() ) then ent = ent.Owner:GetViewModel() end
+		if ( ent.Owner == LocalPlayer() ) then ent = ent.Owner:GetViewModel() end
 
 		local att = ent:GetAttachment( attid )
 		if ( att ) then

--- a/garrysmod/gamemodes/sandbox/entities/effects/lasertracer.lua
+++ b/garrysmod/gamemodes/sandbox/entities/effects/lasertracer.lua
@@ -9,12 +9,28 @@ function EFFECT:Init( data )
 	local ent = data:GetEntity()
 	local attid = data:GetAttachment()
 
+	-- if ( data:GetFlags() & TRACER_FLAG_USEATTACHMENT ) then
 	if ( IsValid( ent ) && attid > 0 ) then
-		if ( ent.Owner == LocalPlayer() ) then ent = ent.Owner:GetViewModel() end
+		local posOverride = nil
+		if ( ent:IsWeapon() && ent.GetTracerOrigin ) then posOverride = ent:GetTracerOrigin() end
 
-		local att = ent:GetAttachment( attid )
-		if ( att ) then
-			self.StartPos = att.Pos
+		if ( posOverride ) then
+			self.StartPos = posOverride
+		else
+			-- If local player is not looking through some entity, try to use the current view model
+			local ply = LocalPlayer()
+			if ( ent:IsWeapon() && ply:GetViewEntity() == ply ) then
+				local owner = ent:GetOwner()
+				if ( owner == ply || ( owner != ply && ply:GetObserverTarget() == owner ) ) then
+					-- No viewmodel FOV adjustments are done on the local player here
+					ent = owner:GetViewModel()
+				end
+			end
+
+			local att = ent:GetAttachment( attid )
+			if ( att ) then
+				self.StartPos = att.Pos
+			end
 		end
 	end
 

--- a/garrysmod/lua/autorun/properties/kinect_controller.lua
+++ b/garrysmod/lua/autorun/properties/kinect_controller.lua
@@ -19,6 +19,7 @@ properties.Add( "motioncontrol_ragdoll", {
 
 		if ( CLIENT && !motionsensor ) then return false end
 		if ( CLIENT && !motionsensor.IsAvailable() ) then return false end
+		if ( !IsValid( ent ) ) then return false end
 		if ( !ent:IsRagdoll() ) then return false end
 		if ( !gamemode.Call( "CanProperty", ply, "motioncontrol_ragdoll", ent ) ) then return false end
 


### PR DESCRIPTION
﻿Summary
- Fix the NPC death notice fallback after resolving an active weapon inflictor.
- Use the local viewmodel for owned sandbox laser tracers.
- Reject invalid motion control ragdoll property targets before calling entity methods.

Validation
- Checked open pull requests for matching npc inflictor, lasertracer viewmodel, and kinect controller guard fixes.
- Ran a CRLF-aware whitespace check on the staged diff.