### PR TITLE
Speedup prop_effect intialization a bit

### DIFF
--- a/garrysmod/gamemodes/base/entities/entities/prop_effect.lua
+++ b/garrysmod/gamemodes/base/entities/entities/prop_effect.lua
@@ -59,11 +59,8 @@ function ENT:Initialize()
 		if ( tab && IsValid( tab[ 1 ] ) ) then self.AttachedEntity = tab[ 1 ] end
 
 		-- Selectively inherit BeingLookedAtByLocalPlayer from base_gmodentity so we don't have to copy paste it
-		local base_gmodentity = scripted_ents.Get( "base_gmodentity" )
-		if ( base_gmodentity ) then
-			self.BeingLookedAtByLocalPlayer = base_gmodentity.BeingLookedAtByLocalPlayer
-			self.MaxWorldTipDistance = base_gmodentity.MaxWorldTipDistance
-		end
+		self.BeingLookedAtByLocalPlayer = scripted_ents.GetMember( "base_gmodentity", "BeingLookedAtByLocalPlayer" )
+		self.MaxWorldTipDistance = scripted_ents.GetMember( "base_gmodentity", "MaxWorldTipDistance" )
 	end
 
 	-- Set collision bounds exactly


### PR DESCRIPTION
There is no point in copying entire table just for 2 values. It is better to use `scripted_ents.GetMember`