### PR TITLE
Fix: Rounding issue with the GetTextValue function and the Player Editor

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/editor_player.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/editor_player.lua
@@ -136,17 +136,17 @@ list.Set( "DesktopWindows", "PlayerEditor", {
 		local function UpdateBodyGroups( pnl, val )
 			if ( pnl.type == "bgroup" ) then
 
-				mdl.Entity:SetBodygroup( pnl.typenum, math.Round( val ) )
+				mdl.Entity:SetBodygroup( pnl.typenum, math.floor( val ) )
 
 				local str = string.Explode( " ", GetConVarString( "cl_playerbodygroups" ) )
 				if ( #str < pnl.typenum + 1 ) then for i = 1, pnl.typenum + 1 do str[ i ] = str[ i ] or 0 end end
-				str[ pnl.typenum + 1 ] = math.Round( val )
+				str[ pnl.typenum + 1 ] = math.floor( val )
 				RunConsoleCommand( "cl_playerbodygroups", table.concat( str, " " ) )
 
 			elseif ( pnl.type == "skin" ) then
 
-				mdl.Entity:SetSkin( math.Round( val ) )
-				RunConsoleCommand( "cl_playerskin", math.Round( val ) )
+				mdl.Entity:SetSkin( math.floor( val ) )
+				RunConsoleCommand( "cl_playerskin", math.floor( val ) )
 
 			end
 		end

--- a/garrysmod/lua/vgui/dnumberscratch.lua
+++ b/garrysmod/lua/vgui/dnumberscratch.lua
@@ -150,7 +150,7 @@ function PANEL:GetTextValue()
 
 	local iDecimals = self:GetDecimals()
 	if ( iDecimals == 0 ) then
-		return Format( "%i", self:GetFloatValue() )
+		return tostring( math.floor( self:GetFloatValue() ) )
 	end
 
 	return Format( "%." .. iDecimals .. "f", self:GetFloatValue() )

--- a/garrysmod/lua/vgui/dnumberscratch.lua
+++ b/garrysmod/lua/vgui/dnumberscratch.lua
@@ -150,7 +150,7 @@ function PANEL:GetTextValue()
 
 	local iDecimals = self:GetDecimals()
 	if ( iDecimals == 0 ) then
-		return tostring( math.floor( self:GetFloatValue() ) )
+		return Format( "%i", self:GetFloatValue() )
 	end
 
 	return Format( "%." .. iDecimals .. "f", self:GetFloatValue() )


### PR DESCRIPTION
Hello,
This PR fixes the issue where the bodygroup changes when close to the next bodygroup. Currently, the system rounds up, which doesn't seem very logical to me; it would be better if the system simply dropped the decimal part.

I modified the `PANEL:GetTextValue` function of the `DNumberScratch` vgui element and the `UpdateBodyGroups` local function of the Player Editor.

I chose not to modify the value received from `PANEL:OnValueChanged` directly at the source, this was done for compatibility reasons and to maintain the logic required by certain addons that need to know the value's precise position on the slider.

# Result
## Before 
<details>

<img width="729" height="97" alt="image" src="https://github.com/user-attachments/assets/a5025021-a2cf-4a6e-8f59-e73e8fd16beb" />

</details>

## After
<details>

<img width="727" height="105" alt="image" src="https://github.com/user-attachments/assets/7998dc5c-c1d5-4057-b912-54078548894d" />

</details>

