### PR TITLE
Improve Vector __index Performance

### DIFF
--- a/garrysmod/lua/includes/extensions/vector.lua
+++ b/garrysmod/lua/includes/extensions/vector.lua
@@ -10,3 +10,20 @@ function meta:ToColor()
 	return Color( x * 255, y * 255, z * 255 )
 
 end
+
+function meta:__index( k )
+
+	local method = meta[ k ]
+	if ( method ) then return method end
+
+	local x, y, z = meta.Unpack( self )
+
+	if ( k == 1 or k == "x" or k == "X" ) then
+		return x
+	elseif ( k == 2 or k == "y" or k == "Y" ) then
+		return y
+	elseif ( k == 3 or k == "z" or k == "Z" ) then
+		return z
+	end
+
+end


### PR DESCRIPTION
This improves the Vector meta's `__index` by a decent bit.

# Benchmark
Bench tool used: https://pastebin.com/4i88e5kK

**Functions**
```lua
local bench = include('bench.lua')
local vec1 = Vector()

-- set original vector metatable with old index
debug.setmetatable(vec1, _VECTOR)

local function test1()
    vec1:Mul(1)
end

local vec2 = Vector()

local function test2()
    vec2:Mul(1)
end

print(SERVER and 'SERVER' or 'CLIENT')
local CALLS = 1000000 * 10 -- ten million
bench.Compare({test1, test2}, CALLS)
```
Result:
```lua
SERVER
1: 0.50063820000014s (Average: 5.0063820000014e-05ms)
2: 0.29487560000007s (Average: 2.9487560000007e-05ms)
Difference: 69%
CLIENT
1: 0.51353349999999s (Average: 5.1353349999999e-05ms)
2: 0.4003015000003s (Average: 4.003015000003e-05ms)
Difference: 28%
```

**Getting x, y, or z components**
```lua
local vec1 = Vector()
local temp

-- set original vector metatable with old index
debug.setmetatable(vec1, _VECTOR)

local function test1()
    temp = vec1.x
end

local vec2 = Vector()

local function test2()
    temp = vec2.x
end

print(SERVER and 'SERVER' or 'CLIENT')
local CALLS = 1000000 * 10 -- ten million
bench.Compare({test1, test2}, CALLS)
```
Result
```lua
SERVER
1: 0.53730780000024s (Average: 5.3730780000024e-05ms)
2: 0.33271079999986s (Average: 3.3271079999986e-05ms)
Difference: 61%
CLIENT
1: 0.49734090000038s (Average: 4.9734090000038e-05ms)
2: 0.38095360000034s (Average: 3.8095360000034e-05ms)
Difference: 30%
```