### PR TITLE
improve Entity.__index performance

### DIFF
--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -77,6 +77,14 @@ function meta:__newindex( key, value )
 
 end
 
+meta.SetTableInternal = meta.SetTableInternal or meta.SetTable
+
+function meta:SetTable( tab )
+	EntityTablesCache[ self ] = nil
+
+	return meta.SetTableInternal( self, tab )
+end
+
 --[[---------------------------------------------------------
 	Name: Short cut to add entities to the table
 -----------------------------------------------------------]]

--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -42,7 +42,9 @@ function meta:__index( key )
 	local tab = EntityTablesCache[ self ]
 	if ( not tab ) then
 		tab = meta.GetTable( self )
-		EntityTablesCache[ self ] = tab
+		if ( tab and not tab.__DoNotCacheEntityTable ) then
+			EntityTablesCache[ self ] = tab
+		end
 	end
 	if ( tab ) then
 		local tabval = tab[ key ]
@@ -64,7 +66,9 @@ function meta:__newindex( key, value )
 	local tab = EntityTablesCache[ self ]
 	if ( not tab ) then
 		tab = meta.GetTable( self )
-		EntityTablesCache[ self ] = tab
+		if ( tab and not tab.__DoNotCacheEntityTable ) then
+			EntityTablesCache[ self ] = tab
+		end
 	end
 
 	tab[ key ] = value
@@ -165,7 +169,11 @@ end
 -----------------------------------------------------------]]
 local function DoDieFunction( ent )
 
-	EntityTablesCache[ ent ] = nil
+	local tab = EntityTablesCache[ ent ]
+	if tab then
+		tab.__DoNotCacheEntityTable = true
+		EntityTablesCache[ ent ] = nil
+	end
 
 	if ( !ent.OnDieFunctions ) then return end
 

--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -80,9 +80,11 @@ end
 meta.SetTableInternal = meta.SetTableInternal or meta.SetTable
 
 function meta:SetTable( tab )
+
 	EntityTablesCache[ self ] = nil
 
 	return meta.SetTableInternal( self, tab )
