### PR TITLE
Add out parameter to the global `*ToColor` functions

### DIFF
--- a/garrysmod/lua/includes/util/color.lua
+++ b/garrysmod/lua/includes/util/color.lua
@@ -42,7 +42,7 @@ end
 --[[---------------------------------------------------------
 	Different color represntations
 -----------------------------------------------------------]]
-function HSVToColor( h, s, v )
+function HSVToColor( h, s, v, out )
 
 	h = h % 360
 
@@ -65,15 +65,25 @@ function HSVToColor( h, s, v )
 		r, g, b = c, 0, x
 	end
 
-	return Color(
-		math.Clamp( math.floor( ( r + m ) * 255 ), 0, 255 ),
-		math.Clamp( math.floor( ( g + m ) * 255 ), 0, 255 ),
-		math.Clamp( math.floor( ( b + m ) * 255 ), 0, 255 )
-	)
+	r = math.Clamp( math.floor( ( r + m ) * 255 ), 0, 255 )
+	g = math.Clamp( math.floor( ( g + m ) * 255 ), 0, 255 )
+	b = math.Clamp( math.floor( ( b + m ) * 255 ), 0, 255 )
+
+	if ( out ) then
+
+		out.r = r
+		out.g = g
+		out.b = b
+
+		return out
+
+	end
+
+	return Color( r, g, b )
 
 end
 
-function HSLToColor( h, s, l )
+function HSLToColor( h, s, l, out )
 
 	h = h % 360
 
@@ -96,15 +106,25 @@ function HSLToColor( h, s, l )
 		r, g, b = c, 0, x
 	end
 
-	return Color(
-		math.Clamp( math.floor( ( r + m ) * 255 ), 0, 255 ),
-		math.Clamp( math.floor( ( g + m ) * 255 ), 0, 255 ),
-		math.Clamp( math.floor( ( b + m ) * 255 ), 0, 255 )
-	)
+	r = math.Clamp( math.floor( ( r + m ) * 255 ), 0, 255 )
+	g = math.Clamp( math.floor( ( g + m ) * 255 ), 0, 255 )
+	b = math.Clamp( math.floor( ( b + m ) * 255 ), 0, 255 )
+
+	if ( out ) then
+
+		out.r = r
+		out.g = g
+		out.b = b
+
+		return out
+
+	end
+
+	return Color( r, g, b )
 
 end
 
-function HWBToColor( h, w, b )
+function HWBToColor( h, w, b, out )
 
 	local v = 1 - b
 	local s = 0
@@ -112,7 +132,7 @@ function HWBToColor( h, w, b )
 		s = 1 - w / v
 	end
 
-	return HSVToColor( h, s, v )
+	return HSVToColor( h, s, v, out )
 
 end
 
@@ -121,10 +141,12 @@ for code = 48, 57 do hex_to_dec[ code ] = code - 48 end  -- '0'–'9'
 for code = 65, 70 do hex_to_dec[ code ] = code - 55 end  -- 'A'–'F'
 for code = 97, 102 do hex_to_dec[ code ] = code - 87 end -- 'a'–'f'
 
-function HexToColor( hex )
+function HexToColor( hex, out )
 
 	local idx = string.byte( hex, 1 ) == 35 and 2 or 1 -- '#' check without allocation
 	local len = #hex - ( idx - 1 )
+
+	local colR, colG, colB, colA
 
 	if ( len == 3 or len == 4 ) then
 
@@ -138,7 +160,10 @@ function HexToColor( hex )
 			return error( "invalid hex input: " .. hex )
 		end
 
-		return Color( r * 16 + r, g * 16 + g, b * 16 + b, a * 16 + a )
+		colR = r * 16 + r
+		colG = g * 16 + g
+		colB = b * 16 + b
+		colA = a * 16 + a
 
 	elseif ( len == 6 or len == 8 ) then
 
@@ -151,12 +176,30 @@ function HexToColor( hex )
 		if !( r1 and r2 and g1 and g2 and b1 and b2 and a1 and a2 ) then
 			return error( "invalid hex input: " .. hex )
 		end
-
-		return Color( r1 * 16 + r2, g1 * 16 + g2, b1 * 16 + b2, a1 * 16 + a2 )
+		
+		colR = r1 * 16 + r2
+		colG = g1 * 16 + g2
+		colB = b1 * 16 + b2
+		colA = a1 * 16 + a2
 
 	end
 
-	return error( "invalid hex input: " .. hex )
+	if ( !colR ) then
+		return error( "invalid hex input: " .. hex )
+	end
+
+	if ( out ) then
+
+		out.r = colR
+		out.g = colG
+		out.b = colB
+		out.a = colA
+
+		return out
+
+	end
+
+	return Color( colR, colG, colB, colA )
 
 end
 


### PR DESCRIPTION
This PR adds an `out` parameter to `HSLToColor`, `HSVToColor`, `HWBToColor`, and `HexToColor`. The main purpose of this is to minimize garbage collector pressure.

A lot of the time, especially with `HSVToColor`, you're just needing the r, g, and b values to pass into a surface.Draw function. Let's take the DrawRainbowText example from the wiki:
```lua
local function DrawRainbowText( frequency, str, font, x, y )

	surface.SetFont( font )
	surface.SetTextPos( x, y )

	for i = 1, #str do
		local col = HSVToColor( i * frequency % 360, 1, 1 ) -- Providing 3 numbers to surface.SetTextColor rather
		surface.SetTextColor( col.r, col.g, col.b )			-- than a single color is faster
		surface.DrawText( string.sub( str, i, i ) )
	end

end
```
If for the example text we are drawing is `Hello`, this would be creating 5 color objects every frame. We only need the r, g, and b values of the created color here, so this is just unnecessary pressure to the garbage collector. With the `out` parameter, we can just create only one color object outside the function, and re-use that instead:
```lua
local text_color = Color(255, 255, 255)

local function DrawRainbowText(frequency, str, font, x, y)
	surface.SetFont(font)
	surface.SetTextPos(x, y)

	for i = 1, #str do
		HSVToColor(i * frequency % 360, 1, 1, text_color)

		surface.SetTextColor(text_color.r, text_color.g, text_color.b)
		surface.DrawText(string.sub(str, i, i))
	end
end
```