### PR TITLE
Disable leafblower by default

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/leafblower.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/leafblower.lua
@@ -1,11 +1,12 @@
 
-TOOL.AddToMenu = false
-
 --
 -- This tool is the most important aspect of Garry's Mod
 --
 
+TOOL.AddToMenu = false
 TOOL.LeftClickAutomatic = true
+
+if ( true ) then return end -- Don't actually run anything below, remove this to make everything below functional
 
 function TOOL:LeftClick( trace )
 


### PR DESCRIPTION
This tool is hidden and seems far from finished? Players can still use it via `gmod_tool leafblower`, but i don't think it was ever intended for use at all?