+
 end
 
 --[[---------------------------------------------------------
@@ -181,6 +183,7 @@ local function DoDieFunction( ent )
 
 	local tab = EntityTablesCache[ ent ]
 	if tab then
+		-- Clear this entity's table from the cache and make sure it doesn't get cached again
 		tab.__DoNotCacheEntityTable = true
 		EntityTablesCache[ ent ] = nil
 	end

--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -55,7 +55,7 @@ function meta:__index( key )
 	-- Legacy: sometimes use self.Owner to get the owner.. so lets carry on supporting that stupidness
 	-- This needs to be retired, just like self.Entity was.
 	--
-	if ( key == "Owner" ) then return meta.GetOwner( self ) end
+	if ( key == "Owner" and not meta.IsPlayer( self ) ) then return meta.GetOwner( self ) end
 
 	return nil
 

--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -55,7 +55,7 @@ function meta:__index( key )
 	-- Legacy: sometimes use self.Owner to get the owner.. so lets carry on supporting that stupidness
 	-- This needs to be retired, just like self.Entity was.
 	--
-	if ( key == "Owner" and not meta.IsPlayer( self ) ) then return meta.GetOwner( self ) end
+	if ( key == "Owner" and not self:IsPlayer() ) then return meta.GetOwner( self ) end
 
 	return nil
 

--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -71,7 +71,9 @@ function meta:__newindex( key, value )
 		end
 	end
 
-	tab[ key ] = value
+	if ( tab ) then
+		tab[ key ] = value
+	end
 
 end
 

--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -66,14 +66,13 @@ function meta:__newindex( key, value )
 	local tab = EntityTablesCache[ self ]
 	if ( not tab ) then
 		tab = meta.GetTable( self )
-		if ( tab and not tab.__DoNotCacheEntityTable ) then
+		if ( not tab ) then return end
+		if ( not tab.__DoNotCacheEntityTable ) then
 			EntityTablesCache[ self ] = tab
 		end
 	end
 
-	if ( tab ) then
-		tab[ key ] = value
-	end
+	tab[ key ] = value
 
 end
 

--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -61,6 +61,8 @@ function meta:__index( key )
 
 end
 
+meta.__newindex_Internal = meta.__newindex_Internal or meta.__newindex
+
 function meta:__newindex( key, value )
 
 	local tab = EntityTablesCache[ self ]
@@ -70,6 +72,10 @@ function meta:__newindex( key, value )
 		if ( not tab.__DoNotCacheEntityTable ) then
 			EntityTablesCache[ self ] = tab
 		end
+	end
+
+	if key == "RenderOverride" then
+		return meta.__newindex_Internal( self, key, value )
 	end
 
 	tab[ key ] = value

--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -61,24 +61,50 @@ function meta:__index( key )
 
 end
 
-meta.__newindex_Internal = meta.__newindex_Internal or meta.__newindex
+if ( CLIENT ) then
 
-function meta:__newindex( key, value )
+	meta.__newindex_Internal = meta.__newindex_Internal or meta.__newindex
 
-	local tab = EntityTablesCache[ self ]
-	if ( not tab ) then
-		tab = meta.GetTable( self )
-		if ( not tab ) then return end
-		if ( not tab.__DoNotCacheEntityTable ) then
-			EntityTablesCache[ self ] = tab
+	function meta:__newindex( key, value )
+
+		local tab = EntityTablesCache[ self ]
+		if ( not tab ) then
+			tab = meta.GetTable( self )
+			if ( not tab ) then return end
+			if ( not tab.__DoNotCacheEntityTable ) then
+				EntityTablesCache[ self ] = tab
+			end
 		end
+
+		if (
+				key == "CalcAbsolutePosition" or
+				key == "RenderOverride" or
+				key == "m_RenderAngles" or
+				key == "m_RenderOrigin"
+		) then
+			return meta.__newindex_Internal( self, key, value )
+		end
+
+		tab[ key ] = value
+
 	end
 
-	if key == "RenderOverride" then
-		return meta.__newindex_Internal( self, key, value )
-	end
+else
 
-	tab[ key ] = value
+	function meta:__newindex( key, value )
+
+		local tab = EntityTablesCache[ self ]
+		if ( not tab ) then
+			tab = meta.GetTable( self )
+			if ( not tab ) then return end
+			if ( not tab.__DoNotCacheEntityTable ) then
+				EntityTablesCache[ self ] = tab
+			end
+		end
+
+		tab[ key ] = value
+
+	end
 
 end
 

--- a/garrysmod/lua/includes/extensions/entity.lua
+++ b/garrysmod/lua/includes/extensions/entity.lua
@@ -24,6 +24,7 @@ function meta:SetShouldPlayPickupSound( bPlaySound )
 	self.m_bPlayPickupSound = tobool( bPlaySound ) or false
 end
 
+local EntityTablesCache = {}
 --
 -- Entity index accessor. This used to be done in engine, but it's done in Lua now because it's faster
 --
@@ -33,15 +34,19 @@ function meta:__index( key )
 	-- Search the metatable. We can do this without dipping into C, so we do it first.
 	--
 	local val = meta[ key ]
-	if ( val != nil ) then return val end
+	if ( val ~= nil ) then return val end
 
 	--
 	-- Search the entity table
 	--
-	local tab = meta.GetTable( self )
+	local tab = EntityTablesCache[ self ]
+	if ( not tab ) then
+		tab = meta.GetTable( self )
+		EntityTablesCache[ self ] = tab
+	end
 	if ( tab ) then
 		local tabval = tab[ key ]
-		if ( tabval != nil ) then return tabval end
+		if ( tabval ~= nil ) then return tabval end
 	end
 
 	--
@@ -51,6 +56,18 @@ function meta:__index( key )
 	if ( key == "Owner" ) then return meta.GetOwner( self ) end
 
 	return nil
+
+end
+
+function meta:__newindex( key, value )
+
+	local tab = EntityTablesCache[ self ]
+	if ( not tab ) then
+		tab = meta.GetTable( self )
+		EntityTablesCache[ self ] = tab
+	end
+
+	tab[ key ] = value
 
 end
 
@@ -147,6 +164,8 @@ end
 	Simple mechanism for calling the die functions.
 -----------------------------------------------------------]]
 local function DoDieFunction( ent )
+
+	EntityTablesCache[ ent ] = nil
 
 	if ( !ent.OnDieFunctions ) then return end
 

--- a/garrysmod/lua/includes/extensions/player.lua
+++ b/garrysmod/lua/includes/extensions/player.lua
@@ -16,21 +16,13 @@ function meta:__index( key )
 	local val = meta[key]
 	if ( val ~= nil ) then return val end
 
