### PR TITLE
Prevent negative player count in server list

### DIFF
--- a/garrysmod/html/js/menu/control.Servers.js
+++ b/garrysmod/html/js/menu/control.Servers.js
@@ -504,6 +504,8 @@ function AddServer( type, id, ping, name, desc, map, players, maxplayers, botpla
 		favorite:		isFav == "true"
 	};
 
+	if ( data.players < 0 || data.maxplayers < 1 ) return;
+
 	if ( data.flag == "eu" ) data.flag = "europeanunion";
 
 	if ( !IN_ENGINE && !version ) data.version_c = 0;


### PR DESCRIPTION
### Summary
If a server is faking data to give a negative player count, don't add the server to the server list.


### Background
There are servers intentionally messing with the server list's gamemode player count. They are broadcasting that they have 127 slots, with 0 players, but 255 bots. Gmod interprets this as -128 human players currently connected. There are 20 identical servers doing this in DarkRP which means DarkRP starts at -2560 players. 
Actual player counts bring it back up closer to zero but it is still negative.
<img width="427" height="269" alt="image" src="https://github.com/user-attachments/assets/c8846b20-abd3-4421-8059-0c5d021f9460" />
In the case of this screenshot there are 1229 players, minus the -2560 players = a listing of -1331.
See https://discord.com/channels/565105920414318602/565108080300261398/1535122344803303515 for more information.

### Solution
This PR looks at the human player count when adding a server. If it is below zero, the `AddServer` function is aborted for that server. The server doesn't get added to the gamemode's total player count and therefore can't add negative playercount.