### PR TITLE
[TTT] restore original arctic playermodel colour while in "serious mode"

### DIFF
--- a/garrysmod/gamemodes/terrortown/gamemode/shared.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/shared.lua
@@ -155,6 +155,9 @@ local playercolor_mode = CreateConVar("ttt_playercolor_mode", "1")
 function GM:TTTPlayerColor(model)
    local mode = playercolor_mode:GetInt()
    if mode == 1 then
+      if model == "models/player/arctic.mdl" then
+         return COLOR_WHITE
+      end
       return table.Random(ttt_playercolors.serious)
    elseif mode == 2 then
       return table.Random(ttt_playercolors.all)


### PR DESCRIPTION
a recent gmod changed allowed the arctic playermodel to be coloured:

https://github.com/Facepunch/garrysmod-requests/issues/3090

![Image](https://github.com/user-attachments/assets/a3472121-1ab6-43be-96c3-b0c30999f34b)

i think for the "serious mode" player colour setting, it should retain the original colour, because it currently looks very bizarre in my opinion

it's subjective, but this seems to fit bku's Original Vision better:

2c130ace89bbf39828220097a984191e5ce7f10c

> @svdm committed on Jun 15, 2013
> TTT: only color whitelisted playermodels
> Arctic looked pretty bad.

it's up to him though