### PR TITLE
A way to distinguish CanTool calls from spawnmenu

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/toolpanel.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/toolpanel.lua
@@ -145,7 +145,7 @@ function PANEL:UpdateToolDisabledStatus()
 
 	local shouldHide = cvar_hide_disabled:GetBool()
 	local searchText = self.SearchBar:GetText():Trim():lower()
-	local fakeTrace = { Entity = game.GetWorld(), Hit = false }
+	local fakeTrace = { Entity = game.GetWorld(), Hit = false, Spawnmenu = true }
 	local anyChanged = false
 
 	for cid, category in ipairs( self.List.pnlCanvas:GetChildren() ) do


### PR DESCRIPTION
Currently, they are called frequently when the spawnmenu is open, making it impossible to determine when it's actually being called during tool use.

For example, this prevents you from reliably displaying notifications in CanTool hooks because they will be spammed when the spawnmenu is open