### PR TITLE
Fix model metadata refresh query

### DIFF
--- a/garrysmod/lua/includes/util/model_database.lua
+++ b/garrysmod/lua/includes/util/model_database.lua
@@ -44,7 +44,7 @@ function OnModelLoaded( ModelName, NumPoseParams, NumSeq, NumAttachments, NumBon
 	-- We delete the old entry because this model may have been updated.
 	-- The chances are very slim, but there's no real harm in it.
 	--
-	sql.Query( "DELETE FROM modelinfo WHERE model = "..safeModelName )
+	sql.Query( "DELETE FROM modelinfo WHERE name = "..safeModelName )
 	sql.Query( Format( [[INSERT INTO modelinfo ( name, 
 												poseparams, 
 												numsequences, 


### PR DESCRIPTION
Summary
- Delete cached model metadata by the table's actual primary-key column before inserting refreshed values.
- Prevent model updates from leaving stale cached metadata when the old delete query fails.

Validation
- Confirmed the modelinfo schema and lookups use name; model is not a declared column.
- Checked all open pull requests; none modify model_database.lua.
- Ran a CRLF-aware whitespace check on the one-line diff.
