### PR TITLE
[Spawnmenu - Search] Fix for icons not loading when overridden.

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/cl_search_models.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/cl_search_models.lua
@@ -147,7 +147,7 @@ local function AddSearchProvider( listname, ctype, stype )
 					local contentIconData = {
 						nicename = name or name_c,
 						spawnname = name_c,
-						material = "entities/" .. name_c .. ".png",
+						material = v.IconOverride or "entities/" .. name_c .. ".png",
 						admin = v.AdminOnly
 					}
 


### PR DESCRIPTION
This PR displays the icons when searching the spawnmenu, if it has been overridden by the `IconOverride` variable.

Before : 
<img width="536" height="241" alt="image" src="https://github.com/user-attachments/assets/82ccb67a-020a-48c1-900c-e364b84b3f34" />
```
FreeImage: Couldn't open file 'entities/glide_repair.png'
FreeImage: Couldn't open file 'entities/glide_homing_launcher.png'
FreeImage: Couldn't open file 'entities/glide_instant_repair.png'
```

After : 
<img width="466" height="209" alt="image" src="https://github.com/user-attachments/assets/4ae58c54-ee04-4603-9130-0c9fd3333ebc" />
