### PR TITLE
[TTT] Fix italic fonts on Linux

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_c4/cl_init.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_c4/cl_init.lua
@@ -282,7 +282,7 @@ vgui.Register( "DisarmPanel", PANEL, "DPanel" )
 
 
 surface.CreateFont("C4Timer", {
-                      font = "Tahoma",
+                      font = GAMEMODE_DEFAULT_UI_FONT,
                       size = 30,
                       weight = 750
                    })

--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
@@ -586,7 +586,7 @@ end
 
 if CLIENT then
    surface.CreateFont("C4ModelTimer", {
-                         font = "Tahoma",
+                         font = GAMEMODE_DEFAULT_UI_FONT,
                          size = 13,
                          weight = 0,
                          antialias = false

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_hud.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_hud.lua
@@ -9,13 +9,13 @@ local GetLang = LANG.GetUnsafeLanguageTable
 local interp = string.Interp
 
 -- Fonts
-surface.CreateFont("TraitorState", {font = "Tahoma",
+surface.CreateFont("TraitorState", {font = GAMEMODE_DEFAULT_UI_FONT,
                                     size = 28,
                                     weight = 1000})
-surface.CreateFont("TimeLeft",     {font = "Tahoma",
+surface.CreateFont("TimeLeft",     {font = GAMEMODE_DEFAULT_UI_FONT,
                                     size = 24,
                                     weight = 800})
-surface.CreateFont("HealthAmmo",   {font = "Tahoma",
+surface.CreateFont("HealthAmmo",   {font = GAMEMODE_DEFAULT_UI_FONT,
                                     size = 24,
                                     weight = 750})
 -- Color presets

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
@@ -1,14 +1,14 @@
 include("shared.lua")
 
 -- Define GM12 fonts for compatibility
-surface.CreateFont("DefaultBold", {font = "Tahoma",
+surface.CreateFont("DefaultBold", {font = GAMEMODE_DEFAULT_UI_FONT,
                                    size = 13,
                                    weight = 1000})
-surface.CreateFont("TabLarge",    {font = "Tahoma",
+surface.CreateFont("TabLarge",    {font = GAMEMODE_DEFAULT_UI_FONT,
                                    size = 13,
                                    weight = 700,
                                    shadow = true, antialias = false})
-surface.CreateFont("Trebuchet22", {font = "Tahoma",
+surface.CreateFont("Trebuchet22", {font = GAMEMODE_DEFAULT_UI_FONT,
                                    size = 22,
                                    weight = 900})
 

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_scoring.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_scoring.lua
@@ -23,7 +23,7 @@ include("scoring_shd.lua")
 local skull_icon = Material("HUD/killicons/default")
 
 surface.CreateFont("WinHuge", {
-   font = "Tahoma",
+   font = GAMEMODE_DEFAULT_UI_FONT,
    size = 72,
    weight = 1000,
    shadow = true,

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_targetid.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_targetid.lua
@@ -128,7 +128,7 @@ end
 
 ---- Crosshair affairs
 
-surface.CreateFont("TargetIDSmall2", {font = "Tahoma",
+surface.CreateFont("TargetIDSmall2", {font = GAMEMODE_DEFAULT_UI_FONT,
                                       size = 16,
                                       weight = 1000})
 

--- a/garrysmod/gamemodes/terrortown/gamemode/shared.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/shared.lua
@@ -6,6 +6,14 @@ GM.Version = "shrug emoji"
 
 GM.Customized = false
 
+-- Font definiton
+GAMEMODE_DEFAULT_UI_FONT = "Tahoma"
+
+if ( system.IsLinux() ) then
+   GAMEMODE_DEFAULT_UI_FONT = "DejaVu Sans"
+end
+
+
 -- Round status consts
 ROUND_WAIT   = 1
 ROUND_PREP   = 2

--- a/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_main.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/vgui/sb_main.lua
@@ -18,7 +18,7 @@ surface.CreateFont("cool_small", {font = "coolvetica",
 surface.CreateFont("cool_large", {font = "coolvetica",
                                   size = 24,
                                   weight = 400})
-surface.CreateFont("treb_small", {font = "Tahoma",
+surface.CreateFont("treb_small", {font = GAMEMODE_DEFAULT_UI_FONT,
                                   size = 14,
                                   weight = 700})
 


### PR DESCRIPTION
This creates a new gloval variable that sets the font to DejaVu Sans instead of Tahoma if it detects that the system is Linux.

The current Tahoma definition makes the fallback font render as italic, somehow. This fixes the italic font problem in many places (scoreboard, HUD, C4 menu, weapon menu etc.).