### PR TITLE
TTT: Raise passive equipment item limit from 32 to 1024

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/cl_equip.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_equip.lua
@@ -613,7 +613,10 @@ local function ReceiveEquipment()
    local ply = LocalPlayer()
    if not IsValid(ply) then return end
 
-   ply.equipment_items = net.ReadInt(bitsRequired(EQUIP_MAX, true))
+   ply.equipment_items_tbl = util.ReadBitFields(EQUIP.GetBitChunk(EQUIP_MAX), bitsRequired(EQUIP.GetBitFlag(EQUIP_MAX)))
+
+   -- backwards compatibility
+   ply.equipment_items = ply.equipment_items_tbl[1]
 end
 net.Receive("TTT_Equipment", ReceiveEquipment)
 

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_init.lua
@@ -220,7 +220,13 @@ function GM:ClearClientState()
 
    client:SetRole(ROLE_INNOCENT)
 
-   client.equipment_items = EQUIP_NONE
+   client.equipment_items = EQUIP_NONE -- deprecated
+
+   client.equipment_items_tbl = {}
+   for i = 1, EQUIP.GetBitChunk(EQUIP_MAX) do
+      client.equipment_items_tbl[i] = EQUIP_NONE
+   end
+
    client.equipment_credits = 0
    client.bought = {}
    client.last_id = nil

--- a/garrysmod/gamemodes/terrortown/gamemode/cl_search.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/cl_search.lua
@@ -424,8 +424,6 @@ end
 
 local bitsRequired = util.BitsRequired
 
-local plyBits = bitsRequired(game.MaxPlayers())
-
 local search = {}
 local function ReceiveRagdollSearch()
    search = {}
@@ -433,7 +431,7 @@ local function ReceiveRagdollSearch()
    -- Basic info
    search.eidx = net.ReadUInt(16)
 
-   search.owner = Entity(net.ReadUInt(plyBits))
+   search.owner = Entity(net.ReadUInt(MAX_PLAYER_BITS))
    if not (IsValid(search.owner) and search.owner:IsPlayer() and (not search.owner:IsTerror())) then
       search.owner = nil
    end
@@ -441,12 +439,12 @@ local function ReceiveRagdollSearch()
    search.nick = net.ReadString()
 
    -- Equipment
-   local eq = net.ReadInt(bitsRequired(EQUIP_MAX, true))
+   local eq = util.ReadBitFields(EQUIP.GetBitChunk(EQUIP_MAX), bitsRequired(EQUIP.GetBitFlag(EQUIP_MAX)))
 
    -- All equipment pieces get their own icon
-   search.eq_armor = util.BitSet(eq, EQUIP_ARMOR)
-   search.eq_radar = util.BitSet(eq, EQUIP_RADAR)
-   search.eq_disg = util.BitSet(eq, EQUIP_DISGUISE)
+   search.eq_armor = EQUIP.HasItem(eq, EQUIP_ARMOR)
+   search.eq_radar = EQUIP.HasItem(eq, EQUIP_RADAR)
+   search.eq_disg = EQUIP.HasItem(eq, EQUIP_DISGUISE)
 
    -- Traitor things
    search.role = net.ReadUInt(2)
@@ -464,16 +462,16 @@ local function ReceiveRagdollSearch()
    if num_kills > 0 then
       search.kills = {}
       for i=1,num_kills do
-         table.insert(search.kills, net.ReadUInt(plyBits))
+         table.insert(search.kills, net.ReadUInt(MAX_PLAYER_BITS))
       end
    else
       search.kills = nil
    end
 
-   search.lastid = {idx=net.ReadUInt(plyBits)}
+   search.lastid = {idx=net.ReadUInt(MAX_PLAYER_BITS)}
 
    -- should we show a menu for this result?
-   search.finder = net.ReadUInt(plyBits)
+   search.finder = net.ReadUInt(MAX_PLAYER_BITS)
 
    search.show = (LocalPlayer():EntIndex() == search.finder)
 