-	--
-	-- Search the entity metatable
-	--
-	local entval = entity[key]
-	if ( entval ~= nil ) then return entval end
+	return entity.__index( self, key )
 
-	--
-	-- Search the entity table
-	--
-	local tab = entity.GetTable( self )
-	if ( tab ) then
-		return tab[ key ]
-	end
+end
 
-	return nil
+function meta:__newindex( key, value )
+
+	return entity.__newindex( self, key, value )
 
 end
 

--- a/garrysmod/lua/includes/extensions/weapon.lua
+++ b/garrysmod/lua/includes/extensions/weapon.lua
@@ -16,30 +16,14 @@ function meta:__index( key )
 	-- Search the metatable. We can do this without dipping into C, so we do it first.
 	--
 	local val = meta[key]
-	if ( val != nil ) then return val end
+	if ( val ~= nil ) then return val end
 
-	--
-	-- Search the entity metatable
-	--
-	local val = entity[key]
-	if ( val != nil ) then return val end
+	return entity.__index( self, key )
 
-	--
-	-- Search the entity table
-	--
-	local tab = entity.GetTable( self )
-	if ( tab != nil ) then
-		local val = tab[ key ]
-		if ( val != nil ) then return val end
-	end
-
-	--
-	-- Legacy: sometimes use self.Owner to get the owner.. so lets carry on supporting that stupidness
-	-- This needs to be retired, just like self.Entity was.
-	--
-	if ( key == "Owner" ) then return entity.GetOwner( self ) end
-	
-	return nil
-	
 end
 
+function meta:__newindex( key, value )
+
+	return entity.__newindex( self, key, value )
+
+end


### PR DESCRIPTION
yet another attempt to optimise `Entity.__index`

this caches `Entity:GetTable()` without any sort of metatable shenanigans that i've seen from other attempts

cached tables get stored in `EntityTablesCache` which gets cleaned up by the `GM:EntityRemoved` hook

the same optimisation can probably be done for `Panel` but i dont remember if there's a way to check for panel deletions

`Entity:GetVar()` and `Entity:SetVar()` are untouched for now

i ran this change in a ttt server for a while and encountered no issue

please discuss if you think this needs changes or if you think this is a bad idea

benchmark, before and after:

<img width="150" height="360" alt="image" src="https://github.com/user-attachments/assets/f4b1f19c-6558-480f-a217-36b61a01d85e" />
<img width="150" height="360" alt="image" src="https://github.com/user-attachments/assets/79686a22-7ad0-4754-a815-b857ed141923" />

around ~30-60x speed increase with jit on and ~3-4x with jit off

```lua
local keys = {}

for i = 1, 1000 do
	keys[i] = "test " .. i
end

local ent = Entity(1)
local SysTime = SysTime

local function dobench()
	local keys, ent, SysTime = keys, ent, SysTime

	local start = SysTime()

	for i = 1, 10000 do
		for i = 1, 1000 do
			ent[keys[i]] = i
		end
	end

	local total_newindex = SysTime() - start

	start = SysTime()

	local a = 0

	for i = 1, 10000 do
		for i = 1, 1000 do
			a = a + ent[keys[i]]
		end
	end

	local total_index = SysTime() - start

	print(a)
	print(total_index)
	print(total_newindex)
end

function bench()
	collectgarbage("collect")
	jit.on()

	for i = 1, 1000 do
		ent[keys[i]] = nil
	end

	dobench()
end
```

i think this change should be compatible with every sane addon

this is compliant with the current behaviour, nothing about the current __index flow is changed, it follows this order:
1\) check player/weapon metatable first
2\) then check entity metatable
3\) then check per-entity table
4\) then check for "Owner" fallback

works identically both server-side and client-side

full-updates on the client don't cause any issue, all they do is invalidate the cache

only caveats i can think of:

without this change, a bad addon can potentially break `Entity:CallOnRemove()` when causing an error in `GM:EntityRemoved`
with this change, an additional issue when a bad addon errors in that hook is that the `EntityTablesCache` table might not get cleaned up

an addon that overrides `Entity:GetTable()` and expects it to be called each time entities are indexed will find that it only gets called once
(i think this is a bizarre use case though, i doubt anyone's doing this and if they are then they should just rework it)

other than that, all other behaviour related to the entity table and indexing it should be identical as far as i know