### PR TITLE
Add search bar to Derma Controls list window

### DIFF
--- a/garrysmod/lua/derma/derma_example.lua
+++ b/garrysmod/lua/derma/derma_example.lua
@@ -3,7 +3,7 @@ local PANEL = {}
 
 function PANEL:Init()
 
-	self:SetTitle( "Derma Initiative Control Test" )
+	self:SetTitle( language.GetPhrase( "derma_controls.title" ) )
 	self.ContentPanel = vgui.Create( "DPropertySheet", self )
 	self.ContentPanel:Dock( FILL )
 
@@ -24,6 +24,29 @@ function PANEL:Init()
 	end
 
 	self:SetSize( 600, 450 )
+
+	self.SearchControl = vgui.Create( "DTextEntry", self )
+	self.SearchControl:Dock( TOP )
+	self.SearchControl:SetUpdateOnType( true )
+	self.SearchControl:SetPlaceholderText( language.GetPhrase( "derma_controls.search" ) )
+	self.SearchControl.OnValueChange = function( _, str )
+		if str == "" then
+			for k, v in ipairs( self.ContentPanel:GetItems() ) do
+				v.Tab:SetVisible( true )
+			end
+		else
+			for k, v in ipairs( self.ContentPanel:GetItems() ) do
+				if string.find( string.lower( v.Name ), string.lower( str ) ) then
+					v.Tab:SetVisible( true )
+				else
+					v.Tab:SetVisible( false )
+				end
+			end
+		end
+
+		-- Force panel refresh (for size)
+		self.ContentPanel.tabScroller:ScrollToChild( self.ContentPanel:GetActiveTab() )
+	end
 
 end
 
@@ -48,7 +71,8 @@ concommand.Add( "derma_controls" .. DermaControlsSuffix, function( player, comma
 
 	if ( IsValid( DermaExample ) ) then
 		DermaExample:Remove()
-	return end
+		return 
+	end
 
 	DermaExample = vgui.CreateFromTable( vguiExampleWindow )
 	DermaExample:SwitchTo( args )

--- a/garrysmod/lua/derma/derma_example.lua
+++ b/garrysmod/lua/derma/derma_example.lua
@@ -30,17 +30,12 @@ function PANEL:Init()
 	self.SearchControl:SetUpdateOnType( true )
 	self.SearchControl:SetPlaceholderText( language.GetPhrase( "derma_controls.search" ) )
 	self.SearchControl.OnValueChange = function( _, str )
-		if str == "" then
-			for k, v in ipairs( self.ContentPanel:GetItems() ) do
+		local strLower = string.lower( str )
+		for k, v in ipairs( self.ContentPanel:GetItems() ) do
+			if ( strLower == "" or string.find( string.lower( v.Name ), strLower ) ) then
 				v.Tab:SetVisible( true )
-			end
-		else
-			for k, v in ipairs( self.ContentPanel:GetItems() ) do
-				if string.find( string.lower( v.Name ), string.lower( str ) ) then
-					v.Tab:SetVisible( true )
-				else
-					v.Tab:SetVisible( false )
-				end
+			else
+				v.Tab:SetVisible( false )
 			end
 		end
 

--- a/garrysmod/resource/localization/en/community.properties
+++ b/garrysmod/resource/localization/en/community.properties
@@ -1006,3 +1006,6 @@ network.online=Online
 chat.dead=*DEAD*
 chat.team=(TEAM)
 chat.console=Console
+
+derma_controls.title=Derma Initiative Control Test
+derma_controls.search=Search for a control...


### PR DESCRIPTION
Hello,
In this PR, I’ve made it possible to translate the phrases in the `derma_controls` menu and added a search bar. This search bar is extremely handy if you have way too many VGUI elements.

# Results
## Before
<img width="634" height="483" alt="image" src="https://github.com/user-attachments/assets/3b7dedc5-527e-4657-b97d-98a919f84cae" />

## After
<img width="656" height="504" alt="image" src="https://github.com/user-attachments/assets/87383fce-fd18-47e4-bc3c-4521603f1f10" />

<img width="692" height="488" alt="image" src="https://github.com/user-attachments/assets/65727477-7b6a-47e3-9285-1f20d8d06b35" />

