### PR TITLE
Optimize string.Explode

### DIFF
--- a/garrysmod/lua/includes/extensions/string.lua
+++ b/garrysmod/lua/includes/extensions/string.lua
@@ -88,21 +88,26 @@ end
 -----------------------------------------------------------]]
 local string_ToTable = string.ToTable
 local string_find = string.find
+
 function string.Explode( separator, str, withpattern )
 	if ( separator == "" ) then return string_ToTable( str ) end
-	if ( withpattern == nil ) then withpattern = false end
+	withpattern = not withpattern
 
 	local ret = {}
 	local current_pos = 1
+	local i = 0
 
-	for i = 1, string_len( str ) do
-		local start_pos, end_pos = string_find( str, separator, current_pos, not withpattern )
+	while true do
+		local start_pos, end_pos = string_find( str, separator, current_pos, withpattern )
 		if ( not start_pos ) then break end
+
+		i = i + 1
 		ret[ i ] = string_sub( str, current_pos, start_pos - 1 )
 		current_pos = end_pos + 1
 	end
 
-	ret[ #ret + 1 ] = string_sub( str, current_pos )
+	i = i + 1
+	ret[ i ] = string_sub( str, current_pos )
 
 	return ret
 end


### PR DESCRIPTION
Slightly speeds up string.Explode, also allows it to be fully jitted (but only on the x86-64 branch for some reason)
```lua
-- https://gist.github.com/Astralcircle/6d6dfebd471fdc3fe3c1043301b938aa
local str = "105689eholdhg,.jdfhglkdjfh34ylkfglkh34ltkjbgkljhr54kjhsd"

GMODBenchmark(10000,
function()
	return string.Explode(str, "4")
end,
function()
	return string.Explode2(str, "4")
end)
```
```
Benchmark results (SERVER):

With jit.off:
1: Total: 0.00083739999996624, AVG: 8.3739999996624e-08, Garbage: 859.38 KB, AVG: 85.9375 Bytes
2: Total: 0.0007181000000287, AVG: 7.181000000287e-08, Garbage: 859.38 KB, AVG: 85.9375 Bytes

With jit.on:
1: Total: 0.00033039999999573, AVG: 3.3039999999573e-08, Garbage: 860.8 KB, AVG: 86.08046875 Bytes
2: Total: 5.8599999988473e-05, AVG: 5.8599999988473e-09, Garbage: 9.04 KB, AVG: 0.904296875 Bytes
```