### PR TITLE
Add hook for spawnmenu selection menu 

### DIFF
--- a/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contentcontainer.lua
+++ b/garrysmod/gamemodes/sandbox/gamemode/spawnmenu/creationmenu/content/contentcontainer.lua
@@ -209,6 +209,8 @@ hook.Add( "SpawnlistOpenGenericMenu", "DragAndDropSelectionMenu", function( canv
 
 	end ):SetIcon( "icon16/bin_closed.png" )
 
+	hook.Run( "SpawnmenuSelectionMenu", menu, selected, spawnicons )
+
 	menu:Open()
 
 end )


### PR DESCRIPTION
Hello,
The purpose of this PR is simply to replicate the mechanism of the `SpawnmenuIconMenuOpen` hook. This will allow adding options to the DermaMenu without overriding the main hook.