@@ -483,7 +481,7 @@ local function ReceiveRagdollSearch()
    local words = net.ReadString()
    search.words = (words != "") and words or nil
 
-   hook.Call("TTTBodySearchEquipment", nil, search, eq)
+   hook.Call("TTTBodySearchEquipment", nil, search, eq[1], eq)
 
    if search.show and hook.Run("TTTShowSearchScreen", search) != false then
       ShowSearchScreen(search)

--- a/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/corpse.lua
@@ -50,13 +50,13 @@ local function IdentifyBody(ply, rag)
       return
    end
 
-   if not hook.Run("TTTCanIdentifyCorpse", ply, rag, (rag.was_role == ROLE_TRAITOR)) then
+   local traitor = rag.was_role == ROLE_TRAITOR
+   if not hook.Run("TTTCanIdentifyCorpse", ply, rag, traitor) then
       return
    end
 
    local finder = ply:Nick()
    local nick = CORPSE.GetPlayerNick(rag, "")
-   local traitor = (rag.was_role == ROLE_TRAITOR)
 
    -- Announce body
    if bodyfound:GetBool() and not CORPSE.GetFound(rag, false) then
@@ -166,8 +166,6 @@ concommand.Add("ttt_call_detective", CallDetective)
 
 local bitsRequired = util.BitsRequired
 
-local plyBits = bitsRequired(game.MaxPlayers()) -- first game.MaxPlayers() of entities are for players.
-
 function GM:TTTCanSearchCorpse(ply, corpse, is_covert, is_long_range, was_traitor)
    -- return true to allow corpse search, false to disallow.
    return true
@@ -182,13 +180,13 @@ function CORPSE.ShowSearch(ply, rag, covert, long_range)
       return
    end
 
-   if not hook.Run("TTTCanSearchCorpse", ply, rag, covert, long_range, (rag.was_role == ROLE_TRAITOR)) then
+   local traitor = rag.was_role == ROLE_TRAITOR
+   if not hook.Run("TTTCanSearchCorpse", ply, rag, covert, long_range, traitor) then
       return
    end
 
    -- init a heap of data we'll be sending
    local nick  = CORPSE.GetPlayerNick(rag)
-   local traitor = (rag.was_role == ROLE_TRAITOR)
    local role  = rag.was_role
    local eq    = rag.equipment or EQUIP_NONE
    local c4    = rag.bomb_wire or 0
@@ -251,9 +249,9 @@ function CORPSE.ShowSearch(ply, rag, covert, long_range)
    -- Send a message with basic info
    net.Start("TTT_RagdollSearch")
       net.WriteUInt(rag:EntIndex(), 16) -- 16 bits
-      net.WriteUInt(owner, plyBits) -- 128 max players. ( 8 bits )
+      net.WriteUInt(owner, MAX_PLAYER_BITS) -- 128 max players. ( 8 bits )
       net.WriteString(nick)
-      net.WriteInt(eq, bitsRequired(EQUIP_MAX, true)) -- Equipment ( default: 4 bits )
+      util.WriteBitFields(eq, bitsRequired(EQUIP.GetBitFlag(EQUIP_MAX))) -- Equipment ( default: 3 bits )
       net.WriteUInt(role, 2) -- ( 2 bits )
       net.WriteUInt(c4, bitsRequired(C4_WIRE_COUNT)) -- 0 -> 2^bits ( default c4: 3 bits )
       net.WriteUInt(dmg, 30) -- DMG_BUCKSHOT is the highest. ( 30 bits )
