### PR TITLE
Set metatable after table construction in table.Copy

### DIFF
--- a/garrysmod/lua/includes/extensions/table.lua
+++ b/garrysmod/lua/includes/extensions/table.lua
@@ -29,7 +29,7 @@ function table.Copy( t, lookup_table )
 	if ( t == nil ) then return nil end
 
 	local copy = {}
-	setmetatable( copy, debug.getmetatable( t ) )
+	
 	for i, v in pairs( t ) do
 		if ( !istable( v ) ) then
 			copy[ i ] = v
@@ -43,7 +43,8 @@ function table.Copy( t, lookup_table )
 			end
 		end
 	end
-	return copy
+
+	return setmetatable( copy, debug.getmetatable( t ) )
 end
 
 --[[---------------------------------------------------------


### PR DESCRIPTION
This fixes a problem with tables that have metatables with a `__newindex` method.

Take this for example:
```lua
local env = {}

function env:GetSecretWord()
	return 'apple'
end

setmetatable(env, { __newindex = _G })
```
Anything new set to this `env` table will instead be set on the `_G` table, but I fully intend on keeping the `GetSecretWord` function in the actual `env` table. But if I copy it...
```lua
local copy = table.Copy(env)

print(copy.GetSecretWord, GetSecretWord)
```
```lua
nil    function: 0xaaef68e2
```
Because the current implementation sets the source's metatable onto the copy before setting everything up, it calls `__newindex` when trying to set `GetSecretWord` on the copy. This pr fixes this unexpected behavior.