### PR TITLE
Fix spawnmenu error

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/content.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/content.lua
@@ -138,7 +138,7 @@ local function AddCategory( tree, catName, options )
 		for k, v in pairs( items ) do
 			local subCat = language.GetPhrase( v.SubCategory or "" )
 			subCats[ subCat ] = subCats[ subCat ] or {}
-			table.insert( subCats[ subCat ], { item = v, sortName = language.GetPhrase( v[ options.SortName ] ) } )
+			table.insert( subCats[ subCat ], { item = v, sortName = ( v[ options.SortName ] and language.GetPhrase( v[ options.SortName ] ) or v.SpawnName ) } )
 		end
 
 		for subCatName, itemList in SortedPairs( subCats ) do


### PR DESCRIPTION
Commit https://github.com/Facepunch/garrysmod/pull/2387/changes/02837bb6da3e7800014d7e8f328ec8ecc9b1edd1 added a sort order for entities/weapons/etc in the spawn menu, but if any item doesn't have a PrintName it errors and prevents that category from opening. 

This PR fixes it. Could probably do with a cleaner solution but it works.