@@ -264,18 +262,18 @@ function CORPSE.ShowSearch(ply, rag, covert, long_range)
 
       net.WriteUInt(#kill_entids, 8)
       for k, idx in ipairs(kill_entids) do
-         net.WriteUInt(idx, plyBits)
+         net.WriteUInt(idx, MAX_PLAYER_BITS)
       end
 
-      net.WriteUInt(lastid, plyBits)
+      net.WriteUInt(lastid, MAX_PLAYER_BITS)
 
       -- Who found this, so if we get this from a detective we can decide not to
       -- show a window
-      net.WriteUInt(ply:EntIndex(), plyBits)
+      net.WriteUInt(ply:EntIndex(), MAX_PLAYER_BITS)
 
       net.WriteString(words)
 
-      -- 94 + string data + plyBits * (3 + #kill_entids)
+      -- 94 + string data + MAX_PLAYER_BITS * (3 + #kill_entids)
 
    -- If found by detective, send to all, else just the finder
    if ply:IsActiveDetective() then
@@ -406,7 +404,7 @@ function CORPSE.Create(ply, attacker, dmginfo)
 
    -- if someone searches this body they can find info on the victim and the
    -- death circumstances
-   rag.equipment = ply:GetEquipmentItems()
+   rag.equipment = ply:GetEquipmentItems(true)
    rag.was_role = ply:GetRole()
    rag.bomb_wire = ply.bomb_wire
    rag.dmgtype = dmginfo:GetDamageType()

--- a/garrysmod/gamemodes/terrortown/gamemode/equip_items_shd.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/equip_items_shd.lua
@@ -2,6 +2,7 @@
 -- This table is used by the client to show items in the equipment menu, and by
 -- the server to check if a certain role is allowed to buy a certain item.
 
+EQUIP = {}
 
 -- If you have custom items you want to add, consider using a separate lua
 -- script that uses table.insert to add an entry to this table. This method
@@ -101,7 +102,18 @@ EquipmentItems = {
       }
    }
 }
+EQUIP.Items = EquipmentItems
 
+
+local eq_lookup = {}
+for i = 0, 2 do
+   local id = tostring(2^i)
+   eq_lookup[id] = {idx = {[ROLE_TRAITOR] = i + 1}, flag = 2^i, chunk = 1}
+
+   if i != 2 then -- exclude EQUIP_DISGUISE
+      eq_lookup[id].idx[ROLE_DETECTIVE] = i + 1
+   end
+end
 
 -- Search if an item is in the equipment table of a given role, and return it if
 -- it exists, else return nil.
@@ -109,24 +121,83 @@ function GetEquipmentItem(role, id)
    local tbl = EquipmentItems[role]
    if not tbl then return end
 
-   for k, v in pairs(tbl) do
-      if v and v.id == id then
+   -- Converting ids into strings reliably allows number comparisons >= 2^47
+   id = tostring(id)
+
+   -- See if we've looked up this equipment item before
+   local eq = eq_lookup[id]
+   if eq and eq.idx then
+      local idx = eq.idx[role]
+      if idx then
+         return tbl[idx]
+      end
+   end
+
+   for k, v in ipairs(tbl) do
+      if v and tostring(v.id) == id then
+         if eq and eq.idx then
+            eq.idx[role] = k
+         end
+
          return v
       end
    end
 end
+EQUIP.GetItem = GetEquipmentItem
 
 -- GMod's bitwise library is limited to a 32-bit signed int
-local EQUIP_LIMIT = 2 ^ 31
+local equip_chunk_size = 32
 
 -- Utility function to register a new Equipment ID
 function GenerateNewEquipmentID()
    local new_max = EQUIP_MAX * 2
 
-   if new_max > EQUIP_LIMIT then
+   if new_max == math.huge then
       error("Passive equipment item limit reached. Things may break in strange ways!")
    end
 
    EQUIP_MAX = new_max
+
+   local equip_count = math.floor(math.log(EQUIP_MAX) / math.log(2))
+   eq_lookup[tostring(EQUIP_MAX)] = {
+      idx = {},
+      flag = bit.tobit(2 ^ (equip_count % equip_chunk_size)),
+      chunk = math.ceil(equip_count / (equip_chunk_size - 1))
+   }
+
    return EQUIP_MAX
+end
+EQUIP.GenerateNewID = GenerateNewEquipmentID
+
+
+-- Networking more than 32 equipment items at once requires
+-- splitting an equipment bit field into 32-bit chunks.
+function EQUIP.GetBitChunk(id)
+   local eq = eq_lookup[tostring(id)]
+   return eq and eq.chunk
+end
+
+-- Returns the bitflag used to access given
+-- equipment ID within its 32-bit chunk.
+function EQUIP.GetBitFlag(id)
+   local eq = eq_lookup[tostring(id)]
+   return eq and eq.flag
+end
+
+-- Given an equipment id, returns if it was found within given equipment table.
+-- Given nil, returns whether given equipment table has any equipment items.
+function EQUIP.HasItem(eq, id)
+   if not id then
+      for _, chunk in ipairs(eq) do
+         if chunk != EQUIP_NONE then return true end
+      end
+
+      return false
+   end
+
+   local chunkID = EQUIP.GetBitChunk(id)
+   if not chunkID then return false end
+
+   local chunk = eq[chunkID] or EQUIP_NONE
+   return util.BitSet(chunk, EQUIP.GetBitFlag(id))
 end

--- a/garrysmod/gamemodes/terrortown/gamemode/player_ext.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player_ext.lua
@@ -66,28 +66,53 @@ end
 
 function plymeta:SendCredits()
    net.Start("TTT_Credits")
-       net.WriteUInt(self:GetCredits(), 8)
+      net.WriteUInt(self:GetCredits(), 8)
    net.Send(self)
 end
 
 --- Equipment items
 function plymeta:AddEquipmentItem(id)
    id = tonumber(id)
-   if id then
-      self.equipment_items = bit.bor(self.equipment_items, id)
-      self:SendEquipment()
+   if not id then return end
+
+   local flag, chunk = EQUIP.GetBitFlag(id), EQUIP.GetBitChunk(id)
+
+   local eq_chunk = self.equipment_items_tbl[chunk] or EQUIP_NONE
+   self.equipment_items_tbl[chunk] = bit.bor(eq_chunk, flag)
+
+   -- backwards compatibility
+   if chunk == 1 then
+      self.equipment_items = self.equipment_items_tbl[1]
    end
+
+   self:SendEquipment()
 end
 
 -- We do this instead of an NW var in order to limit the info to just this ply
 function plymeta:SendEquipment()
+   local eq = self.equipment_items_tbl
+
+   local max_chunk = EQUIP.GetBitChunk(EQUIP_MAX)
+   if #eq < max_chunk then
+      -- Prevent an error if equipment items are added after a round restart
+      for i = 1, max_chunk do
+         if not eq[i] then self.equipment_items_tbl[i] = EQUIP_NONE end
+      end
+   end
+
    net.Start("TTT_Equipment")
-      net.WriteInt(self.equipment_items, util.BitsRequired(EQUIP_MAX, true))
+      util.WriteBitFields(eq, util.BitsRequired(EQUIP.GetBitFlag(EQUIP_MAX)))
    net.Send(self)
 end
 
 function plymeta:ResetEquipment()
-   self.equipment_items = EQUIP_NONE
+   self.equipment_items = EQUIP_NONE -- deprecated
+
+   self.equipment_items_tbl = {}
+   for i = 1, EQUIP.GetBitChunk(EQUIP_MAX) do
+      self.equipment_items_tbl[i] = EQUIP_NONE
+   end
+
    self:SendEquipment()
 end
 

--- a/garrysmod/gamemodes/terrortown/gamemode/player_ext_shd.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/player_ext_shd.lua
@@ -90,16 +90,15 @@ end
 
 function plymeta:GetCredits() return self.equipment_credits or 0 end
 
-function plymeta:GetEquipmentItems() return self.equipment_items or EQUIP_NONE end
+function plymeta:GetEquipmentItems(tbl)
+   if not self.equipment_items_tbl then return tbl and {EQUIP_NONE} or EQUIP_NONE end
+   return tbl and self.equipment_items_tbl or unpack(self.equipment_items_tbl)
+end
 
 -- Given an equipment id, returns if player owns this. Given nil, returns if
 -- player has any equipment item.
 function plymeta:HasEquipmentItem(id)
-   if not id then
-      return self:GetEquipmentItems() != EQUIP_NONE
-   else
-      return util.BitSet(self:GetEquipmentItems(), id)
-   end
+   return EQUIP.HasItem(self:GetEquipmentItems(true), id)
 end
 
 function plymeta:HasEquipment()
@@ -114,7 +113,7 @@ function plymeta:GetEyeTrace(mask)
 
    if CLIENT then
       local framenum = FrameNumber()
-      
+
       if self.LastPlayerTrace == framenum and self.LastPlayerTraceMask == mask then
          return self.PlayerTrace
       end

--- a/garrysmod/gamemodes/terrortown/gamemode/util.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/util.lua
@@ -176,17 +176,17 @@ function util.passthrough(x) return x end
 -- Fisher-Yates shuffle
 local rand = math.random
 function table.Shuffle(t)
-  local n = #t
+   local n = #t
 
-  while n > 1 do
-    -- n is now the last pertinent index
-    local k = rand(n) -- 1 <= k <= n
-    -- Quick swap
-    t[n], t[k] = t[k], t[n]
-    n = n - 1
-  end
+   while n > 1 do
+      -- n is now the last pertinent index
+      local k = rand(n) -- 1 <= k <= n
+      -- Quick swap
+      t[n], t[k] = t[k], t[n]
+      n = n - 1
+   end
 
-  return t
+   return t
 end
 
 -- Override with nil check
@@ -372,6 +372,11 @@ end
 
 -- Returns the number of bits required to network an integer
 function util.BitsRequired(num, signed)
+   if num < 0 then
+      num = math.abs(num)
+      signed = true
+   end
+
    local bits, max = 0, 1
    while max <= num do
       bits = bits + 1
@@ -383,4 +388,27 @@ function util.BitsRequired(num, signed)
    end
 
    return bits
+end
+
+function util.ReadBitFields(num_chunks, remainder_bits)
+   local tbl = {}
+   for i = 1, num_chunks do
+      if i != num_chunks or remainder_bits == 0 or remainder_bits == 32 then
+         tbl[i] = net.ReadInt(32)
+      else
+         tbl[i] = net.ReadUInt(remainder_bits)
+      end
+   end
+
+   return tbl
+end
+
+function util.WriteBitFields(tbl, remainder_bits)
+   for i, chunk in ipairs(tbl) do
+      if i != #tbl or remainder_bits == 0 or remainder_bits == 32 then
+         net.WriteInt(chunk, 32)
+      else
+         net.WriteUInt(chunk, remainder_bits)
+      end
+   end
 end

--- a/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/weaponry.lua
@@ -420,11 +420,13 @@ local function OrderEquipment(ply, cmd, args)
                       net.Start("TTT_BoughtItem")
                       net.WriteBool(is_item)
                       if is_item then
+                         -- https://github.com/Facepunch/garrysmod-issues/issues/6556
+                         local exp = math.floor(math.log(id) / math.log(2))
+                         local max_exp = math.floor(math.log(EQUIP_MAX) / math.log(2))
+
                          -- since we only network one item here, convert the bitflag equipment id
                          -- into a power of two exponent before networking it
-
-                         local exponent = math.log(id) / math.log(2)
-                         net.WriteUInt(exponent, bitsRequired(math.log(EQUIP_MAX) / math.log(2)))
+                         net.WriteUInt(exp, bitsRequired(max_exp))
                       else
                          net.WriteString(id)
                       end


### PR DESCRIPTION
Currently, since a player's equipment items are stored within a single number, the equipment item limit is determined by the 32-bit limit of the bitwise and net libraries. By splitting the player's equipment items into 32-bit chunks once the limit is reached, the maximum number of equipment items can be taken all the way up to 1024, at which point lua becomes unable to store equipment IDs that large.

In the context of vanilla gameplay, this is obviously quite unnecessary. However, overhaul addons that add custom roles with unique equipment menus are often packaged with their own custom equipment item handling, as the limit of 32 becomes much more restrictive with extra unique role shops in play. This implementation is intended to extend the limit as far as possible without either breaking addons that rely on the existing behaviour or introducing extra networking overhead.