### PR TITLE
Make VehicleMemDupe entity modifier more strict

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/commands.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/commands.lua
@@ -1142,7 +1142,7 @@ function Spawn_Vehicle( ply, vname, tr )
 
 	if ( vehicle.Members ) then
 		table.Merge( Ent, vehicle.Members )
-		duplicator.StoreEntityModifier( Ent, "VehicleMemDupe", vehicle.Members )
+		duplicator.StoreEntityModifier( Ent, "VehicleMemDupe", {} )
 	end
 
 	undo.Create( "Vehicle" )
@@ -1160,7 +1160,13 @@ concommand.Add( "gm_spawnvehicle", function( ply, cmd, args ) Spawn_Vehicle( ply
 
 local function VehicleMemDupe( ply, ent, Data )
 
-	table.Merge( ent, Data )
+	local vname = ent:IsVehicle() and ent:GetVehicleClass()
+	if ( !vname ) then return end
+
+	local vehicle = list.GetEntry( "Vehicles", vname )
+	if ( !vehicle or !vehicle.Members ) then return end
+	
+	table.Merge( ent, vehicle.Members )
 
 end
 duplicator.RegisterEntityModifier( "VehicleMemDupe", VehicleMemDupe )


### PR DESCRIPTION
Currently it can modify any part of the table of any entity, even if it's not a vehicle
I added checks to only do this for vehicles and not rely on information from the modifier (which could be harmful)

To completely prevent this, you also need to merge https://github.com/Facepunch/garrysmod/pull/2265