### PR TITLE
Fix gmod_admin_cleanup error when run twice

### DIFF
--- a/garrysmod/lua/includes/modules/cleanup.lua
+++ b/garrysmod/lua/includes/modules/cleanup.lua
@@ -174,11 +174,15 @@ if ( SERVER ) then
 
 	end
 
+	local cleanupRunning = false
+
 	function CC_AdminCleanup( pl, command, args )
 
 		if ( IsValid( pl ) && !pl:IsAdmin() ) then return end
 
 		if ( !args[ 1 ] ) then
+
+			if ( cleanupRunning ) then return end
 
 			for key, ply in pairs( cleanup_list ) do
 
@@ -196,7 +200,11 @@ if ( SERVER ) then
 
 			end
 
+			cleanupRunning = true
+
 			game.CleanUpMap( false, nil, function()
+				cleanupRunning = false
+
 				-- Send tooltip command to client
 				if ( IsValid( pl ) ) then pl:SendLua( "hook.Run('OnCleanup','all')" ) end
 			end )


### PR DESCRIPTION
## Details
This PR fixes [this issue](https://github.com/Facepunch/garrysmod-issues/issues/7005).

Running `gmod_admin_cleanup` twice in a short time (e.g. `gmod_admin_cleanup; gmod_admin_cleanup`) caused an error:

```
[ERROR] Cannot run game.CleanUpMap while it is already running!
  1. unknown - lua/includes/modules/cleanup.lua:199
   2. unknown - lua/includes/modules/concommand.lua:60
```