### PR TITLE
Remove buffer from table.move polyfill

### DIFF
--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -793,11 +793,33 @@ if ( !table.move ) then
 			destTbl = sourceTbl
 		end
 
-		local buffer = { unpack( sourceTbl, from, to ) }
+		local window = to - from
 
-		dest = math.floor( dest - 1 )
-		for i = 1, to - from + 1 do
-			destTbl[ dest + i ] = buffer[ i ]
+		if destTbl == sourceTbl then
+
+			local windowEnd = dest + window
+
+			if dest <= to and windowEnd >= to then
+
+				local off = dest - from
+				local toOff = to - off
+
+				for i = 1, windowEnd - to do
+					sourceTbl[ to + i ] = sourceTbl[ toOff + i ]
+				end
+
+				for i = to, dest, -1 do
+					sourceTbl[ i ] = sourceTbl[ i - off ]
+				end
+
+				return sourceTbl
+
+			end
+
+		end
+
+		for i = 0, window do
+			destTbl[ dest + i ] = sourceTbl[ from + i ]
 		end
 
 		return destTbl


### PR DESCRIPTION
Creating a buffer seemed unnecessary so I got it to work without one.

When the tables are different, or the given dest would not resize the table, it does a shallow copy.

If the dest would resize, the first loop copies the back half of the window first. It goes front-to-back so the array size will be increased without creating holes. The second loop finishes the copy.

This should (and in my testing did) provide a measurable increase in speed.