### PR TITLE
Added a Lua error when the "Model Detail" setting is set to Low.

### DIFF
--- a/garrysmod/lua/menu/problems/problems.lua
+++ b/garrysmod/lua/menu/problems/problems.lua
@@ -206,6 +206,12 @@ end
 
 timer.Create( "menu_check_for_problems", 1, 0, function()
 
+	if ( math.floor( GetConVarNumber( "r_rootlod" ) ) == 2 ) then
+		FireProblem( { id = "r_rootlod", text = "#problem.r_rootlod", type = "config", fix = function() RunConsoleCommand( "r_rootlod", "1" ) end, severity = 1 } )
+	else
+		ClearProblem( "r_rootlod" )
+	end
+
 	if ( math.floor( GetConVarNumber( "mat_hdr_level" ) ) != 2 ) then
 		FireProblem( { id = "mat_hdr_level", text = "#problem.mat_hdr_level", type = "config", fix = function() RunConsoleCommand( "mat_hdr_level", "2" ) end, severity = 1 } )
 	else

--- a/garrysmod/lua/menu/problems/problems.lua
+++ b/garrysmod/lua/menu/problems/problems.lua
@@ -207,7 +207,7 @@ end
 timer.Create( "menu_check_for_problems", 1, 0, function()
 
 	if ( math.floor( GetConVarNumber( "r_rootlod" ) ) == 2 ) then
-		FireProblem( { id = "r_rootlod", text = "#problem.r_rootlod", type = "config", fix = function() RunConsoleCommand( "r_rootlod", "1" ) end, severity = 1 } )
+		FireProblem( { id = "r_rootlod", text = "#problem.r_rootlod", type = "config", fix = function() RunConsoleCommand( "r_rootlod", "0" ) end, severity = 1 } )
 	else
 		ClearProblem( "r_rootlod" )
 	end

--- a/garrysmod/resource/localization/en/main_menu.properties
+++ b/garrysmod/resource/localization/en/main_menu.properties
@@ -107,7 +107,7 @@ problem_grp.config=Configuration
 problem_grp.hardware=Hardware
 problem_grp.addons=Addons
 
-problem.r_rootlod=The current "Model Detail" setting can cause serious display issues with certain complex models. This problem typically occurs with vehicles. Even though it may be set to "Medium," it is recommended to keep this setting at "High."
+problem.r_rootlod=The current "Model Detail" setting can cause serious display issues with certain complex models. This problem typically occurs with vehicles. Even though it may be set to "Medium", it is recommended to keep this setting at "High".
 problem.mat_hdr_level=High Dynamic Range (HDR) lighting is disabled. Certain maps will have no lighting.
 problem.mat_bumpmap=Bumpmapping is turned off. Certain models will look incorrect.
 problem.mat_specular=Specular reflections are turned off. Certain models will look incorrect.

--- a/garrysmod/resource/localization/en/main_menu.properties
+++ b/garrysmod/resource/localization/en/main_menu.properties
@@ -107,6 +107,7 @@ problem_grp.config=Configuration
 problem_grp.hardware=Hardware
 problem_grp.addons=Addons
 
+problem.r_rootlod=The current "Model Detail" setting can cause serious display issues with certain complex models. This problem typically occurs with vehicles. Even though it may be set to "Medium," it is recommended to keep this setting at "High."
 problem.mat_hdr_level=High Dynamic Range (HDR) lighting is disabled. Certain maps will have no lighting.
 problem.mat_bumpmap=Bumpmapping is turned off. Certain models will look incorrect.
 problem.mat_specular=Specular reflections are turned off. Certain models will look incorrect.


### PR DESCRIPTION
Hello,
Many players unfamiliar with Garry's Mod (especially new ones) complain about display issues when the model rendering setting is set to "Low." It would be a good idea to implement an error notification for this, similar to how it is already handled for HDR.

**I set it to "0" by default because some of the most popular Workshop vehicles absolutely require the "Model Detail" setting to be on "High."**


# Display issue [(Example)](https://steamcommunity.com/workshop/filedetails/?id=120766823)
<details>
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/e6fd88ae-508a-4c31-a70d-3355beafcecf" />
</details>

<details>
<img width="885" height="465" alt="image" src="https://github.com/user-attachments/assets/52b396c0-656a-4279-9a4e-70e8d59499e9" />
</details>