### PR TITLE
TTT: Fix high ping T radio and add more custom sound options

### DIFF
--- a/garrysmod/gamemodes/terrortown/entities/entities/ttt_radio.lua
+++ b/garrysmod/gamemodes/terrortown/entities/entities/ttt_radio.lua
@@ -33,10 +33,8 @@ function ENT:Initialize()
    end
 
    -- Register with owner
-   if CLIENT then
-      if LocalPlayer() == self:GetOwner() then
-         LocalPlayer().radio = self
-      end
+   if CLIENT and LocalPlayer() == self:GetOwner() then
+      LocalPlayer().radio = self
    end
 
    self.SoundQueue = {}
@@ -77,10 +75,8 @@ function ENT:OnTakeDamage(dmginfo)
 end
 
 function ENT:OnRemove()
-   if CLIENT then
-      if LocalPlayer() == self:GetOwner() then
-         LocalPlayer().radio = nil
-      end
+   if CLIENT and LocalPlayer() == self:GetOwner() then
+      LocalPlayer().radio = nil
    end
 end
 
@@ -90,12 +86,12 @@ function ENT:AddSound(snd)
    end
 end
 
-function ENT:PlayDelayedSound(snd, ampl, last)
+function ENT:PlayDelayedSound(snd, ampl, last, pitch, vol, chan, flags, dsp)
    if istable(snd) then
       snd = table.Random(snd)
    end
 
-   self:BroadcastSound(snd, ampl)
+   self:BroadcastSound(snd, ampl, pitch, vol, chan, flags, dsp, true)
 
    self.Playing = not last
 
@@ -109,7 +105,12 @@ function ENT:PlaySound(snd)
    if hook.Run("TTTRadioPlaySound", self, snd, soundData) == true then return end
 
    local sndlist = soundData.sound
-   local ampl = soundData.ampl
+   local ampl, pitch, vol = soundData.ampl, soundData.pitch, soundData.vol
+   local chan, flags, dsp = soundData.chan, soundData.flags, soundData.dsp
+
+   local a = istable(ampl) and math.random(ampl[1], ampl[2]) or ampl
+   local p = istable(pitch) and math.random(pitch[1], pitch[2]) or pitch
+   local v = istable(vol) and math.Rand(vol[1], vol[2]) or vol
 
    local serial = soundData.serial
    local times = soundData.times
@@ -135,11 +136,15 @@ function ENT:PlaySound(snd)
                            -- maybe we can get destroyed while a timer is still up
                            if not IsValid(self) then return end
 
-                           self:PlayDelayedSound(sndpath, ampl, i == times)
+                           self:PlayDelayedSound(sndpath, a, i == times, p, v, chan, flags, dsp)
                         end)
 
             local d = istable(delay) and math.Rand(delay[1], delay[2]) or delay
             t = t + d
+
+            a = istable(ampl) and math.random(ampl[1], ampl[2]) or ampl
+            p = istable(pitch) and math.random(pitch[1], pitch[2]) or pitch
+            v = istable(vol) and math.Rand(vol[1], vol[2]) or vol
 
             if serial then
                idx = idx + 1
@@ -151,7 +156,7 @@ function ENT:PlaySound(snd)
       end
    end
 
-   self:PlayDelayedSound(sndlist, ampl, true)
+   self:PlayDelayedSound(sndlist, a, true, p, v, chan, flags, dsp)
 end
 
 local nextplay = 0

--- a/garrysmod/gamemodes/terrortown/gamemode/entity.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/entity.lua
@@ -18,10 +18,11 @@ function meta:IsExplosive()
 end
 
 -- Some sounds are important enough that they shouldn't be affected by CPASAttenuationFilter
-function meta:BroadcastSound(snd, lvl, pitch, vol, channel, flags, dsp)
+function meta:BroadcastSound(snd, lvl, pitch, vol, channel, flags, dsp, unreliable)
    lvl = lvl or 75
 
-   local rf = RecipientFilter()
+   -- Set unreliable when playing sounds in rapid succession (e.g. automatic weapons)
+   local rf = RecipientFilter(unreliable)
 
    if lvl == 0 then
       rf:AddAllPlayers()

--- a/garrysmod/gamemodes/terrortown/gamemode/radio_shd.lua
+++ b/garrysmod/gamemodes/terrortown/gamemode/radio_shd.lua
@@ -13,12 +13,20 @@ TRADIO = {}
 -- serial: If true, play through the sound table in sequential order instead of randomly.
 -- times: The number of times to repeat the sound. If set to a table, randomizes the number of times within the range {min, max}.
 -- delay: The delay between sound repetitions. If set to a table, randomizes the delay within the range {min, max}.
--- ampl: The sound level. See https://wiki.facepunch.com/gmod/Enums/SNDLVL
+--
+-- The settings below control the emitted sound. See https://wiki.facepunch.com/gmod/Entity:EmitSound
+--
+-- ampl: The sound level. If set to a table, randomizes the level within the range {min, max}.
+-- pitch: The sound pitch. If set to a table, randomizes the pitch within the range {min, max}.
+-- vol: The sound volume. If set to a table, randomizes the volume within the range {min, max}.
+-- chan: The sound channel.
+-- flags: Sound flags.
+-- dsp: Sound DSP preset.
 --
 -- If serial = true, you can nest multiple sound tables within the sound table.
 -- This will cause the radio to choose a random sound from the first table,
 -- then on the next repetition, choose a random sound from the next table,
--- and so on. See footsteps (lines 70-80) for an example of this.
+-- and so on. See "footsteps" for an example of this.
 --
 --
 -- If you want to add custom sounds to the radio, use TRADIO.AddNewSound in a shared lua file.


### PR DESCRIPTION
When playing a radio sound with a low delay (MAC10, HUGE, Glock, etc), it will be played back with an unnaturally high delay when the listener has high ping. This is fixed by adding the option to create an unreliable channel recipient filter to Entity:BroadcastSound.

This also implements the other EmitSound options into the custom radio sound settings, simply because adding self:BroadcastSound(snd, ampl, nil, nil, nil, nil, nil, true) looked a bit silly :trollface: 