### PR TITLE
Fix TTT state and report chunking

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_health_station.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_health_station.lua
@@ -32,6 +32,7 @@ ENT.RechargeRate = 1
 ENT.RechargeFreq = 2 -- in seconds
 
 ENT.NextHeal = 0
+ENT.NextCharge = 0
 ENT.HealRate = 1
 ENT.HealFreq = 0.2
 

--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_health_station.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_health_station.lua
@@ -73,6 +73,7 @@ function ENT:Initialize()
    self:SetPlacer(nil)
 
    self.NextHeal = 0
+   self.NextCharge = 0
 
    self.fingerprints = {}
 end
@@ -138,12 +139,11 @@ end
 
 if SERVER then
    -- recharge
-   local nextcharge = 0
    function ENT:Think()
-      if nextcharge < CurTime() then
+      if self.NextCharge < CurTime() then
          self:AddToStorage(self.RechargeRate)
 
-         nextcharge = CurTime() + self.RechargeFreq
+         self.NextCharge = CurTime() + self.RechargeFreq
       end
    end
 

--- a/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_wtester.lua
+++ b/garrysmod/gamemodes/terrortown/entities/weapons/weapon_ttt_wtester.lua
@@ -86,6 +86,7 @@ function SWEP:SetupDataTables()
 end
 
 function SWEP:Initialize()
+   self.ItemSamples = {}
    self:SetCharge(MAX_CHARGE)
    self:SetLastScanned(-1)
 

--- a/garrysmod/gamemodes/terrortown/gamemode/scoring.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/scoring.lua
@@ -229,14 +229,14 @@ function SCORE:StreamToClients()
 
       repeat
          net.Start("TTT_ReportStream_Part")
-            net.WriteData(string.sub(events, curpos + 1, curpos + MaxStreamLength + 1), MaxStreamLength)
+            net.WriteData(string.sub(events, curpos + 1, curpos + MaxStreamLength), MaxStreamLength)
          net.Broadcast()
 
-         curpos = curpos + MaxStreamLength + 1
+         curpos = curpos + MaxStreamLength
       until(len - curpos <= MaxStreamLength)
 
       net.Start("TTT_ReportStream")
-         net.WriteUInt(len, 16)
+         net.WriteUInt(len - curpos, 16)
          net.WriteData(string.sub(events, curpos + 1, len), len - curpos)
       net.Broadcast()
    end


### PR DESCRIPTION
﻿Summary
- Keep DNA sample state per weapon instance.
- Give each health station its own recharge cooldown, including across Lua auto-refresh.
- Preserve every byte and send the correct final chunk length for oversized round reports.

Validation
- Checked current upstream and open pull requests for matching TTT changes.
- Exercised report chunk boundaries around one and two full chunks, including a report larger than 128 KB.
- Reviewed existing-entity behavior through Lua auto-refresh.
- Ran a CRLF-aware whitespace check on the diff.
