### PR TITLE
remove hack for npc_antlionguardian texture/material

### DIFF
--- a/garrysmod/lua/autorun/base_npcs.lua
+++ b/garrysmod/lua/autorun/base_npcs.lua
@@ -238,7 +238,6 @@ AddNPC( {
 	Class = "npc_antlionguard",
 	Category = Category,
 	KeyValues = { cavernbreed = 1, incavern = 1, SquadName = "antlions" },
-	Material = "Models/antlion_guard/antlionGuard2"
 }, "npc_antlionguardian" )
 
 AddNPC( {

--- a/garrysmod/lua/autorun/base_npcs.lua
+++ b/garrysmod/lua/autorun/base_npcs.lua
@@ -237,7 +237,7 @@ AddNPC( {
 AddNPC( {
 	Class = "npc_antlionguard",
 	Category = Category,
-	KeyValues = { cavernbreed = 1, incavern = 1, SquadName = "antlions" },
+	KeyValues = { cavernbreed = 1, incavern = 1, SquadName = "antlions" }
 }, "npc_antlionguardian" )
 
 AddNPC( {


### PR DESCRIPTION
This was a workaround for GMod shipping with the base HL2 antlion guard model which lacks the second skin slot/group used for the guardian however it's been unnecessary since the episodic/ep2 merge replaced the model and so this workaround should probably be removed since it can occasionally cause unintended visuals under some conditions such as if someone changes the model the NPC is using to something else.

EDIT: I made this PR right before going to sleep and forgot to remove the comma, whoops (testing in game I removed it but forgot to do so when making a commit). I see it's been sorted out though so I guess this is just a sorry for missing that in the first place.