### PR TITLE
Fix spawnmenu error related to subcategories & custom addons

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/content.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/content.lua
@@ -203,7 +203,7 @@ function PANEL:PopulateFromList( listName, tree, options )
 
 		-- Remove from previous category..
 		for cat, catPnl in pairs( self.Categories ) do
-			if ( !IsValid( catPnl.PropPanel ) or !IsValid( catPnl.PropPanel.SubCategories ) ) then continue end
+			if ( !IsValid( catPnl.PropPanel ) or !catPnl.PropPanel.SubCategories ) then continue end
 
 			for subCatName, icons in pairs( catPnl.PropPanel.SubCategories ) do
 				for id, icon in pairs( icons ) do

--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/content.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/content.lua
@@ -203,7 +203,7 @@ function PANEL:PopulateFromList( listName, tree, options )
 
 		-- Remove from previous category..
 		for cat, catPnl in pairs( self.Categories ) do
-			if ( !IsValid( catPnl.PropPanel ) ) then continue end
+			if ( !IsValid( catPnl.PropPanel ) or !IsValid( catPnl.PropPanel.SubCategories ) ) then continue end
 
 			for subCatName, icons in pairs( catPnl.PropPanel.SubCategories ) do
 				for id, icon in pairs( icons ) do


### PR DESCRIPTION
After subcategories for sweps/sents were natively added added (#2387), resaving ANY swep lua files produce error if you have addons that have own implementation of subcategories like weapon bases (ARC9 or Modern Warfare). These addons create own `PropPanel`s in their tabs, but since new code expects `PropPanel.SubCategories` on every `PropPanel`, refreshing causes an error.

```
[ERROR] gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/content.lua:208: bad argument #1 to 'pairs' (table expected, got nil)
  1. pairs - [C]:-1
   2. RefreshContent - gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/content.lua:208
    3. AutorefreshWeaponToSpawnmenu - gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/weapons.lua:29
     4. unknown - gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/weapons.lua:37

Timer Failed! [Simple][@gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contenttypes/weapons.lua (line 37)]
```


https://github.com/user-attachments/assets/7dad888e-b682-4e5b-ace0-84b10f72e4e1



This PR adds validity check for `PropPanel.SubCategories` before looping through it
